### PR TITLE
NH-70998 PeriodicExportingMetricReader with export_interval infinity

### DIFF
--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -8,6 +8,7 @@
 
 import importlib
 import logging
+import math
 import os
 import sys
 import time
@@ -398,7 +399,11 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                 "Creating PeriodicExportingMetricReader using %s",
                 exporter_name,
             )
-            reader = PeriodicExportingMetricReader(exporter)
+            # Inf interval to not invoke periodic collection
+            reader = PeriodicExportingMetricReader(
+                exporter,
+                export_interval_millis=math.inf,
+            )
             metric_readers.append(reader)
 
         # Use configured Resource attributes then merge with

--- a/tests/unit/test_configurator/test_configurator_metrics_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_metrics_exporter.py
@@ -4,6 +4,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
+import math
 import os
 import pytest
 
@@ -153,11 +154,15 @@ class TestConfiguratorMetricsExporter:
             del os.environ["OTEL_METRICS_EXPORTER"]
 
         # Mock entry points
-        mock_exporter_class = mocker.MagicMock()
+        mock_exporter = mocker.Mock()
+        mock_exporter_class = mocker.Mock()
+        mock_exporter_class.configure_mock(return_value=mock_exporter)
+        mock_load = mocker.Mock()
+        mock_load.configure_mock(return_value=mock_exporter_class)
         mock_exporter_entry_point = mocker.Mock()
         mock_exporter_entry_point.configure_mock(
             **{
-                "load": mock_exporter_class
+                "load": mock_load,
             }
         )
         mock_points = iter([mock_exporter_entry_point])
@@ -185,6 +190,14 @@ class TestConfiguratorMetricsExporter:
             mock_apmconfig_enabled_expt,
         )
         mock_pemreader.assert_called_once()
+        mock_pemreader.assert_has_calls(
+            [
+                mocker.call(
+                    mock_exporter,
+                    export_interval_millis=math.inf,
+                )
+            ]
+        )
         trace_mocks.get_tracer_provider.assert_called_once()
         trace_mocks.get_tracer_provider().get_tracer.assert_called_once()
         metrics_mocks.set_meter_provider.assert_called_once()
@@ -279,11 +292,15 @@ class TestConfiguratorMetricsExporter:
             del os.environ["OTEL_METRICS_EXPORTER"]
 
         # Mock entry points
-        mock_exporter_class = mocker.MagicMock()
+        mock_exporter = mocker.Mock()
+        mock_exporter_class = mocker.Mock()
+        mock_exporter_class.configure_mock(return_value=mock_exporter)
+        mock_load = mocker.Mock()
+        mock_load.configure_mock(return_value=mock_exporter_class)
         mock_exporter_entry_point = mocker.Mock()
         mock_exporter_entry_point.configure_mock(
             **{
-                "load": mock_exporter_class
+                "load": mock_load,
             }
         )
         mock_exporter_class_invalid = mocker.Mock()
@@ -335,6 +352,14 @@ class TestConfiguratorMetricsExporter:
         )
         # Called for the valid one
         mock_pemreader.assert_called_once()
+        mock_pemreader.assert_has_calls(
+            [
+                mocker.call(
+                    mock_exporter,
+                    export_interval_millis=math.inf,
+                )
+            ]
+        )
         # Rest not called at all
         trace_mocks.get_tracer_provider.assert_not_called()
         trace_mocks.get_tracer_provider().get_tracer.assert_not_called()


### PR DESCRIPTION
We init [PeriodicExportingMetricReader](https://github.com/open-telemetry/opentelemetry-python/blob/1061d96562990b1c2b596ace87239e7f9616589a/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/export/__init__.py#L420-L428) with export interval infinity so reading is no longer periodic.