### PR TITLE
NH-74059 Use EC2_RUNNER_ARN

### DIFF
--- a/.github/workflows/build_publish_lambda_layer_aarch64.yaml
+++ b/.github/workflows/build_publish_lambda_layer_aarch64.yaml
@@ -24,8 +24,7 @@ jobs:
           private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.EC2_RUNNER_ARN }}
           aws-region: us-east-1
       - id: launch
         uses: solarwinds/ec2-runner-action@main
@@ -74,8 +73,7 @@ jobs:
           private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.EC2_RUNNER_ARN }}
           aws-region: us-east-1
       - uses: solarwinds/ec2-runner-action@main
         with:

--- a/.github/workflows/build_publish_lambda_layer_aarch64.yaml
+++ b/.github/workflows/build_publish_lambda_layer_aarch64.yaml
@@ -9,6 +9,10 @@ name: Publish APM Python lambda layer for aarch64
 on:
   workflow_call:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   launch_arm64:
     name: Launch arm64 ec2 runners

--- a/.github/workflows/build_publish_pypi_and_draft_release.yaml
+++ b/.github/workflows/build_publish_pypi_and_draft_release.yaml
@@ -16,6 +16,10 @@ on:
 env:
   RELEASE_NAME: rel-${{ github.event.inputs.version }}
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   is_publishable:
     name: Check if version valid

--- a/.github/workflows/build_publish_pypi_and_draft_release.yaml
+++ b/.github/workflows/build_publish_pypi_and_draft_release.yaml
@@ -59,8 +59,7 @@ jobs:
           private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.EC2_RUNNER_ARN }}
           aws-region: us-east-1
       - id: launch
         uses: solarwinds/ec2-runner-action@main
@@ -111,8 +110,7 @@ jobs:
           private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.EC2_RUNNER_ARN }}
           aws-region: us-east-1
       - uses: solarwinds/ec2-runner-action@main
         with:

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -9,6 +9,10 @@ name: Publish to TestPyPi
 on:
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build_publish_sdist_and_x86_64:
     name: Build and publish sdist and x86_64

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -45,8 +45,7 @@ jobs:
           private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.EC2_RUNNER_ARN }}
           aws-region: us-east-1
       - id: launch
         uses: solarwinds/ec2-runner-action@main
@@ -97,8 +96,7 @@ jobs:
           private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.EC2_RUNNER_ARN }}
           aws-region: us-east-1
       - uses: solarwinds/ec2-runner-action@main
         with:

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -43,8 +43,7 @@ jobs:
           private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.EC2_RUNNER_ARN }}
           aws-region: us-east-1
       - id: launch
         uses: solarwinds/ec2-runner-action@main
@@ -266,8 +265,7 @@ jobs:
           private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.EC2_RUNNER_ARN }}
           aws-region: us-east-1
       - uses: solarwinds/ec2-runner-action@main
         with:

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -30,6 +30,10 @@ env:
   SW_APM_SERVICE_KEY_PROD: ${{ secrets.SW_APM_SERVICE_KEY_PROD }}
   SW_APM_SERVICE_KEY_STAGING: ${{ secrets.SW_APM_SERVICE_KEY_STAGING }}
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   launch-arm64:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Workflows use new `EC2_RUNNER_ARN` instead of old key combo.

Tested by running [smoke test](https://github.com/solarwinds/apm-python/actions/runs/8084999471/job/22091576851) workflow and [layer publish](https://github.com/solarwinds/apm-python/actions/runs/8085062667) workflow which were both successful.