### PR TITLE
NH-71963 Upgrade getsentry token action

### DIFF
--- a/.github/workflows/build_publish_lambda_layer_aarch64.yaml
+++ b/.github/workflows/build_publish_lambda_layer_aarch64.yaml
@@ -17,7 +17,7 @@ jobs:
       label: ${{ steps.launch.outputs.label }} # github runner label
       instance-id: ${{ steps.launch.outputs.instance-id }} # ec2 instance id
     steps:
-      - uses: getsentry/action-github-app-token@v2
+      - uses: getsentry/action-github-app-token@v3
         id: github-token
         with:
           app_id: ${{ vars.APPLICATION_ID }}
@@ -67,7 +67,7 @@ jobs:
       - build_layer_aarch64
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/action-github-app-token@v2
+      - uses: getsentry/action-github-app-token@v3
         id: github-token
         with:
           app_id: ${{ vars.APPLICATION_ID }}

--- a/.github/workflows/build_publish_pypi_and_draft_release.yaml
+++ b/.github/workflows/build_publish_pypi_and_draft_release.yaml
@@ -52,7 +52,7 @@ jobs:
       label: ${{ steps.launch.outputs.label }} # github runner label
       instance-id: ${{ steps.launch.outputs.instance-id }} # ec2 instance id
     steps:
-      - uses: getsentry/action-github-app-token@v2
+      - uses: getsentry/action-github-app-token@v3
         id: github-token
         with:
           app_id: ${{ vars.APPLICATION_ID }}
@@ -104,7 +104,7 @@ jobs:
       - build_publish_aarch64
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/action-github-app-token@v2
+      - uses: getsentry/action-github-app-token@v3
         id: github-token
         with:
           app_id: ${{ vars.APPLICATION_ID }}
@@ -128,7 +128,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: getsentry/action-github-app-token@v2
+      - uses: getsentry/action-github-app-token@v3
         id: github-token
         with:
           app_id: ${{ vars.APPLICATION_ID }}

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -38,7 +38,7 @@ jobs:
       label: ${{ steps.launch.outputs.label }} # github runner label
       instance-id: ${{ steps.launch.outputs.instance-id }} # ec2 instance id
     steps:
-      - uses: getsentry/action-github-app-token@v2
+      - uses: getsentry/action-github-app-token@v3
         id: github-token
         with:
           app_id: ${{ vars.APPLICATION_ID }}
@@ -90,7 +90,7 @@ jobs:
       - build_publish_aarch64
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/action-github-app-token@v2
+      - uses: getsentry/action-github-app-token@v3
         id: github-token
         with:
           app_id: ${{ vars.APPLICATION_ID }}

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -36,7 +36,7 @@ jobs:
     outputs:
       matrix: ${{ steps.launch.outputs.matrix }}
     steps:
-      - uses: getsentry/action-github-app-token@v2
+      - uses: getsentry/action-github-app-token@v3
         id: github-token
         with:
           app_id: ${{ vars.APPLICATION_ID }}
@@ -259,7 +259,7 @@ jobs:
       - install-tests
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/action-github-app-token@v2
+      - uses: getsentry/action-github-app-token@v3
         id: github-token
         with:
           app_id: ${{ vars.APPLICATION_ID }}


### PR DESCRIPTION
Upgrade [getsentry/action-github-app-token](https://github.com/getsentry/action-github-app-token) to [v3](https://github.com/getsentry/action-github-app-token/releases/tag/v3.0.0) which updates to use Node 20.

Test run of Verify Installation workflow: https://github.com/solarwinds/apm-python/actions/runs/7875245332. There are only Node 16 warnings for the Ubuntu 18 tests which we're keeping for now.