### PR TITLE
NH-66126 Exporter defaults based on configured protocol

### DIFF
--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,3 +1,4 @@
 opentelemetry-exporter-otlp==1.20.0
+opentelemetry-exporter-otlp-proto-grpc==1.20.0
 opentelemetry-exporter-otlp-proto-http==1.20.0
 opentelemetry-instrumentation-aws-lambda==0.41b0

--- a/solarwinds_apm/apm_constants.py
+++ b/solarwinds_apm/apm_constants.py
@@ -19,11 +19,9 @@ INTL_SWO_TRANSACTION_ATTR_KEY = "sw.transaction"
 INTL_SWO_TRANSACTION_ATTR_MAX = 255
 INTL_SWO_X_OPTIONS_KEY = "sw_xtraceoptions"
 INTL_SWO_X_OPTIONS_RESPONSE_KEY = "xtrace_options_response"
+INTL_SWO_DEFAULT_OTLP_EXPORTER = "otlp_proto_http"
+INTL_SWO_DEFAULT_OTLP_EXPORTER_GRPC = "otlp_proto_grpc"
 INTL_SWO_DEFAULT_TRACES_EXPORTER = "solarwinds_exporter"
-# TODO change lambda defaults to `otlp`
-# https://swicloud.atlassian.net/browse/NH-66126
-INTL_SWO_DEFAULT_METRICS_EXPORTER_LAMBDA = "otlp_proto_http"
-INTL_SWO_DEFAULT_TRACES_EXPORTER_LAMBDA = "otlp_proto_http"
 INTL_SWO_TRACECONTEXT_PROPAGATOR = "tracecontext"
 INTL_SWO_BAGGAGE_PROPAGATOR = "baggage"
 INTL_SWO_PROPAGATOR = "solarwinds_propagator"

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -336,14 +336,18 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                     INTL_SWO_SUPPORT_EMAIL,
                 )
                 raise
-            logger.debug(
-                "Setting trace with BatchSpanProcessor using %s",
-                exporter_name,
-            )
 
             if apm_config.is_lambda:
+                logger.debug(
+                    "Setting trace with SimpleSpanProcessor using %s",
+                    exporter_name,
+                )
                 span_processor = SimpleSpanProcessor(exporter)
             else:
+                logger.debug(
+                    "Setting trace with BatchSpanProcessor using %s",
+                    exporter_name,
+                )
                 span_processor = BatchSpanProcessor(exporter)
 
             trace.get_tracer_provider().add_span_processor(span_processor)

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -337,6 +337,8 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                 )
                 raise
 
+            logger.debug("Loaded exporter (%s) with endpoint %s", type(exporter), exporter._endpoint)
+
             if apm_config.is_lambda:
                 logger.debug(
                     "Setting trace with SimpleSpanProcessor using %s",

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -337,8 +337,6 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                 )
                 raise
 
-            logger.debug("Loaded exporter (%s) with endpoint %s", type(exporter), exporter._endpoint)
-
             if apm_config.is_lambda:
                 logger.debug(
                     "Setting trace with SimpleSpanProcessor using %s",


### PR DESCRIPTION
Before this PR, metrics and traces exporter defaults depended on is_lambda (see https://github.com/solarwinds/apm-python/pull/217).

After this PR, the defaults don't depend on lambda. They instead depend on `OTEL_EXPORTER_OTLP_PROTOCOL` which we require for otlp exporting in any environment.

If Protocol is `http/protobuf`:

1. `OTEL_METRICS_EXPORTER` defaults to otlp_proto_http
2. `OTEL_TRACES_EXPORTER` defaults to otlp_proto_http

If Protocol is `grpc`:

1. `OTEL_METRICS_EXPORTER` defaults to otlp_proto_grpc
2. `OTEL_TRACES_EXPORTER` defaults to otlp_proto_grpc

If Protocol is anything else or unset:

1. No default for `OTEL_METRICS_EXPORTER`. User must configure metrics exporters else none will initialize.
2. `OTEL_TRACES_EXPORTER` defaults to solarwinds_exporter

Note that the above are for default values. Any combination of env vars to specify protocol, exporter, endpoint will still be respected.

This does deviate from the Otel default distro, which uses otlp_proto_grpc by default.

We now start packaging otlp_proto_grpc with our layer to better match Otel's layer and because export by grpc is available and working and the default for Otel Python.
