### PR TITLE
NH-70758 Fix grpcio ImportError if outside py38

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,10 @@ aws-lambda: check-zip wrapper
 	mkdir -p ${target_dir}/python
 	@echo -e "Install upstream dependencies to include in layer"
 	@/opt/python/cp38-cp38/bin/pip3.8 install -t ${target_dir}/python -r lambda/requirements.txt
+	@echo -e "Install other version-specific .so files for deps"
+	@set -e; for PYBIN in cp39-cp39 cp310-cp310 cp311-cp311; do /opt/python/$${PYBIN}/bin/pip install -t ${target_dir}/$${PYBIN} -r lambda/requirements-so.txt; done
+	@set -e; for PYBIN in cp39-cp39 cp310-cp310 cp311-cp311; do cp ${target_dir}/$${PYBIN}/charset_normalizer/*.so ${target_dir}/python/charset_normalizer/ && cp ${target_dir}/$${PYBIN}/grpc/_cython/*.so ${target_dir}/python/grpc/_cython/ && cp ${target_dir}/$${PYBIN}/wrapt/*.so ${target_dir}/python/wrapt/; done
+	@set -e; for PYBIN in cp39-cp39 cp310-cp310 cp311-cp311; do rm -rf ${target_dir}/$${PYBIN} ; done
 	@echo -e "Install upstream dependencies without deps to include in layer"
 	@/opt/python/cp38-cp38/bin/pip3.8 install -t ${target_dir}/nodeps -r lambda/requirements-nodeps.txt --no-deps
 	@echo -e "Install solarwinds_apm to be packed up in zip archive to target directory."

--- a/lambda/requirements-so.txt
+++ b/lambda/requirements-so.txt
@@ -1,0 +1,3 @@
+charset_normalizer==3.3.2
+grpcio==1.62.0
+wrapt==1.16.0


### PR DESCRIPTION
Fixes grpcio module `ImportError` if layer run outside Python 3.8. See [comment](https://swicloud.atlassian.net/browse/NH-70758?focusedCommentId=2634819) for testing.