### PR TITLE
NH-73037 sw.is_error attribute as boolean

### DIFF
--- a/solarwinds_apm/trace/otlp_metrics_processor.py
+++ b/solarwinds_apm/trace/otlp_metrics_processor.py
@@ -87,9 +87,9 @@ class SolarWindsOTLPMetricsSpanProcessor(_SwBaseMetricsProcessor):
         meter_attrs = {}
         has_error = self.has_error(span)
         if has_error:
-            meter_attrs.update({"sw.is_error": "true"})
+            meter_attrs.update({"sw.is_error": True})
         else:
-            meter_attrs.update({"sw.is_error": "false"})
+            meter_attrs.update({"sw.is_error": False})
 
         is_span_http = self.is_span_http(span)
         # convert from ns to milliseconds

--- a/tests/unit/test_processors/test_otlp_metrics_processor.py
+++ b/tests/unit/test_processors/test_otlp_metrics_processor.py
@@ -307,7 +307,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 mocker.call(
                     amount=123,
                     attributes={
-                        'sw.is_error': 'true',
+                        'sw.is_error': True,
                         'http.status_code': 200,
                         'http.method': 'foo-method',
                         'sw.transaction': 'foo'
@@ -354,7 +354,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 mocker.call(
                     amount=123,
                     attributes={
-                        'sw.is_error': 'true',
+                        'sw.is_error': True,
                         'http.status_code': 200,
                         'http.method': 'foo-method',
                         'sw.transaction': 'foo'
@@ -401,7 +401,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 mocker.call(
                     amount=123,
                     attributes={
-                        'sw.is_error': 'true',
+                        'sw.is_error': True,
                         'http.status_code': 200,
                         'http.method': 'foo-method',
                         'sw.transaction': 'foo'
@@ -441,7 +441,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 mocker.call(
                     amount=123,
                     attributes={
-                        'sw.is_error': 'true',
+                        'sw.is_error': True,
                         'http.status_code': 200,
                         'http.method': 'foo-method',
                         'sw.transaction': 'foo'
@@ -512,7 +512,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 mocker.call(
                     amount=123,
                     attributes={
-                        'sw.is_error': 'true',
+                        'sw.is_error': True,
                         'http.status_code': 200,
                         'http.method': 'foo-method',
                         'sw.transaction': 'foo'
@@ -545,7 +545,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 mocker.call(
                     amount=123,
                     attributes={
-                        'sw.is_error': 'false',
+                        'sw.is_error': False,
                         'http.status_code': 200,
                         'http.method': 'foo-method',
                         'sw.transaction': 'foo'
@@ -579,7 +579,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 mocker.call(
                     amount=123,
                     attributes={
-                        'sw.is_error': 'true',
+                        'sw.is_error': True,
                         'sw.transaction': 'foo'
                     }
                 )
@@ -610,7 +610,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 mocker.call(
                     amount=123,
                     attributes={
-                        'sw.is_error': 'true',
+                        'sw.is_error': True,
                         'sw.transaction': 'foo'
                     }
                 )
@@ -642,7 +642,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 mocker.call(
                     amount=123,
                     attributes={
-                        'sw.is_error': 'false',
+                        'sw.is_error': False,
                         'sw.transaction': 'foo'
                     }
                 )


### PR DESCRIPTION
`sw.is_error` attribute on response_time metrics uses boolean values instead of string.

See also [comment](https://swicloud.atlassian.net/browse/NH-73037?focusedCommentId=2626890).