### PR TITLE
NH-72055 Remove meters for sample_rate, sample_source

### DIFF
--- a/solarwinds_apm/apm_meter_manager.py
+++ b/solarwinds_apm/apm_meter_manager.py
@@ -124,33 +124,3 @@ class SolarWindsMeterManager:
                 callbacks=[consume_triggered_trace_count],
             )
         )
-
-        def get_last_used_sample_rate(
-            options: CallbackOptions,
-        ) -> Iterable[Observation]:
-            (
-                status,
-                trace_count,
-            ) = self.oboe_settings_api.getLastUsedSampleRate()
-            yield Observation(trace_count, {"status": status})
-
-        self.sample_rate = self.meter_request_counters.create_observable_gauge(
-            name="trace.service.sample_rate",
-            callbacks=[get_last_used_sample_rate],
-        )
-
-        def get_last_used_sample_source(
-            options: CallbackOptions,
-        ) -> Iterable[Observation]:
-            (
-                status,
-                trace_count,
-            ) = self.oboe_settings_api.getLastUsedSampleSource()
-            yield Observation(trace_count, {"status": status})
-
-        self.sample_source = (
-            self.meter_request_counters.create_observable_gauge(
-                name="trace.service.sample_source",
-                callbacks=[get_last_used_sample_source],
-            )
-        )

--- a/solarwinds_apm/apm_noop.py
+++ b/solarwinds_apm/apm_noop.py
@@ -217,12 +217,6 @@ class SolarWindsMeterManager:
         self.triggered_trace_count = NoOpObservableGauge(
             name="trace.service.triggered_trace_count"
         )
-        self.sample_rate = NoOpObservableGauge(
-            name="trace.service.sample_rate"
-        )
-        self.sample_source = NoOpObservableGauge(
-            name="trace.service.sample_source"
-        )
 
 
 class LoggingOptions:

--- a/tests/unit/test_apm_meter_manager.py
+++ b/tests/unit/test_apm_meter_manager.py
@@ -53,8 +53,6 @@ class TestApmMeterManager:
             "trace.service.tokenbucket_exhaustion_count": "consume_tokenbucket_exhaustion_count",
             "trace.service.through_trace_count": "consume_through_trace_count",
             "trace.service.triggered_trace_count": "consume_triggered_trace_count",
-            "trace.service.sample_rate": "get_last_used_sample_rate",
-            "trace.service.sample_source": "get_last_used_sample_source"
         }
 
         assert mock_histo.mock_calls == [


### PR DESCRIPTION
As per spec update, removes the OTLP meters (regular and no-op) that report `trace.service.sample_rate` and `trace.service.sample_source`.

Keeps the API no-op methods since extension still has them.