### PR TITLE
NH-70998 Set histogram preferred temporality delta

### DIFF
--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -32,8 +32,6 @@ from opentelemetry.metrics import set_meter_provider
 from opentelemetry.propagate import set_global_textmap
 from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk._configuration import _OTelSDKConfigurator
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.metrics import Histogram, MeterProvider
 from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -34,6 +34,11 @@ from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk._configuration import _OTelSDKConfigurator
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.metrics import Histogram, MeterProvider
+from opentelemetry.sdk.metrics.export import (
+    AggregationTemporality,
+    PeriodicExportingMetricReader,
+)
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
@@ -358,6 +363,8 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             return
         environ_exporter_names = environ_exporter.split(",")
 
+        # Report all histograms with delta aggregation, including response_time
+        temporality_delta = {Histogram: AggregationTemporality.DELTA}
         metric_readers = []
         for exporter_name in environ_exporter_names:
             exporter = None
@@ -367,7 +374,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                         "opentelemetry_metrics_exporter",
                         exporter_name,
                     )
-                ).load()()
+                ).load()(preferred_temporality=temporality_delta)
             except Exception as ex:
                 logger.exception("A exception was raised: %s", ex)
                 logger.exception(

--- a/tests/unit/test_configurator/test_configurator_metrics_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_metrics_exporter.py
@@ -121,6 +121,7 @@ class TestConfiguratorMetricsExporter:
             test_configurator._configure_metrics_exporter(
                 mock_apmconfig_enabled_expt,
             )
+        
         mock_pemreader.assert_not_called()
         trace_mocks.get_tracer_provider.assert_not_called()
         trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
@@ -167,11 +168,29 @@ class TestConfiguratorMetricsExporter:
         # Mock Otel
         get_resource_mocks(mocker)
         trace_mocks = get_trace_mocks(mocker)
+        mock_histogram = mocker.patch(
+            "solarwinds_apm.configurator.Histogram"
+        )
+        mock_agg_temp = mocker.patch(
+            "solarwinds_apm.configurator.AggregationTemporality"
+        )
+        mock_agg_temp.DELTA = "foo-delta"
 
         # Test!
         test_configurator = configurator.SolarWindsConfigurator()
         test_configurator._configure_metrics_exporter(
             mock_apmconfig_enabled_expt,
+        )
+        mock_exporter_entry_point.load.assert_called_once()
+        mock_exporter_entry_point.load.assert_has_calls(
+            [
+                mocker.call(),
+                mocker.call()(
+                    preferred_temporality={
+                        mock_histogram: "foo-delta"
+                    }
+                )
+            ]
         )
         mock_pemreader.assert_called_once()
         trace_mocks.get_tracer_provider.assert_called_once()
@@ -229,6 +248,13 @@ class TestConfiguratorMetricsExporter:
         # Mock Otel
         get_resource_mocks(mocker)
         trace_mocks = get_trace_mocks(mocker)
+        mock_histogram = mocker.patch(
+            "solarwinds_apm.configurator.Histogram"
+        )
+        mock_agg_temp = mocker.patch(
+            "solarwinds_apm.configurator.AggregationTemporality"
+        )
+        mock_agg_temp.DELTA = "foo-delta"
 
         # Test!
         test_configurator = configurator.SolarWindsConfigurator()
@@ -240,6 +266,11 @@ class TestConfiguratorMetricsExporter:
         mock_iter_entry_points.assert_has_calls(
             [
                 mocker.call("opentelemetry_metrics_exporter", "invalid_exporter"),
+            ]
+        )
+        mock_exporter_entry_point_invalid.load.assert_has_calls(
+            [
+                mocker.call(),
             ]
         )
         # Not called at all
@@ -305,6 +336,13 @@ class TestConfiguratorMetricsExporter:
         # Mock Otel
         get_resource_mocks(mocker)
         trace_mocks = get_trace_mocks(mocker)
+        mock_histogram = mocker.patch(
+            "solarwinds_apm.configurator.Histogram"
+        )
+        mock_agg_temp = mocker.patch(
+            "solarwinds_apm.configurator.AggregationTemporality"
+        )
+        mock_agg_temp.DELTA = "foo-delta"
 
         # Test!
         test_configurator = configurator.SolarWindsConfigurator()
@@ -316,6 +354,23 @@ class TestConfiguratorMetricsExporter:
             [
                 mocker.call("opentelemetry_metrics_exporter", "valid_exporter"),
                 mocker.call("opentelemetry_metrics_exporter", "invalid_exporter"),
+            ]
+        )
+        mock_exporter_entry_point.load.assert_called_once()
+        mock_exporter_entry_point.load.assert_has_calls(
+            [
+                mocker.call(),
+                mocker.call()(
+                    preferred_temporality={
+                        mock_histogram: "foo-delta"
+                    }
+                )
+            ]
+        )
+        mock_exporter_entry_point_invalid.load.assert_called_once()
+        mock_exporter_entry_point_invalid.load.assert_has_calls(
+            [
+                mocker.call(),
             ]
         )
         # Called for the valid one


### PR DESCRIPTION
Depends on https://github.com/solarwinds/apm-python/pull/289. EDIT: that's done thanks!

Sets preference for all histograms to report using delta aggregation, including `response_time`.

The entry point `load` is called for any metrics exporters specified by `OTEL_METRICS_EXPORTER`. Otel Python's otlp metrics exporters for [http](https://github.com/open-telemetry/opentelemetry-python/blob/1061d96562990b1c2b596ace87239e7f9616589a/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/metric_exporter/__init__.py#L103) and [grpc](https://github.com/open-telemetry/opentelemetry-python/blob/1061d96562990b1c2b596ace87239e7f9616589a/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/metric_exporter/__init__.py#L101) both accept optional `preferred_temporality`. I don't think there are others in Otel Python. If someone configures a custom metrics exporter, it needs to also accept temporality or general **kwargs, else this might error.

Please let me know what you think!