### PR TITLE
NH-62591 Add temp switches for unit tests while c-lib <13

### DIFF
--- a/tests/unit/test_apm_config/test_apm_config_get_extension.py
+++ b/tests/unit/test_apm_config/test_apm_config_get_extension.py
@@ -14,10 +14,16 @@ from solarwinds_apm.apm_noop import (
     OboeAPI as NoopOboeApi,
 )
 from solarwinds_apm.extension import oboe as Extension
-from solarwinds_apm.extension.oboe import (
-    Context,
-    OboeAPI,
-)
+from solarwinds_apm.extension.oboe import Context
+
+try:
+    # c-lib <14 does not have OboeAPI
+    # TODO remove the except after upgrading
+    # https://swicloud.atlassian.net/browse/NH-68264
+    from solarwinds_apm.extension.oboe import OboeAPI
+except ImportError:
+    from solarwinds_apm.apm_noop import OboeAPI as OboeAPI
+
 
 # pylint: disable=unused-import
 from .fixtures.env_vars import fixture_mock_env_vars

--- a/tests/unit/test_sampler/test_sampler.py
+++ b/tests/unit/test_sampler/test_sampler.py
@@ -224,10 +224,20 @@ class Test_SwSampler():
                 "getTracingDecision": mock_get_tracing_decision
             }
         )
-        mock_oboe_api_component = mocker.patch(
-            "solarwinds_apm.extension.oboe.OboeAPI.__init__",
-            return_value=mock_oboe_api
-        )
+        try:
+            mock_oboe_api_component = mocker.patch(
+                "solarwinds_apm.extension.oboe.OboeAPI.__init__",
+                return_value=mock_oboe_api
+            )
+        except ModuleNotFoundError:
+            # c-lib <14 does not have OboeAPI
+            # TODO remove the except after upgrading
+            # https://swicloud.atlassian.net/browse/NH-68264
+            mock_oboe_api_component = mocker.patch(
+                "solarwinds_apm.apm_noop.OboeAPI.__init__",
+                return_value=mock_oboe_api
+            )
+
         mock_apm_config.configure_mock(
             **{
                 "agent_enabled": True,


### PR DESCRIPTION
Add temporary switches in two unit tests so that they pass while on c-lib <13. I've noted to change these later in https://swicloud.atlassian.net/browse/NH-68264. Doing this under NH-62591 before upstream upgrade to make testing other things easier.