### PR TITLE
NH-65069 Add lambda layer build-publish workflows

### DIFF
--- a/.github/actions/package_lambda_solarwinds_apm_aarch64/action.yaml
+++ b/.github/actions/package_lambda_solarwinds_apm_aarch64/action.yaml
@@ -1,0 +1,18 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+name: package_lambda_solarwinds_apm_aarch64
+
+description: Package solarwinds_apm lambda layer for aarch64
+
+runs:
+  using: 'docker'
+  image: quay.io/pypa/manylinux_2_28_aarch64:latest
+  entrypoint: 'make'
+  args:
+    - 'aws-lambda'
+  env:
+    PLATFORM: aarch64

--- a/.github/actions/package_lambda_solarwinds_apm_x86_64/action.yaml
+++ b/.github/actions/package_lambda_solarwinds_apm_x86_64/action.yaml
@@ -1,0 +1,18 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+name: package_lambda_solarwinds_apm_x86_64
+
+description: Package solarwinds_apm lambda layer for x86_64
+
+runs:
+  using: 'docker'
+  image: quay.io/pypa/manylinux_2_28_x86_64:latest
+  entrypoint: 'make'
+  args:
+    - 'aws-lambda'
+  env:
+    PLATFORM: x86_64

--- a/.github/workflows/build_publish_lambda_layer_aarch64.yaml
+++ b/.github/workflows/build_publish_lambda_layer_aarch64.yaml
@@ -1,0 +1,58 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+name: Publish APM Python lambda layer for aarch64
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_layer_aarch64:
+    runs-on: ubuntu-latest
+    outputs:
+      SW_APM_VERSION: ${{ steps.save-apm-python-version.outputs.SW_APM_VERSION }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/package_lambda_solarwinds_apm_aarch64
+    - name: Save APM Python Version for naming
+      id: save-apm-python-version
+      run: |
+        echo "SW_APM_VERSION=$(grep __version__ ./solarwinds_apm/version.py | cut -d= -f 2 | tr -d ' "')" >> $GITHUB_OUTPUT
+    - uses: actions/upload-artifact@v3
+      name: Save assembled layer to build
+      with:
+        name: solarwinds_apm_lambda.zip
+        path: dist/solarwinds_apm_lambda.zip
+
+  publish-layer:
+    uses: ./.github/workflows/layer-publish.yml
+    needs: build_layer_aarch64
+    strategy:
+      matrix:
+        aws_region: 
+          - ap-northeast-1
+          - ap-northeast-2
+          - ap-south-1
+          - ap-southeast-1
+          - ap-southeast-2
+          - ca-central-1
+          - eu-central-1
+          - eu-north-1
+          - eu-west-1
+          - eu-west-2
+          - eu-west-3
+          - sa-east-1
+          - us-east-1
+          - us-east-2
+          - us-west-1
+          - us-west-2
+    with:
+      artifact-name: solarwinds_apm_lambda.zip
+      layer-name: solarwinds_apm_lambda
+      component-version: ${{ needs.build_layer_aarch64.outputs.SW_APM_VERSION }}
+      aws_region: ${{ matrix.aws_region }}
+      architecture: amd64
+    secrets: inherit

--- a/.github/workflows/build_publish_lambda_layer_aarch64.yaml
+++ b/.github/workflows/build_publish_lambda_layer_aarch64.yaml
@@ -54,5 +54,5 @@ jobs:
       layer-name: solarwinds_apm_lambda
       component-version: ${{ needs.build_layer_aarch64.outputs.SW_APM_VERSION }}
       aws_region: ${{ matrix.aws_region }}
-      architecture: amd64
+      architecture: arm64
     secrets: inherit

--- a/.github/workflows/build_publish_lambda_layer_x86_64.yaml
+++ b/.github/workflows/build_publish_lambda_layer_x86_64.yaml
@@ -1,0 +1,58 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+name: Publish APM Python lambda layer for x86_64
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_layer_x86_64:
+    runs-on: ubuntu-latest
+    outputs:
+      SW_APM_VERSION: ${{ steps.save-apm-python-version.outputs.SW_APM_VERSION }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/package_lambda_solarwinds_apm_x86_64
+    - name: Save APM Python Version for naming
+      id: save-apm-python-version
+      run: |
+        echo "SW_APM_VERSION=$(grep __version__ ./solarwinds_apm/version.py | cut -d= -f 2 | tr -d ' "')" >> $GITHUB_OUTPUT
+    - uses: actions/upload-artifact@v3
+      name: Save assembled layer to build
+      with:
+        name: solarwinds_apm_lambda.zip
+        path: dist/solarwinds_apm_lambda.zip
+
+  publish-layer:
+    uses: ./.github/workflows/layer-publish.yml
+    needs: build_layer_x86_64
+    strategy:
+      matrix:
+        aws_region: 
+          - ap-northeast-1
+          - ap-northeast-2
+          - ap-south-1
+          - ap-southeast-1
+          - ap-southeast-2
+          - ca-central-1
+          - eu-central-1
+          - eu-north-1
+          - eu-west-1
+          - eu-west-2
+          - eu-west-3
+          - sa-east-1
+          - us-east-1
+          - us-east-2
+          - us-west-1
+          - us-west-2
+    with:
+      artifact-name: solarwinds_apm_lambda.zip
+      layer-name: solarwinds_apm_lambda
+      component-version: ${{ needs.build_layer_x86_64.outputs.SW_APM_VERSION }}
+      aws_region: ${{ matrix.aws_region }}
+      architecture: x86_64
+    secrets: inherit

--- a/.github/workflows/publish_lambda_layer.yaml
+++ b/.github/workflows/publish_lambda_layer.yaml
@@ -1,0 +1,82 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+name: Publish Lambda Layer to staging
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: 'Name of actions/upload-artifact result'
+        required: true
+        type: string
+      layer-name:
+        description: 'Base layer name'
+        required: true
+        type: string
+      component-version:
+        description: 'Version of APM Python library in this release'
+        required: true
+        type: string
+      aws_region:
+        description: 'Publish to which AWS region'
+        required: true
+        type: string
+      architecture:
+        description: 'Must be x86_64 or amd64'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish_layer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Construct Layer Name
+        shell: bash
+        run: |
+          LAYER_NAME=${{ inputs.layer-name }}
+          
+          if [[ "${{ inputs.architecture }}" != "x86_64" ]] && [[ "${{ inputs.architecture }}" != "amd64" ]] ; then
+            echo "ERROR: architecture must be one of x86_64, amd64"
+            exit 1
+          else
+            LAYER_NAME=$LAYER_NAME-${{ inputs.architecture }}
+            echo "ARCH=${{ inputs.architecture }}" >> $GITHUB_ENV
+          fi
+          
+          COMPONENT_VERSION_UNDERSCORES=$(echo ${{ inputs.component-version }} | sed -r 's/\./_/g')
+          LAYER_NAME=$LAYER_NAME-COMPONENT_VERSION_UNDERSCORES
+          
+          echo GITHUB_ENV:
+          cat $GITHUB_ENV
+
+      - name: Download built layer
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.artifact-name }}
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.STAGING_LAMBDA_ROLE_ARN }}
+          role-duration-seconds: 1200
+          aws-region: ${{ inputs.aws_region }}
+          mask-aws-account-id: false
+
+      - name: Publish Lambda Layer
+        run: |
+          LAYER_ARN=$(
+            aws lambda publish-layer-version \
+              --layer-name $LAYER_NAME \
+              --license-info "Apache 2.0" \
+              --compatible-architectures $ARCH \
+              --zip-file fileb://${{ inputs.artifact-name }} \
+              --query 'LayerVersionArn' \
+              --output text
+          )

--- a/.github/workflows/publish_lambda_layer.yaml
+++ b/.github/workflows/publish_lambda_layer.yaml
@@ -26,7 +26,7 @@ on:
         required: true
         type: string
       architecture:
-        description: 'Must be x86_64 or amd64'
+        description: 'Must be x86_64 or arm64'
         required: true
         type: string
 
@@ -43,8 +43,8 @@ jobs:
         run: |
           LAYER_NAME=${{ inputs.layer-name }}
           
-          if [[ "${{ inputs.architecture }}" != "x86_64" ]] && [[ "${{ inputs.architecture }}" != "amd64" ]] ; then
-            echo "ERROR: architecture must be one of x86_64, amd64"
+          if [[ "${{ inputs.architecture }}" != "x86_64" ]] && [[ "${{ inputs.architecture }}" != "arm64" ]] ; then
+            echo "ERROR: architecture must be one of x86_64, arm64"
             exit 1
           else
             LAYER_NAME=$LAYER_NAME-${{ inputs.architecture }}


### PR DESCRIPTION
First PR to start adding APM Python lambda layer build-publish workflows. It would be great to get this on `main` for the first time to start test runs on GH then fix and enhance.

Adds 3 workflows:
1. `build_publish_lambda_layer_x86_64`
2. `build_publish_lambda_layer_aarch`
3. `publish_lambda_layer` which is called by each of above

Some key features:
* The `build_publish_*` flows are manually triggered for now, assuming called on `main` and not multiple times.
* Zip archive is generated by `make aws-lambda` target, same as local builds.
* AWS CLI is used to publish to our staging account. I did a manual test of the command on my local (with a wrong name) to layer `solarwinds-apm-python_0_18_0_aarch64`
* The published ARNs are supposed to be `arn:aws:lambda:<region>:<account>:layer:solarwinds-apm-python-<arm64|x86_64>-0_18_0:1` at least for now.

I will need some help adding a new secret `STAGING_LAMBDA_ROLE_ARN`. I'm going to refine naming and versioning of APM Python layer in a future PR. I will probably also add a single workflow to trigger both arch builds.

Please let me know what you think!