### PR TITLE
NH-70998 Fix no-op function signature

### DIFF
--- a/solarwinds_apm/apm_noop.py
+++ b/solarwinds_apm/apm_noop.py
@@ -240,7 +240,7 @@ class OboeAPI:
     def __init__(self, *args, **kwargs):
         pass
 
-    def getTracingDecision(self):
+    def getTracingDecision(self, *args, **kwargs):
         return (
             0,
             0,


### PR DESCRIPTION
Fix clib API getTracingDecision no-op function signature, to stop TypeError if lambda and no-op.