### PR TITLE
APM Python 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/solarwinds/apm-python/compare/rel-1.0.0...HEAD)
 
-## [1.0.0.0](https://github.com/solarwinds/apm-python/releases/tag/rel-1.0.0) - 2023-11-10
+## [1.0.0](https://github.com/solarwinds/apm-python/releases/tag/rel-1.0.0) - 2023-11-14
 
 ### Changed
 - Change c-lib usage and `agent_enabled` calculation if `is_lambda` ([#211](https://github.com/solarwinds/apm-python/pull/211))

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "1.0.0.0"
+__version__ = "1.0.0"


### PR DESCRIPTION
Contents for publish and release of APM Python 1.0.0

tox tests pass on this PR... most of them. Still waiting for lint and format check to get an available runner. I expect this to pass [like the last PR for testrelease](https://github.com/solarwinds/apm-python/pull/219) since all .py files the same.

Test traces:

- [SWO Django](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/66892896E7618D901833562D90A488C8/47FD2590CB92A827/details/breakdown?perspective=requests&serviceId=e-1655756171056209920)
- [SWO FastAPI](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/3B62C3B90D94AC0C5592238C56751296/9106B56F0766F012/details/breakdown?perspective=requests&serviceId=e-1655757500269252608)
- [AO Django](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/979726137374CDEA610E80AF752B449300000000?duration=3600)
- [AO FastAPI](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/46319D5160FA956EAB2D79060219075F00000000?duration=3600)

Will be published to PyPI and smoke tested after merge.