### PR TITLE
NH-74450 Custom distro load_instrumentor catches and logs

### DIFF
--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -116,7 +116,15 @@ class SolarWindsDistro(BaseDistro):
             # Note: Django ORM accepts options in settings.py
             # https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/django/django.html
             kwargs["commenter_options"] = self.detect_commenter_options()
-        instrumentor: BaseInstrumentor = entry_point.load()
+        try:
+            instrumentor: BaseInstrumentor = entry_point.load()
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.error(
+                "Could not load instrumentor %s: %s",
+                entry_point.name,
+                ex,
+            )
+            return
         instrumentor().instrument(**kwargs)
 
     def enable_commenter(self) -> bool:


### PR DESCRIPTION
Updates custom distro `load_instrumentor` method to catch and log errors at auto-instrumentation, such as `grpcio` ImportError when the wrong distro for a particular architecture is used (e.g. `arm64` instead of `x86_64`). Example output, instead of a multi-line stacktrace:

> `2024-03-05 17:58:41,108 [ solarwinds_apm.distro ERROR p#17.140002353669952] Could not load instrumentor grpc_aio_client: cannot import name 'cygrpc' from 'grpc._cython' (/opt/python/grpc/_cython/__init__.py)`