### PR TITLE
NH-69217 OTLP metrics sw.transaction configurable by env var

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -117,6 +117,7 @@ class SolarWindsApmConfig:
             "transaction_name": None,
         }
         self.is_lambda = self.calculate_is_lambda()
+        self.lambda_function_name = os.environ.get("AWS_LAMBDA_FUNCTION_NAME")
         self.agent_enabled = True
         self.update_with_cnf_file()
         self.update_with_env_var()

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -155,6 +155,33 @@ class TestSolarWindsApmConfig:
         assert test_config.service_name == "sw_service_name"
         assert test_config.get("service_key") == "service_key_with:sw_service_name"
 
+    def test__init_custom_transction_names_env_vars(self, mocker):
+        # save any env vars for later
+        old_env_lambda_name = os.environ.get("AWS_LAMBDA_FUNCTION_NAME")
+        if old_env_lambda_name:
+            del os.environ["AWS_LAMBDA_FUNCTION_NAME"]
+        old_env_trans_name = os.environ.get("SW_APM_TRANSACTION_NAME")
+        if old_env_trans_name:
+            del os.environ["SW_APM_TRANSACTION_NAME"]
+
+        mocker.patch.dict(
+            os.environ,
+            {
+                "AWS_LAMBDA_FUNCTION_NAME": "foo-lambda",
+                "SW_APM_TRANSACTION_NAME": "foo-trans-name",
+            },
+        )
+
+        config = apm_config.SolarWindsApmConfig()
+        assert config.lambda_function_name == "foo-lambda"
+        assert config.get("transaction_name") == "foo-trans-name"
+
+        # restore env vars
+        if old_env_lambda_name:
+            os.environ["AWS_LAMBDA_FUNCTION_NAME"] = old_env_lambda_name
+        if old_env_trans_name:
+            os.environ["SW_APM_TRANSACTION_NAME"] = old_env_trans_name
+
     def test_calculate_metric_format_no_collector(self, mocker):
         # Save any collector in os for later
         old_collector = os.environ.get("SW_APM_COLLECTOR", None)

--- a/tests/unit/test_processors/test_otlp_metrics_processor.py
+++ b/tests/unit/test_processors/test_otlp_metrics_processor.py
@@ -16,6 +16,11 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
         is_span_http=True,
         get_retval=TransactionNames("foo", "bar")
     ):
+        mocker.patch(
+            "solarwinds_apm.trace.SolarWindsOTLPMetricsSpanProcessor.calculate_otlp_transaction_name",
+            return_value="foo",
+        )
+
         mock_random = mocker.patch(
             "solarwinds_apm.trace.otlp_metrics_processor.random"
         )

--- a/tests/unit/test_processors/test_otlp_metrics_processor.py
+++ b/tests/unit/test_processors/test_otlp_metrics_processor.py
@@ -4,10 +4,123 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
+from os import environ
+
 from solarwinds_apm.trace import SolarWindsOTLPMetricsSpanProcessor
 from solarwinds_apm.trace.tnames import TransactionNames
 
 class TestSolarWindsOTLPMetricsSpanProcessor:
+
+    def test__init(self, mocker):
+        mock_tx_mgr = mocker.Mock()
+        mock_meters = mocker.Mock()
+        mock_apm_config = mocker.Mock()
+        mock_apm_config.configure_mock(
+            **{
+                "service_name": "foo-service-name",
+                # one call to get "transaction_name"
+                "get": mocker.Mock(return_value="foo-env-txn-name"),
+                "lambda_function_name": "foo-lambda-name",
+            }
+        )
+        processor = SolarWindsOTLPMetricsSpanProcessor(
+            mock_tx_mgr,
+            mock_apm_config,
+            mock_meters,
+        )
+        assert processor.apm_txname_manager == mock_tx_mgr
+        assert processor.apm_meters == mock_meters
+        assert processor.service_name == "foo-service-name"
+        assert processor.env_transaction_name == "foo-env-txn-name"
+        assert processor.lambda_function_name == "foo-lambda-name"
+
+    def test_calculate_otlp_transaction_name_custom(self, mocker):
+        mock_apm_config = mocker.Mock()
+        mock_apm_config.configure_mock(
+            **{
+                # one call to get "transaction_name"
+                "get": mocker.Mock(return_value="unused"),
+                "lambda_function_name": "unused",
+            }
+        )
+
+        tnames = TransactionNames(
+            "unused",
+            "unused",
+            "foo-custom-name",
+        )
+
+        assert "foo-custom-name" == SolarWindsOTLPMetricsSpanProcessor(
+            mocker.Mock(),
+            mock_apm_config,
+            mocker.Mock()
+        ).calculate_otlp_transaction_name(tnames)
+
+    def test_calculate_otlp_transaction_name_env_trans(self, mocker):
+        mock_apm_config = mocker.Mock()
+        mock_apm_config.configure_mock(
+            **{
+                # one call to get "transaction_name"
+                "get": mocker.Mock(return_value="foo-env-trans-name"),
+                "lambda_function_name": "unused",
+            }
+        )
+
+        tnames = TransactionNames(
+            "unused",
+            "unused",
+            None,
+        )
+
+        assert "foo-env-trans-name" == SolarWindsOTLPMetricsSpanProcessor(
+            mocker.Mock(),
+            mock_apm_config,
+            mocker.Mock()
+        ).calculate_otlp_transaction_name(tnames)
+
+    def test_calculate_otlp_transaction_name_env_lambda(self, mocker):
+        mock_apm_config = mocker.Mock()
+        mock_apm_config.configure_mock(
+            **{
+                # one call to get "transaction_name"
+                "get": mocker.Mock(return_value=None),
+                "lambda_function_name": "foo-lambda-name",
+            }
+        )
+
+        tnames = TransactionNames(
+            "unused",
+            "unused",
+            None,
+        )
+
+        assert "foo-lambda-name" == SolarWindsOTLPMetricsSpanProcessor(
+            mocker.Mock(),
+            mock_apm_config,
+            mocker.Mock()
+        ).calculate_otlp_transaction_name(tnames)
+
+    def test_calculate_otlp_transaction_name_default(self, mocker):
+        mock_apm_config = mocker.Mock()
+        mock_apm_config.configure_mock(
+            **{
+                # one call to get "transaction_name"
+                "get": mocker.Mock(return_value=None),
+                "lambda_function_name": None,
+            }
+        )
+
+        tnames = TransactionNames(
+            "foo-trans-name",
+            "unused",
+            None,
+        )
+
+        assert "foo-trans-name" == SolarWindsOTLPMetricsSpanProcessor(
+            mocker.Mock(),
+            mock_apm_config,
+            mocker.Mock()
+        ).calculate_otlp_transaction_name(tnames)
 
     def patch_for_on_end(
         self,


### PR DESCRIPTION
Depends on #255 for name storage type update -- now merged to main

Updates OTLP metrics processor to calculate transaction name for response_time metrics following this order of decreasing precedence:

1. custom SDK name (already stored by `TxnNameCalculatorProcessor`)
2. SW_APM_TRANSACTION_NAME (already stored by `ApmConfig`)
3. AWS_LAMBDA_FUNCTION_NAME (now also stored by `ApmConfig`)
4. automated naming from span name, attributes (already stored by `TxnNameCalculatorProcessor`)