### PR TITLE
NH-70998 Rename Gauge callback local variables

### DIFF
--- a/solarwinds_apm/apm_meter_manager.py
+++ b/solarwinds_apm/apm_meter_manager.py
@@ -67,7 +67,9 @@ class SolarWindsMeterManager:
         def consume_request_count(
             options: CallbackOptions,
         ) -> Iterable[Observation]:
-            status, request_count = self.oboe_settings_api.consumeRequestCount()
+            status, request_count = (
+                self.oboe_settings_api.consumeRequestCount()
+            )
             yield Observation(request_count, {"status": status})
 
         self.request_count = (

--- a/solarwinds_apm/apm_meter_manager.py
+++ b/solarwinds_apm/apm_meter_manager.py
@@ -56,8 +56,8 @@ class SolarWindsMeterManager:
         def consume_samplecount(
             options: CallbackOptions,
         ) -> Iterable[Observation]:
-            status, trace_count = self.oboe_settings_api.consumeSampleCount()
-            yield Observation(trace_count, {"status": status})
+            status, sample_count = self.oboe_settings_api.consumeSampleCount()
+            yield Observation(sample_count, {"status": status})
 
         self.samplecount = self.meter_request_counters.create_observable_gauge(
             name="trace.service.samplecount",
@@ -67,8 +67,8 @@ class SolarWindsMeterManager:
         def consume_request_count(
             options: CallbackOptions,
         ) -> Iterable[Observation]:
-            status, trace_count = self.oboe_settings_api.consumeRequestCount()
-            yield Observation(trace_count, {"status": status})
+            status, request_count = self.oboe_settings_api.consumeRequestCount()
+            yield Observation(request_count, {"status": status})
 
         self.request_count = (
             self.meter_request_counters.create_observable_gauge(
@@ -82,9 +82,9 @@ class SolarWindsMeterManager:
         ) -> Iterable[Observation]:
             (
                 status,
-                trace_count,
+                tokenbucket_exh_count,
             ) = self.oboe_settings_api.consumeTokenBucketExhaustionCount()
-            yield Observation(trace_count, {"status": status})
+            yield Observation(tokenbucket_exh_count, {"status": status})
 
         self.tokenbucket_exhaustion_count = (
             self.meter_request_counters.create_observable_gauge(
@@ -98,9 +98,9 @@ class SolarWindsMeterManager:
         ) -> Iterable[Observation]:
             (
                 status,
-                trace_count,
+                through_trace_count,
             ) = self.oboe_settings_api.consumeThroughTraceCount()
-            yield Observation(trace_count, {"status": status})
+            yield Observation(through_trace_count, {"status": status})
 
         self.through_trace_count = (
             self.meter_request_counters.create_observable_gauge(
@@ -114,9 +114,9 @@ class SolarWindsMeterManager:
         ) -> Iterable[Observation]:
             (
                 status,
-                trace_count,
+                tt_count,
             ) = self.oboe_settings_api.consumeTriggeredTraceCount()
-            yield Observation(trace_count, {"status": status})
+            yield Observation(tt_count, {"status": status})
 
         self.triggered_trace_count = (
             self.meter_request_counters.create_observable_gauge(


### PR DESCRIPTION
Cosmetic change to rename ObservableGauge callback functions' local variables. Just for clarity, and noticed these after the c-lib 14.0.2 update.

Does not change for the sample_rate/source callbacks because they'll be removed in https://github.com/solarwinds/apm-python/pull/299