### PR TITLE
NH-68264 Configurator does the only OboeAPI init

### DIFF
--- a/solarwinds_apm/apm_meter_manager.py
+++ b/solarwinds_apm/apm_meter_manager.py
@@ -16,6 +16,14 @@ from opentelemetry.metrics import CallbackOptions, Observation, get_meter
 if TYPE_CHECKING:
     from solarwinds_apm.apm_config import SolarWindsApmConfig
 
+    try:
+        # c-lib <14 does not have OboeAPI
+        # TODO remove the except after upgrading
+        # https://swicloud.atlassian.net/browse/NH-68264
+        from solarwinds_apm.extension.oboe import OboeAPI
+    except ImportError:
+        from solarwinds_apm.apm_noop import OboeAPI
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,9 +31,12 @@ class SolarWindsMeterManager:
     """SolarWinds Python OTLP Meter Manager"""
 
     def __init__(
-        self, apm_config: "SolarWindsApmConfig", **kwargs: int
+        self,
+        apm_config: "SolarWindsApmConfig",
+        oboe_api: "OboeAPI",
+        **kwargs: int,
     ) -> None:
-        self.oboe_settings_api = apm_config.oboe_api()
+        self.oboe_settings_api = oboe_api
 
         # Returns named `Meter` to handle instrument creation.
         # A convenience wrapper for MeterProvider.get_meter

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -97,6 +97,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         apm_config = SolarWindsApmConfig()
         # TODO add args
         # https://swicloud.atlassian.net/browse/NH-68264
+        # See also SolarWindsApmConfig._get_extension_components
         oboe_api = apm_config.oboe_api()
 
         # TODO Add experimental trace flag, clean up

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -69,6 +69,14 @@ from solarwinds_apm.version import __version__
 if TYPE_CHECKING:
     from solarwinds_apm.extension.oboe import Reporter
 
+    try:
+        # c-lib <14 does not have OboeAPI
+        # TODO remove the except after upgrading
+        # https://swicloud.atlassian.net/browse/NH-68264
+        from solarwinds_apm.extension.oboe import OboeAPI
+    except ImportError:
+        from solarwinds_apm.apm_noop import OboeAPI
+
 solarwinds_apm_logger = apm_logging.logger
 logger = logging.getLogger(__name__)
 
@@ -87,6 +95,9 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         apm_txname_manager = SolarWindsTxnNameManager()
         apm_fwkv_manager = SolarWindsFrameworkKvManager()
         apm_config = SolarWindsApmConfig()
+        # TODO add args
+        # https://swicloud.atlassian.net/browse/NH-68264
+        oboe_api = apm_config.oboe_api()
 
         # TODO Add experimental trace flag, clean up
         #      https://swicloud.atlassian.net/browse/NH-65067
@@ -96,7 +107,10 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             )
             apm_meters = NoopMeterManager()
         else:
-            apm_meters = SolarWindsMeterManager(apm_config)
+            apm_meters = SolarWindsMeterManager(
+                apm_config,
+                oboe_api,
+            )
 
         reporter = self._initialize_solarwinds_reporter(apm_config)
         self._configure_otel_components(
@@ -105,6 +119,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             apm_config,
             reporter,
             apm_meters,
+            oboe_api,
         )
         # Report an status event after everything is done.
         self._report_init_event(reporter, apm_config)
@@ -116,9 +131,10 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         apm_config: SolarWindsApmConfig,
         reporter: "Reporter",
         apm_meters: SolarWindsMeterManager,
+        oboe_api: "OboeAPI",
     ) -> None:
         """Configure OTel sampler, exporter, propagator, response propagator"""
-        self._configure_sampler(apm_config)
+        self._configure_sampler(apm_config, oboe_api)
         if apm_config.agent_enabled:
             self._configure_service_entry_id_span_processor()
             self._configure_txnname_calculator_span_processor(
@@ -152,6 +168,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
     def _configure_sampler(
         self,
         apm_config: SolarWindsApmConfig,
+        oboe_api: "OboeAPI",
     ) -> None:
         """Always configure SolarWinds OTel sampler, or none if disabled"""
         if not apm_config.agent_enabled:
@@ -163,7 +180,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                 "solarwinds_apm",
                 "opentelemetry_traces_sampler",
                 self._DEFAULT_SW_TRACES_SAMPLER,
-            )(apm_config)
+            )(apm_config, oboe_api)
         except Exception as ex:
             logger.exception("A exception was raised: %s", ex)
             logger.exception(

--- a/tests/integration/test_base_sw_headers_attrs.py
+++ b/tests/integration/test_base_sw_headers_attrs.py
@@ -33,6 +33,13 @@ from solarwinds_apm.distro import SolarWindsDistro
 from solarwinds_apm.propagator import SolarWindsPropagator
 from solarwinds_apm.sampler import ParentBasedSwSampler
 
+try:
+    # c-lib <14 does not have OboeAPI
+    # TODO remove the except after upgrading
+    # https://swicloud.atlassian.net/browse/NH-68264
+    from solarwinds_apm.extension.oboe import OboeAPI
+except ImportError:
+    from solarwinds_apm.apm_noop import OboeAPI
 
 class TestBaseSwHeadersAndAttributes(TestBase):
     """
@@ -105,7 +112,7 @@ class TestBaseSwHeadersAndAttributes(TestBase):
             "solarwinds_apm",
             "opentelemetry_traces_sampler",
             configurator._DEFAULT_SW_TRACES_SAMPLER
-        )(apm_config)
+        )(apm_config, OboeAPI())
         self.tracer_provider = TracerProvider(sampler=sampler)
         # Set InMemorySpanExporter for testing
         # We do NOT use SolarWindsSpanExporter

--- a/tests/unit/test_apm_meter_manager.py
+++ b/tests/unit/test_apm_meter_manager.py
@@ -27,11 +27,13 @@ class TestApmMeterManager:
             return_value=mock_meter
         )
 
-        # Mock APM Config
+        # Mock args
         mock_apm_config = mocker.Mock()
+        mock_oboe_api = mocker.Mock()
 
         # Test!
-        SolarWindsMeterManager(mock_apm_config)
+        mgr = SolarWindsMeterManager(mock_apm_config, mock_oboe_api)
+        assert mgr.oboe_settings_api == mock_oboe_api
         mock_otel_get_meter.assert_has_calls(
             [
                 mocker.call("sw.apm.request.metrics"),

--- a/tests/unit/test_configurator/test_configurator_configure_otel.py
+++ b/tests/unit/test_configurator/test_configurator_configure_otel.py
@@ -15,6 +15,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_meter_manager,
         mock_extension,
         mock_apmconfig_enabled,
+        mock_oboe_api_obj,
 
         mock_config_serviceentryid_processor,
         mock_config_inbound_processor,
@@ -31,6 +32,7 @@ class TestConfiguratorConfigureOtelComponents:
             mock_apmconfig_enabled,
             mock_extension.Reporter,
             mock_meter_manager,
+            mock_oboe_api_obj,
         )
 
         mock_config_serviceentryid_processor.assert_called_once()
@@ -61,6 +63,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_meter_manager,
         mock_extension,
         mock_apmconfig_disabled,
+        mock_oboe_api_obj,
 
         mock_config_serviceentryid_processor,
         mock_config_inbound_processor,
@@ -77,6 +80,7 @@ class TestConfiguratorConfigureOtelComponents:
             mock_apmconfig_disabled,
             mock_extension.Reporter,
             mock_meter_manager,
+            mock_oboe_api_obj,
         )
 
         mock_config_serviceentryid_processor.assert_not_called()

--- a/tests/unit/test_configurator/test_configurator_sampler.py
+++ b/tests/unit/test_configurator/test_configurator_sampler.py
@@ -19,6 +19,7 @@ class TestConfiguratorSampler:
         self,
         mocker,
         mock_apmconfig_disabled,
+        mock_oboe_api_obj,
         mock_tracerprovider,
     ):
         # Mock Otel
@@ -26,7 +27,10 @@ class TestConfiguratorSampler:
         trace_mocks = get_trace_mocks(mocker)
 
         test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_sampler(mock_apmconfig_disabled)
+        test_configurator._configure_sampler(
+            mock_apmconfig_disabled,
+            mock_oboe_api_obj,
+        )
 
         # sets tracer_provider with noop
         trace_mocks.NoOpTracerProvider.assert_called_once()
@@ -40,6 +44,7 @@ class TestConfiguratorSampler:
         self,
         mocker,
         mock_apmconfig_enabled,
+        mock_oboe_api_obj,
         mock_tracerprovider,
     ):
         # Mock entry points
@@ -57,7 +62,10 @@ class TestConfiguratorSampler:
         # Test!
         test_configurator = configurator.SolarWindsConfigurator()
         with pytest.raises(Exception):
-            test_configurator._configure_sampler(mock_apmconfig_enabled)
+            test_configurator._configure_sampler(
+                mock_apmconfig_enabled,
+                mock_oboe_api_obj,
+            )
 
         # no tracer_provider is set
         trace_mocks.NoOpTracerProvider.assert_not_called()
@@ -69,6 +77,7 @@ class TestConfiguratorSampler:
         self,
         mocker,
         mock_apmconfig_enabled,
+        mock_oboe_api_obj,
         mock_tracerprovider,
     ):
         # Mock entry points
@@ -82,7 +91,10 @@ class TestConfiguratorSampler:
 
         # Test!
         test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_sampler(mock_apmconfig_enabled)
+        test_configurator._configure_sampler(
+            mock_apmconfig_enabled,
+            mock_oboe_api_obj,
+        )
 
         # tracer_provider set with new resource using configured service_name
         trace_mocks.set_tracer_provider.assert_called_once()
@@ -101,6 +113,7 @@ class TestConfiguratorSampler:
         self,
         mocker,
         mock_apmconfig_enabled,
+        mock_oboe_api_obj,
         mock_tracerprovider,
     ):
         # Save any SAMPLER env var for later
@@ -131,7 +144,10 @@ class TestConfiguratorSampler:
 
         # Test!
         test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_sampler(mock_apmconfig_enabled)
+        test_configurator._configure_sampler(
+            mock_apmconfig_enabled,
+            mock_oboe_api_obj,
+        )
 
         # sampler loaded was solarwinds_sampler, not configured foo_sampler
         mock_load_entry_point.assert_called_once_with(

--- a/tests/unit/test_sampler/fixtures/sampler.py
+++ b/tests/unit/test_sampler/fixtures/sampler.py
@@ -48,7 +48,7 @@ def fixture_swsampler(mocker):
             "is_lambda": False,
         }
     )
-    return _SwSampler(mock_apm_config)
+    return _SwSampler(mock_apm_config, mocker.Mock())
 
 
 # Sampler fixtures with Transaction Filters =================
@@ -106,4 +106,4 @@ def fixture_swsampler_txnfilters(mocker):
             "get": mock_get,
         }
     )
-    return _SwSampler(mock_apm_config)
+    return _SwSampler(mock_apm_config, mocker.Mock())

--- a/tests/unit/test_sampler/test_sampler_calculate_attributes.py
+++ b/tests/unit/test_sampler/test_sampler_calculate_attributes.py
@@ -242,8 +242,10 @@ class Test_SwSampler_calculate_attributes():
     """
     def test_init(self, mocker):
         mock_apm_config = mocker.Mock()
-        sampler = _SwSampler(mock_apm_config)
+        mock_oboe_api = mocker.Mock()
+        sampler = _SwSampler(mock_apm_config, mock_oboe_api)
         assert sampler.apm_config == mock_apm_config
+        assert sampler.oboe_settings_api == mock_oboe_api
 
     def test_decision_drop_with_no_sw_keys_nor_custom_keys_nor_tt_unsigned(
         self,


### PR DESCRIPTION
Before this change: custom Sampler and MeterManager each init'd their own instances of OboeAPI.

After this change: the Configurator init's one OboeAPI that gets passed to Sampler and MeterManager. I wanted to do this before updating the init call args.