### PR TITLE
NH-67051 Add Reporter config tests

### DIFF
--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -99,13 +99,17 @@ def mock_apmconfig_enabled_expt(mocker):
 
 @pytest.fixture(name="mock_extension")
 def mock_extension(mocker):
-    return mocker.patch(
-        "solarwinds_apm.extension"
+    mock_reporter = mocker.Mock()
+    mock_ext = mocker.Mock()
+    mock_ext.configure_mock(
+        **{
+            "Reporter": mock_reporter
+        }
     )
-
-@pytest.fixture(name="mock_reporter")
-def mock_reporter(mocker):
-    return mocker.Mock()
+    return {
+        "extension": mock_ext,
+        "Reporter": mock_reporter,
+    }
 
 @pytest.fixture(name="mock_fwkv_manager")
 def mock_fwkv_manager(mocker):

--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -97,6 +97,29 @@ def mock_apmconfig_enabled_expt(mocker):
         get_apmconfig_mocks(mocker, True, True)
     )
 
+@pytest.fixture(name="mock_apmconfig_enabled_reporter_settings")
+def mock_apmconfig_enabled_reporter_settings(mocker):
+    mock_reporter = mocker.Mock()
+    mock_ext = mocker.Mock()
+    mock_ext.configure_mock(
+        **{
+            "Reporter": mock_reporter
+        }
+    )
+
+    mock_apmconfig = mocker.Mock()
+    mock_apmconfig.configure_mock(
+        **{
+            "agent_enabled": True,
+            "certificates": "foo-certs",
+            "extension": mock_ext,
+            "get": mocker.Mock(return_value="foo"),
+            "service_name": "foo-service",
+            "metric_format": "bar"
+        }
+    )
+    return mock_apmconfig
+
 @pytest.fixture(name="mock_extension")
 def mock_extension(mocker):
     mock_reporter = mocker.Mock()

--- a/tests/unit/test_configurator/test_configurator_init_reporter.py
+++ b/tests/unit/test_configurator/test_configurator_init_reporter.py
@@ -1,0 +1,44 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+from solarwinds_apm import configurator
+
+class TestConfiguratorInitializeReporter:
+    def test_configurator_initialize_sw_reporter(
+        self,
+        mocker,
+        mock_apmconfig_enabled_reporter_settings,
+    ):
+        test_configurator = configurator.SolarWindsConfigurator()
+        test_configurator._initialize_solarwinds_reporter(
+            mock_apmconfig_enabled_reporter_settings,
+        )
+
+        mock_apmconfig_enabled_reporter_settings.extension.Reporter.assert_called_once_with(
+            **{
+                "hostname_alias": "foo",
+                "log_level": "foo",
+                "log_file_path": "foo",
+                "max_transactions": "foo",
+                "max_flush_wait_time": "foo",
+                "events_flush_interval": "foo",
+                "max_request_size_bytes": "foo",
+                "reporter": "foo",
+                "host": "foo",
+                "service_key": "foo",
+                "certificates": "foo-certs",
+                "buffer_size": "foo",
+                "trace_metrics": "foo",
+                "histogram_precision": "foo",
+                "token_bucket_capacity": "foo",
+                "token_bucket_rate": "foo",
+                "file_single": "foo",
+                "ec2_metadata_timeout": "foo",
+                "grpc_proxy": "foo",
+                "stdout_clear_nonblocking": 0,
+                "metric_format": "bar",
+            }
+        )

--- a/tests/unit/test_configurator/test_configurator_traces_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_traces_exporter.py
@@ -17,7 +17,7 @@ class TestConfiguratorTracesExporter:
     def test_configure_traces_exporter_disabled(
         self,
         mocker,
-        mock_reporter,
+        mock_extension,
         mock_txn_name_manager,
         mock_fwkv_manager,
         mock_apmconfig_disabled,
@@ -28,7 +28,7 @@ class TestConfiguratorTracesExporter:
 
         test_configurator = configurator.SolarWindsConfigurator()
         test_configurator._configure_traces_exporter(
-            mock_reporter,
+            mock_extension["Reporter"],
             mock_txn_name_manager,
             mock_fwkv_manager,
             mock_apmconfig_disabled,
@@ -40,7 +40,7 @@ class TestConfiguratorTracesExporter:
     def test_configure_traces_exporter_none(
         self,
         mocker,
-        mock_reporter,
+        mock_extension,
         mock_txn_name_manager,
         mock_fwkv_manager,
         mock_apmconfig_enabled,
@@ -56,7 +56,7 @@ class TestConfiguratorTracesExporter:
 
         test_configurator = configurator.SolarWindsConfigurator()
         test_configurator._configure_traces_exporter(
-            mock_reporter,
+            mock_extension["Reporter"],
             mock_txn_name_manager,
             mock_fwkv_manager,
             mock_apmconfig_enabled,
@@ -72,7 +72,7 @@ class TestConfiguratorTracesExporter:
     def test_configure_traces_exporter_invalid(
         self,
         mocker,
-        mock_reporter,
+        mock_extension,
         mock_txn_name_manager,
         mock_fwkv_manager,
         mock_apmconfig_enabled,
@@ -105,7 +105,7 @@ class TestConfiguratorTracesExporter:
 
         with pytest.raises(Exception):
             test_configurator._configure_traces_exporter(
-                mock_reporter,
+                mock_extension["Reporter"],
                 mock_txn_name_manager,
                 mock_fwkv_manager,
                 mock_apmconfig_enabled,
@@ -122,7 +122,7 @@ class TestConfiguratorTracesExporter:
     def test_configure_traces_exporter_valid(
         self,
         mocker,
-        mock_reporter,
+        mock_extension,
         mock_txn_name_manager,
         mock_fwkv_manager,
         mock_apmconfig_enabled,
@@ -161,7 +161,7 @@ class TestConfiguratorTracesExporter:
         # Test!
         test_configurator = configurator.SolarWindsConfigurator()
         test_configurator._configure_traces_exporter(
-            mock_reporter,
+            mock_extension["Reporter"],
             mock_txn_name_manager,
             mock_fwkv_manager,
             mock_apmconfig_enabled,
@@ -177,7 +177,7 @@ class TestConfiguratorTracesExporter:
     def test_configure_traces_exporter_invalid_valid_mixed(
         self,
         mocker,
-        mock_reporter,
+        mock_extension,
         mock_txn_name_manager,
         mock_fwkv_manager,
         mock_apmconfig_enabled,
@@ -235,7 +235,7 @@ class TestConfiguratorTracesExporter:
         test_configurator = configurator.SolarWindsConfigurator()
         with pytest.raises(Exception):
             test_configurator._configure_traces_exporter(
-                mock_reporter,
+                mock_extension["Reporter"],
                 mock_txn_name_manager,
                 mock_fwkv_manager,
                 mock_apmconfig_enabled,
@@ -258,7 +258,7 @@ class TestConfiguratorTracesExporter:
     def test_configure_traces_exporter_valid_invalid_mixed(
         self,
         mocker,
-        mock_reporter,
+        mock_extension,
         mock_txn_name_manager,
         mock_fwkv_manager,
         mock_apmconfig_enabled,
@@ -315,7 +315,7 @@ class TestConfiguratorTracesExporter:
         test_configurator = configurator.SolarWindsConfigurator()
         with pytest.raises(Exception):
             test_configurator._configure_traces_exporter(
-                mock_reporter,
+                mock_extension["Reporter"],
                 mock_txn_name_manager,
                 mock_fwkv_manager,
                 mock_apmconfig_enabled,


### PR DESCRIPTION
Adds Reporter configurator function unit tests, with updated fixtures.

At distro startup, it's the upstream `_configure` method that decides if Reporter should be init'd.