### PR TITLE
NH-70994 Remove sw.nonce from metrics attributes

### DIFF
--- a/solarwinds_apm/trace/otlp_metrics_processor.py
+++ b/solarwinds_apm/trace/otlp_metrics_processor.py
@@ -5,7 +5,6 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 import logging
-import random
 from typing import TYPE_CHECKING
 
 from solarwinds_apm.trace.base_metrics_processor import _SwBaseMetricsProcessor
@@ -87,9 +86,7 @@ class SolarWindsOTLPMetricsSpanProcessor(_SwBaseMetricsProcessor):
         # TODO add sw.service_name
         # https://swicloud.atlassian.net/browse/NH-67392
         # support ssa and conform to Otel proto common_pb2
-        meter_attrs = {
-            "sw.nonce": random.getrandbits(64) >> 1,
-        }
+        meter_attrs = {}
 
         # TODO add trace.service.requests, trace.service.errors
         # https://swicloud.atlassian.net/browse/NH-67392

--- a/tests/unit/test_processors/test_otlp_metrics_processor.py
+++ b/tests/unit/test_processors/test_otlp_metrics_processor.py
@@ -134,16 +134,6 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             return_value="foo",
         )
 
-        mock_random = mocker.patch(
-            "solarwinds_apm.trace.otlp_metrics_processor.random"
-        )
-        mock_random.configure_mock(
-            **{
-                # 4 >> 1 is 2
-                "getrandbits": mocker.Mock(return_value=4)
-            }
-        )
-
         mock_has_error = mocker.patch(
             "solarwinds_apm.trace.SolarWindsOTLPMetricsSpanProcessor.has_error"
         )
@@ -415,7 +405,6 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
         mock_meters.response_time.record.assert_called_once_with(
             amount=123,
             attributes={
-                'sw.nonce': 2,
                 'sw.is_error': 'true',
                 'http.status_code': 'foo-code',
                 'http.method': 'foo-method',
@@ -443,7 +432,6 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
         mock_meters.response_time.record.assert_called_once_with(
             amount=123,
             attributes={
-                'sw.nonce': 2,
                 'sw.is_error': 'false',
                 'http.status_code': 'foo-code',
                 'http.method': 'foo-method',
@@ -471,7 +459,6 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
         mock_meters.response_time.record.assert_called_once_with(
             amount=123,
             attributes={
-                'sw.nonce': 2,
                 'sw.is_error': 'true',
                 'sw.transaction': 'foo'
             }
@@ -498,7 +485,6 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
         mock_meters.response_time.record.assert_called_once_with(
             amount=123,
             attributes={
-                'sw.nonce': 2,
                 'sw.is_error': 'false',
                 'sw.transaction': 'foo'
             }


### PR DESCRIPTION
Remove `sw.nonce` metrics attribute setting by APM Python, as ingestion does that now.