### PR TITLE
NH-67783 Update APM Python package classifiers and metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,15 +8,16 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 keywords = solarwinds_apm appoptics_apm traceview tracelytics oboe liboboe instrumentation performance opentelemetry
 license_files = (LICENSE,)
-url = https://www.appoptics.com/monitor/python-performance
+url = https://www.solarwinds.com/solarwinds-observability/use-cases/python-performance-monitoring
 download_url = https://pypi.org/project/solarwinds-apm/
 classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Typing :: Typed
-    Development Status :: 3 - Alpha
+    Development Status :: 4 - Beta
     Intended Audience :: Developers
     Intended Audience :: Information Technology
 


### PR DESCRIPTION
Update APM Python package classifiers and metadata because GA, py3.11 has been supported a while, and updated url.