### PR TITLE
NH-74279 Add sw.apm.version resource attribute

### DIFF
--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -179,7 +179,11 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             TracerProvider(
                 sampler=sampler,
                 resource=Resource.create(
-                    {"service.name": apm_config.service_name}
+                    {
+                        "sw.apm.version": __version__,
+                        "sw.data.module": "apm",
+                        "service.name": apm_config.service_name,
+                    }
                 ),
             ),
         )
@@ -402,6 +406,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         resource = trace.get_tracer_provider().get_tracer(__name__).resource
         sw_resource = Resource.create(
             {
+                "sw.apm.version": __version__,
                 "sw.data.module": "apm",
                 "service.name": apm_config.service_name,
             }

--- a/tests/unit/test_configurator/test_configurator_sampler.py
+++ b/tests/unit/test_configurator/test_configurator_sampler.py
@@ -89,6 +89,12 @@ class TestConfiguratorSampler:
         resource_mocks = get_resource_mocks(mocker)
         trace_mocks = get_trace_mocks(mocker)
 
+        # Mock APM version
+        mocker.patch(
+            "solarwinds_apm.configurator.__version__",
+            "1.2.3",
+        )
+
         # Test!
         test_configurator = configurator.SolarWindsConfigurator()
         test_configurator._configure_sampler(
@@ -101,7 +107,13 @@ class TestConfiguratorSampler:
         resource_mocks.create.assert_has_calls(
             [
                 # service name from apmconfig fixture
-                mocker.call({"service.name": "foo-service"})
+                mocker.call(
+                    {
+                        "sw.apm.version": "1.2.3",
+                        "sw.data.module": "apm",
+                        "service.name": "foo-service"
+                    }
+                )
             ]
         )
         mock_tracerprovider.assert_called_once()
@@ -129,6 +141,12 @@ class TestConfiguratorSampler:
         # Mock Otel
         resource_mocks = get_resource_mocks(mocker)
         trace_mocks = get_trace_mocks(mocker)
+
+        # Mock APM version
+        mocker.patch(
+            "solarwinds_apm.configurator.__version__",
+            "1.2.3",
+        )
 
         # Mock sw sampler
         mock_sw_sampler = mocker.patch(
@@ -161,7 +179,13 @@ class TestConfiguratorSampler:
         resource_mocks.create.assert_has_calls(
             [
                 # service name from apmconfig fixture
-                mocker.call({"service.name": "foo-service"})
+                mocker.call(
+                    {
+                        "sw.apm.version": "1.2.3",
+                        "sw.data.module": "apm",
+                        "service.name": "foo-service"
+                    }
+                )
             ]
         )
         mock_tracerprovider.assert_called_once()


### PR DESCRIPTION
Adds `sw.apm.version` resource attribute to TraceProvider and MeterProvider.

Also adds `sw.data.module` to TraceProvider which was missing? because MeterProvider already receiving it.