### PR TITLE
NH-67051 fix dumbness

### DIFF
--- a/tests/unit/test_configurator/test_configurator_configure.py
+++ b/tests/unit/test_configurator/test_configurator_configure.py
@@ -8,6 +8,7 @@ from solarwinds_apm import configurator
 
 class TestConfiguratorConfigure:
     def test_configurator_configure(
+        self,
         mocker,
         mock_txn_name_manager_init,
         mock_fwkv_manager_init,
@@ -33,6 +34,7 @@ class TestConfiguratorConfigure:
         mock_report_init.assert_called_once()
 
     def test_configurator_configure_experimental(
+        self,
         mocker,
         mock_txn_name_manager_init,
         mock_fwkv_manager_init,

--- a/tests/unit/test_configurator/test_configurator_configure_otel.py
+++ b/tests/unit/test_configurator/test_configurator_configure_otel.py
@@ -8,6 +8,7 @@ from solarwinds_apm import configurator
 
 class TestConfiguratorConfigureOtelComponents:
     def test_configure_otel_components_agent_enabled(
+        self,
         mocker,
         mock_txn_name_manager,
         mock_fwkv_manager,
@@ -51,6 +52,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_response_propagator.assert_called_once()
 
     def test_configure_otel_components_agent_disabled(
+        self,
         mocker,
         mock_txn_name_manager,
         mock_fwkv_manager,


### PR DESCRIPTION
Fixes dumb test function signatures, caught by CodeQL in #241: `Normal methods should have 'self', rather than 'mocker', as their first parameter.`