### PR TITLE
NH-70772 Add formatter to rotatingfilehandler

### DIFF
--- a/solarwinds_apm/apm_logging.py
+++ b/solarwinds_apm/apm_logging.py
@@ -214,6 +214,10 @@ def set_sw_log_type(log_type, log_filepath=""):
                 maxBytes=0,
                 backupCount=0,
             )
+            file_formatter = logging.Formatter(
+                "%(asctime)s [ %(name)s %(levelname)-8s p#%(process)d.%(thread)d] %(message)s"
+            )
+            file_hander.setFormatter(file_formatter)
             logger.addHandler(file_hander)
             # stop logging to stream
             logger.removeHandler(_stream_handler)


### PR DESCRIPTION
Adds formatter to RotatingFileHandler so that logs in contents of `SW_APM_LOG_FILEPATH` match what the StreamHandler already does. Example logs

```
2024-02-21 17:04:46,652 [ solarwinds_apm.configurator WARNING  p#1.281472885620768] Agent disabled. Not sending init message.
2024-02-21 17:04:49,552 [ solarwinds_apm.api DEBUG    p#1.281472856486304] Cannot cache custom transaction name abc because agent not enabled; ignoring
```