### PR TITLE
NH-70998 OTLP response_time metrics in milliseconds

### DIFF
--- a/solarwinds_apm/trace/base_metrics_processor.py
+++ b/solarwinds_apm/trace/base_metrics_processor.py
@@ -90,9 +90,13 @@ class _SwBaseMetricsProcessor(SpanProcessor):
         self,
         start_time: int,
         end_time: int,
+        time_conversion: int = 1e3,
     ) -> int:
-        """Calculate span time in microseconds (us) using start and end time
-        in nanoseconds (ns). OTel span start/end_time are optional."""
+        """Calculate span time (via time_conversion e.g. 1e3, 1e6)
+        using start and end time in nanoseconds (ns). OTel span
+        start/end_time are optional."""
         if not start_time or not end_time:
             return 0
-        return int((end_time - start_time) // 1e3)
+        ms_start_time = int(start_time // time_conversion)
+        ms_end_time = int(end_time // time_conversion)
+        return ms_end_time - ms_start_time

--- a/solarwinds_apm/trace/inbound_metrics_processor.py
+++ b/solarwinds_apm/trace/inbound_metrics_processor.py
@@ -70,6 +70,7 @@ class SolarWindsInboundMetricsSpanProcessor(_SwBaseMetricsProcessor):
             trans_name = tnames.custom_name
 
         is_span_http = self.is_span_http(span)
+        # convert from ns to microseconds
         span_time = self.calculate_span_time(
             span.start_time,
             span.end_time,

--- a/solarwinds_apm/trace/otlp_metrics_processor.py
+++ b/solarwinds_apm/trace/otlp_metrics_processor.py
@@ -91,9 +91,11 @@ class SolarWindsOTLPMetricsSpanProcessor(_SwBaseMetricsProcessor):
             meter_attrs.update({"sw.is_error": "false"})
 
         is_span_http = self.is_span_http(span)
+        # convert from ns to milliseconds
         span_time = self.calculate_span_time(
             span.start_time,
             span.end_time,
+            1e6,
         )
 
         if is_span_http:

--- a/tests/unit/test_processors/test_base_metrics_processor.py
+++ b/tests/unit/test_processors/test_base_metrics_processor.py
@@ -310,8 +310,18 @@ class TestSwBaseMetricsProcessor:
         assert 0 == processor.calculate_span_time(0, 1000)
         assert 0 == processor.calculate_span_time(1000, 0)
 
-    def test_calculate_span_time(self, mocker):
+    def test_calculate_span_time_default_1e3(self, mocker):
         processor = _SwBaseMetricsProcessor(
             mocker.Mock(),
         )
         assert 1 == processor.calculate_span_time(2000, 3000)
+
+    def test_calculate_span_time_1e6(self, mocker):
+        processor = _SwBaseMetricsProcessor(
+            mocker.Mock(),
+        )
+        assert 1 == processor.calculate_span_time(
+            2000000,
+            3000000,
+            1e6,
+        )


### PR DESCRIPTION
Fixes OTLP response_time metrics so they're reported in milliseconds (not nanoseconds, as before).

Here is a test otelcol metrics message following a request to a route with a `time.sleep(3)` included:

```
Metric #0
Descriptor:
     -> Name: trace.service.response_time
     -> Description: measures the duration of an inbound HTTP request
     -> Unit: ms
     -> DataType: Histogram
     -> AggregationTemporality: Cumulative
HistogramDataPoints #0
Data point attributes:
     -> sw.is_error: Str(false)
     -> http.status_code: Int(200)
     -> http.method: Str(GET)
     -> sw.transaction: Str(unused)
StartTimestamp: 2024-02-01 18:28:18.418123297 +0000 UTC
Timestamp: 2024-02-01 18:28:18.420461838 +0000 UTC
Count: 1
Sum: 3017.000000
Min: 3017.000000
Max: 3017.000000
```