### PR TITLE
NH-66478 Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,17 +7,24 @@ updates:
     interval: weekly
 
   groups:
-    otel-contrib:
+    otel-core:
+      patterns:
+        - "opentelemetry-api"
+        - "opentelemetry-sdk"
+      update-types:
+        - minor
+        - patch
+
+    otel-instrumentors:
       patterns:
         - "opentelemetry-instrumentation-*"
       update-types:
         - minor
         - patch
 
-    otel:
+    otel-utils:
       patterns:
-        - "opentelemetry-api"
-        - "opentelemetry-sdk"
+        - "opentelemetry-*"
       update-types:
         - minor
         - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,7 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: daily
-    time: "11:00"
-    timezone: "America/Vancouver"
+    interval: weekly
 
   groups:
     otel-contrib:


### PR DESCRIPTION
Updates pip ecosystem groups for Dependabot dependency checks to `otel-core`, `otel-instrumentors`, `otel-utils`, `misc` for PR clarity. Also reverts pip ecosystem checks back to `weekly` so PRs don't happen on weekend.