### PR TITLE
NH-67051 Add the top-level `configurator._configure` tests

### DIFF
--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -251,6 +251,20 @@ def mock_apmconfig_enabled_reporter_settings(mocker):
     )
     return mock_apmconfig
 
+
+@pytest.fixture(name="mock_apmconfig_experimental_otelcol_init")
+def mock_apmconfig_experimental_otelcol_init(mocker):
+    mock_apmconfig = mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsApmConfig"
+    )
+    mock_apmconfig.return_value = {
+        "experimental":
+            {
+                "otel_collector": True
+            }
+    }
+    return mock_apmconfig
+
 # ==================================================================
 # Configurator APM Python extension mocks
 # ==================================================================
@@ -337,6 +351,50 @@ def mock_config_response_propagator(mocker):
     return mocker.patch(
         "solarwinds_apm.configurator.SolarWindsConfigurator._configure_response_propagator"
     )
+
+@pytest.fixture(name="mock_init_sw_reporter")
+def mock_init_sw_reporter(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsConfigurator._initialize_solarwinds_reporter"
+    )
+
+@pytest.fixture(name="mock_config_otel_components")
+def mock_config_otel_components(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsConfigurator._configure_otel_components"
+    )
+
+@pytest.fixture(name="mock_report_init")
+def mock_report_init(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsConfigurator._report_init_event"
+    )
+
+
+@pytest.fixture(name="mock_txn_name_manager_init")
+def mock_txn_name_manager_init(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsTxnNameManager"
+    )
+
+@pytest.fixture(name="mock_fwkv_manager_init")
+def mock_fwkv_manager_init(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsFrameworkKvManager"
+    )
+
+@pytest.fixture(name="mock_meter_manager_init")
+def mock_meter_manager_init(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsMeterManager"
+    )
+
+@pytest.fixture(name="mock_noop_meter_manager_init")
+def mock_noop_meter_manager_init(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.NoopMeterManager"
+    )
+
 
 # ==================================================================
 # Configurator APM Python other mocks

--- a/tests/unit/test_configurator/test_configurator_configure.py
+++ b/tests/unit/test_configurator/test_configurator_configure.py
@@ -1,0 +1,58 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+from solarwinds_apm import configurator
+
+class TestConfiguratorConfigure:
+    def test_configurator_configure(
+        mocker,
+        mock_txn_name_manager_init,
+        mock_fwkv_manager_init,
+        mock_apmconfig_enabled,
+        mock_meter_manager_init,
+        mock_noop_meter_manager_init,
+        mock_init_sw_reporter,
+        mock_config_otel_components,
+        mock_report_init,
+    ):
+        test_configurator = configurator.SolarWindsConfigurator()
+        test_configurator._configure()
+
+        mock_txn_name_manager_init.assert_called_once()
+        mock_fwkv_manager_init.assert_called_once()
+        mock_apmconfig_enabled.assert_called_once()
+
+        mock_noop_meter_manager_init.assert_called_once()
+        mock_meter_manager_init.assert_not_called()
+
+        mock_init_sw_reporter.assert_called_once()
+        mock_config_otel_components.assert_called_once()
+        mock_report_init.assert_called_once()
+
+    def test_configurator_configure_experimental(
+        mocker,
+        mock_txn_name_manager_init,
+        mock_fwkv_manager_init,
+        mock_apmconfig_experimental_otelcol_init,
+        mock_meter_manager_init,
+        mock_noop_meter_manager_init,
+        mock_init_sw_reporter,
+        mock_config_otel_components,
+        mock_report_init,
+    ):
+        test_configurator = configurator.SolarWindsConfigurator()
+        test_configurator._configure()
+
+        mock_txn_name_manager_init.assert_called_once()
+        mock_fwkv_manager_init.assert_called_once()
+        mock_apmconfig_experimental_otelcol_init.assert_called_once()
+
+        mock_meter_manager_init.assert_called_once()
+        mock_noop_meter_manager_init.assert_not_called()
+        
+        mock_init_sw_reporter.assert_called_once()
+        mock_config_otel_components.assert_called_once()
+        mock_report_init.assert_called_once()


### PR DESCRIPTION
Add the top-level `configurator._configure` tests, the one called by Otel `instrument` via entry points.