### PR TITLE
NH-68251 Split create/report init event and log status

### DIFF
--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -339,6 +339,19 @@ def mock_config_otel_components(mocker):
         "solarwinds_apm.configurator.SolarWindsConfigurator._configure_otel_components"
     )
 
+@pytest.fixture(name="mock_create_init")
+def mock_create_init(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsConfigurator._create_init_event"
+    )
+
+@pytest.fixture(name="mock_create_init_fail")
+def mock_create_init_fail(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsConfigurator._create_init_event",
+        return_value=None,
+    )
+
 @pytest.fixture(name="mock_report_init")
 def mock_report_init(mocker):
     return mocker.patch(

--- a/tests/unit/test_configurator/test_configurator_configure.py
+++ b/tests/unit/test_configurator/test_configurator_configure.py
@@ -7,7 +7,7 @@
 from solarwinds_apm import configurator
 
 class TestConfiguratorConfigure:
-    def test_configurator_configure(
+    def test_configurator_configure_init_success(
         self,
         mocker,
         mock_txn_name_manager_init,
@@ -15,6 +15,7 @@ class TestConfiguratorConfigure:
         mock_apmconfig_enabled,
         mock_init_sw_reporter,
         mock_config_otel_components,
+        mock_create_init,
         mock_report_init,
     ):
         test_configurator = configurator.SolarWindsConfigurator()
@@ -26,4 +27,39 @@ class TestConfiguratorConfigure:
 
         mock_init_sw_reporter.assert_called_once()
         mock_config_otel_components.assert_called_once()
+        mock_create_init.assert_called_once()
         mock_report_init.assert_called_once()
+
+    def test_configurator_configure_init_failure(
+        self,
+        mocker,
+        mock_txn_name_manager_init,
+        mock_fwkv_manager_init,
+        mock_apmconfig_enabled,
+        mock_init_sw_reporter,
+        mock_config_otel_components,
+        mock_create_init_fail,
+        mock_report_init,
+    ):
+        mock_log_error = mocker.Mock()
+        mock_logger = mocker.patch(
+            "solarwinds_apm.configurator.logger"
+        )
+        mock_logger.configure_mock(
+            **{
+                "error": mock_log_error,
+            }
+        )
+
+        test_configurator = configurator.SolarWindsConfigurator()
+        test_configurator._configure()
+
+        mock_txn_name_manager_init.assert_called_once()
+        mock_fwkv_manager_init.assert_called_once()
+        mock_apmconfig_enabled.assert_called_once()
+
+        mock_init_sw_reporter.assert_called_once()
+        mock_config_otel_components.assert_called_once()
+        mock_create_init_fail.assert_called_once()
+        mock_report_init.assert_not_called()
+        mock_log_error.assert_called_once()

--- a/tests/unit/test_configurator/test_configurator_create_init_event.py
+++ b/tests/unit/test_configurator/test_configurator_create_init_event.py
@@ -1,0 +1,281 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+from solarwinds_apm import configurator
+from solarwinds_apm.extension.oboe import Event
+
+from .fixtures.trace import get_trace_mocks
+
+class TestConfiguratorCreateInitEvent:
+    def test_configurator_create_init_is_lambda(
+        self,
+        mocker,
+        mock_sys,
+        mock_apm_version,
+        mock_fw_versions,
+        mock_extension,
+        mock_apmconfig_enabled_is_lambda,
+    ):
+        trace_mocks = get_trace_mocks(mocker)
+
+        test_configurator = configurator.SolarWindsConfigurator()
+        result = test_configurator._create_init_event(
+            mock_extension.Reporter,
+            mock_apmconfig_enabled_is_lambda,
+        )
+
+        assert result is None
+
+        # Otel and APM methods not called
+        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_not_called()
+        mock_fw_versions.assert_not_called()
+
+        # Extension methods not called
+        mock_apmconfig_enabled_is_lambda.extension.Config.getVersionString.assert_not_called()
+        assert mocker.call(True,) not in mock_apmconfig_enabled_is_lambda.extension.Metadata.makeRandom.mock_calls
+        mock_apmconfig_enabled_is_lambda.extension.Context.set.assert_not_called()
+        mock_apmconfig_enabled_is_lambda.extension.Metadata.makeRandom().createEvent().addInfo.assert_not_called()
+
+    def test_configurator_create_init_bad_init_status_disabled(
+        self,
+        mocker,
+        mock_sys,
+        mock_apm_version,
+        mock_fw_versions,
+        mock_extension_status_code_invalid_protocol,
+        mock_apmconfig_disabled,
+    ):
+        trace_mocks = get_trace_mocks(mocker)
+
+        test_configurator = configurator.SolarWindsConfigurator()
+        result = test_configurator._create_init_event(
+            mock_extension_status_code_invalid_protocol.Reporter,
+            mock_apmconfig_disabled,
+        )
+
+        assert result is None
+
+        # Otel and APM methods not called
+        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_not_called()
+        mock_fw_versions.assert_not_called()
+
+        # Extension methods not called
+        mock_apmconfig_disabled.extension.Config.getVersionString.assert_not_called()
+        assert mocker.call(True,) not in mock_apmconfig_disabled.extension.Metadata.makeRandom.mock_calls
+        mock_apmconfig_disabled.extension.Context.set.assert_not_called()
+        mock_apmconfig_disabled.extension.Metadata.makeRandom().createEvent().addInfo.assert_not_called()
+
+    def test_configurator_create_init_bad_init_status_enabled(
+        self,
+        mocker,
+        mock_sys,
+        mock_apm_version,
+        mock_fw_versions,
+        mock_extension_status_code_invalid_protocol,
+        mock_apmconfig_enabled,
+    ):
+        trace_mocks = get_trace_mocks(mocker)
+
+        test_configurator = configurator.SolarWindsConfigurator()
+        result = test_configurator._create_init_event(
+            mock_extension_status_code_invalid_protocol.Reporter,
+            mock_apmconfig_enabled,
+        )
+
+        assert result is None
+
+        # Otel and APM methods not called
+        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_not_called()
+        mock_fw_versions.assert_not_called()
+
+        # Extension methods not called
+        mock_apmconfig_enabled.extension.Config.getVersionString.assert_not_called()
+        assert mocker.call(True,) not in mock_apmconfig_enabled.extension.Metadata.makeRandom.mock_calls
+        mock_apmconfig_enabled.extension.Context.set.assert_not_called()
+        mock_apmconfig_enabled.extension.Metadata.makeRandom().createEvent().addInfo.assert_not_called()
+
+    def test_configurator_create_init_ok_init_status_disabled(
+        self,
+        mocker,
+        mock_sys,
+        mock_apm_version,
+        mock_fw_versions,
+        mock_extension,
+        mock_apmconfig_disabled,
+    ):
+        trace_mocks = get_trace_mocks(mocker)
+
+        test_configurator = configurator.SolarWindsConfigurator()
+        result = test_configurator._create_init_event(
+            mock_extension.Reporter,
+            mock_apmconfig_disabled,
+        )
+
+        assert result is None
+
+        # Otel and APM methods not called
+        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_not_called()
+        mock_fw_versions.assert_not_called()
+
+        # Extension methods not called
+        mock_apmconfig_disabled.extension.Config.getVersionString.assert_not_called()
+        assert mocker.call(True,) not in mock_apmconfig_disabled.extension.Metadata.makeRandom.mock_calls
+        mock_apmconfig_disabled.extension.Context.set.assert_not_called()
+        mock_apmconfig_disabled.extension.Metadata.makeRandom().createEvent().addInfo.assert_not_called()
+
+    def test_configurator_create_init_already_init_status_disabled(
+        self,
+        mocker,
+        mock_sys,
+        mock_apm_version,
+        mock_fw_versions,
+        mock_extension_status_code_already_init,
+        mock_apmconfig_disabled,
+    ):
+        trace_mocks = get_trace_mocks(mocker)
+
+        test_configurator = configurator.SolarWindsConfigurator()
+        result = test_configurator._create_init_event(
+            mock_extension_status_code_already_init.Reporter,
+            mock_apmconfig_disabled,
+        )
+
+        assert result is None
+
+        # Otel and APM methods not called
+        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_not_called()
+        mock_fw_versions.assert_not_called()
+
+        # Extension methods not called
+        mock_apmconfig_disabled.extension.Config.getVersionString.assert_not_called()
+        assert mocker.call(True,) not in mock_apmconfig_disabled.extension.Metadata.makeRandom.mock_calls
+        mock_apmconfig_disabled.extension.Context.set.assert_not_called()
+        mock_apmconfig_disabled.extension.Metadata.makeRandom().createEvent().addInfo.assert_not_called()
+
+    def test_configurator_create_init_invalid_md(
+        self,
+        mocker,
+        mock_sys,
+        mock_apm_version,
+        mock_fw_versions,
+        mock_extension,
+        mock_apmconfig_enabled_md_invalid,
+    ):
+        trace_mocks = get_trace_mocks(mocker)
+
+        test_configurator = configurator.SolarWindsConfigurator()
+        result = test_configurator._create_init_event(
+            mock_extension.Reporter,
+            mock_apmconfig_enabled_md_invalid,
+        )
+
+        assert isinstance(
+            result,
+            type(mock_apmconfig_enabled_md_invalid.extension.Metadata.makeRandom().createEvent()),
+        )
+
+        # Otel and APM methods called
+        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_called_once()
+        mock_fw_versions.assert_called_once()
+
+        # Some extension methods called
+        mock_apmconfig_enabled_md_invalid.extension.Config.getVersionString.assert_called_once()
+
+    def test_configurator_create_init_bad_sys_py_version_still_creates_without_runtime_version(
+        self,
+        mocker,
+        mock_sys_error_version_info,
+        mock_apm_version,
+        mock_fw_versions,
+        mock_extension,
+        mock_apmconfig_enabled,
+    ):
+        trace_mocks = get_trace_mocks(mocker)
+
+        test_configurator = configurator.SolarWindsConfigurator()
+        result = test_configurator._create_init_event(
+            mock_extension.Reporter,
+            mock_apmconfig_enabled,
+        )
+
+        assert isinstance(
+            result,
+            type(mock_apmconfig_enabled.extension.Metadata.makeRandom().createEvent()),
+        )
+
+        # Otel and APM methods called
+        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_called_once()
+        mock_fw_versions.assert_called_once()
+
+        # Extension methods called
+        mock_apmconfig_enabled.extension.Config.getVersionString.assert_called_once()
+        mock_apmconfig_enabled.extension.Metadata.makeRandom.assert_has_calls(
+            [
+                mocker.call(True,),  # makeRandom(True)
+            ]
+        )
+        mock_apmconfig_enabled.extension.Context.set.assert_called_once()
+        mock_apmconfig_enabled.extension.Metadata.makeRandom().createEvent().addInfo.assert_has_calls(
+            [
+                mocker.call("Layer", "Python"),
+                mocker.call("__Init", True),
+                mocker.call("process.runtime.name", "foo-name"),
+                mocker.call("process.runtime.description", "foo-runtime"),
+                mocker.call("process.executable.path", "/foo/path"),
+                mocker.call("APM.Version", "0.0.0"),
+                mocker.call("APM.Extension.Version", "1.1.1"),
+                mocker.call("foo-fw", "bar-version")
+            ]
+        )
+
+    def test_configurator_create_init(
+        self,
+        mocker,
+        mock_sys,
+        mock_apm_version,
+        mock_fw_versions,
+        mock_extension,
+        mock_apmconfig_enabled,
+    ):
+        trace_mocks = get_trace_mocks(mocker)
+
+        # Test!
+        test_configurator = configurator.SolarWindsConfigurator()
+        result = test_configurator._create_init_event(
+            mock_extension.Reporter,
+            mock_apmconfig_enabled,
+        )
+
+        assert isinstance(
+            result,
+            type(mock_apmconfig_enabled.extension.Metadata.makeRandom().createEvent()),
+        )
+
+        # Otel and APM methods called
+        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_called_once()
+        mock_fw_versions.assert_called_once()
+
+        # Extension methods called
+        mock_apmconfig_enabled.extension.Config.getVersionString.assert_called_once()
+        mock_apmconfig_enabled.extension.Metadata.makeRandom.assert_has_calls(
+            [
+                mocker.call(True,),  # makeRandom(True)
+            ]
+        )
+        mock_apmconfig_enabled.extension.Context.set.assert_called_once()
+        mock_apmconfig_enabled.extension.Metadata.makeRandom().createEvent().addInfo.assert_has_calls(
+            [
+                mocker.call("Layer", "Python"),
+                mocker.call("__Init", True),
+                mocker.call("process.runtime.version", "3.11.12"),
+                mocker.call("process.runtime.name", "foo-name"),
+                mocker.call("process.runtime.description", "foo-runtime"),
+                mocker.call("process.executable.path", "/foo/path"),
+                mocker.call("APM.Version", "0.0.0"),
+                mocker.call("APM.Extension.Version", "1.1.1"),
+                mocker.call("foo-fw", "bar-version")
+            ]
+        )

--- a/tests/unit/test_configurator/test_configurator_create_init_event.py
+++ b/tests/unit/test_configurator/test_configurator_create_init_event.py
@@ -5,7 +5,6 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 from solarwinds_apm import configurator
-from solarwinds_apm.extension.oboe import Event
 
 from .fixtures.trace import get_trace_mocks
 

--- a/tests/unit/test_configurator/test_configurator_report_init_event.py
+++ b/tests/unit/test_configurator/test_configurator_report_init_event.py
@@ -1,4 +1,4 @@
-# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+# © 2024 SolarWinds Worldwide, LLC. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -6,259 +6,28 @@
 
 from solarwinds_apm import configurator
 
-from .fixtures.trace import get_trace_mocks
 
 class TestConfiguratorReportInitEvent:
-    def test_configurator_report_init_is_lambda(
-        self,
-        mocker,
-        mock_sys,
-        mock_apm_version,
-        mock_fw_versions,
-        mock_extension,
-        mock_apmconfig_enabled_is_lambda,
-    ):
-        trace_mocks = get_trace_mocks(mocker)
-
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._report_init_event(
-            mock_extension.Reporter,
-            mock_apmconfig_enabled_is_lambda,
-        )
-
-        # Otel and APM methods not called
-        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_not_called()
-        mock_fw_versions.assert_not_called()
-
-        # Extension methods not called
-        mock_apmconfig_enabled_is_lambda.extension.Config.getVersionString.assert_not_called()
-        assert mocker.call(True,) not in mock_apmconfig_enabled_is_lambda.extension.Metadata.makeRandom.mock_calls
-        mock_apmconfig_enabled_is_lambda.extension.Context.set.assert_not_called()
-        mock_apmconfig_enabled_is_lambda.extension.Metadata.makeRandom().createEvent().addInfo.assert_not_called()
-        mock_extension.Reporter.sendStatus.assert_not_called()
-
-    def test_configurator_report_init_bad_init_status_disabled(
-        self,
-        mocker,
-        mock_sys,
-        mock_apm_version,
-        mock_fw_versions,
-        mock_extension_status_code_invalid_protocol,
-        mock_apmconfig_disabled,
-    ):
-        trace_mocks = get_trace_mocks(mocker)
-
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._report_init_event(
-            mock_extension_status_code_invalid_protocol.Reporter,
-            mock_apmconfig_disabled,
-        )
-
-        # Otel and APM methods not called
-        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_not_called()
-        mock_fw_versions.assert_not_called()
-
-        # Extension methods not called
-        mock_apmconfig_disabled.extension.Config.getVersionString.assert_not_called()
-        assert mocker.call(True,) not in mock_apmconfig_disabled.extension.Metadata.makeRandom.mock_calls
-        mock_apmconfig_disabled.extension.Context.set.assert_not_called()
-        mock_apmconfig_disabled.extension.Metadata.makeRandom().createEvent().addInfo.assert_not_called()
-        mock_extension_status_code_invalid_protocol.Reporter.sendStatus.assert_not_called()
-
-    def test_configurator_report_init_bad_init_status_enabled(
-        self,
-        mocker,
-        mock_sys,
-        mock_apm_version,
-        mock_fw_versions,
-        mock_extension_status_code_invalid_protocol,
-        mock_apmconfig_enabled,
-    ):
-        trace_mocks = get_trace_mocks(mocker)
-
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._report_init_event(
-            mock_extension_status_code_invalid_protocol.Reporter,
-            mock_apmconfig_enabled,
-        )
-
-        # Otel and APM methods not called
-        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_not_called()
-        mock_fw_versions.assert_not_called()
-
-        # Extension methods not called
-        mock_apmconfig_enabled.extension.Config.getVersionString.assert_not_called()
-        assert mocker.call(True,) not in mock_apmconfig_enabled.extension.Metadata.makeRandom.mock_calls
-        mock_apmconfig_enabled.extension.Context.set.assert_not_called()
-        mock_apmconfig_enabled.extension.Metadata.makeRandom().createEvent().addInfo.assert_not_called()
-        mock_extension_status_code_invalid_protocol.Reporter.sendStatus.assert_not_called()
-
-    def test_configurator_report_init_ok_init_status_disabled(
-        self,
-        mocker,
-        mock_sys,
-        mock_apm_version,
-        mock_fw_versions,
-        mock_extension,
-        mock_apmconfig_disabled,
-    ):
-        trace_mocks = get_trace_mocks(mocker)
-
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._report_init_event(
-            mock_extension.Reporter,
-            mock_apmconfig_disabled,
-        )
-
-        # Otel and APM methods not called
-        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_not_called()
-        mock_fw_versions.assert_not_called()
-
-        # Extension methods not called
-        mock_apmconfig_disabled.extension.Config.getVersionString.assert_not_called()
-        assert mocker.call(True,) not in mock_apmconfig_disabled.extension.Metadata.makeRandom.mock_calls
-        mock_apmconfig_disabled.extension.Context.set.assert_not_called()
-        mock_apmconfig_disabled.extension.Metadata.makeRandom().createEvent().addInfo.assert_not_called()
-        mock_extension.sendStatus.assert_not_called()
-
-    def test_configurator_report_init_already_init_status_disabled(
-        self,
-        mocker,
-        mock_sys,
-        mock_apm_version,
-        mock_fw_versions,
-        mock_extension_status_code_already_init,
-        mock_apmconfig_disabled,
-    ):
-        trace_mocks = get_trace_mocks(mocker)
-
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._report_init_event(
-            mock_extension_status_code_already_init.Reporter,
-            mock_apmconfig_disabled,
-        )
-
-        # Otel and APM methods not called
-        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_not_called()
-        mock_fw_versions.assert_not_called()
-
-        # Extension methods not called
-        mock_apmconfig_disabled.extension.Config.getVersionString.assert_not_called()
-        assert mocker.call(True,) not in mock_apmconfig_disabled.extension.Metadata.makeRandom.mock_calls
-        mock_apmconfig_disabled.extension.Context.set.assert_not_called()
-        mock_apmconfig_disabled.extension.Metadata.makeRandom().createEvent().addInfo.assert_not_called()
-        mock_extension_status_code_already_init.sendStatus.assert_not_called()
-
-    def test_configurator_report_init_invalid_md(
-        self,
-        mocker,
-        mock_sys,
-        mock_apm_version,
-        mock_fw_versions,
-        mock_extension,
-        mock_apmconfig_enabled_md_invalid,
-    ):
-        trace_mocks = get_trace_mocks(mocker)
-
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._report_init_event(
-            mock_extension.Reporter,
-            mock_apmconfig_enabled_md_invalid,
-        )
-
-        # Otel and APM methods called
-        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_called_once()
-        mock_fw_versions.assert_called_once()
-
-        # Some extension methods called
-        mock_apmconfig_enabled_md_invalid.extension.Config.getVersionString.assert_called_once()
-        # But message not sent
-        mock_extension.sendStatus.assert_not_called()
-
-    def test_configurator_report_init_bad_sys_py_version_still_reports_without_runtime_version(
-        self,
-        mocker,
-        mock_sys_error_version_info,
-        mock_apm_version,
-        mock_fw_versions,
-        mock_extension,
-        mock_apmconfig_enabled,
-    ):
-        trace_mocks = get_trace_mocks(mocker)
-
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._report_init_event(
-            mock_extension.Reporter,
-            mock_apmconfig_enabled,
-        )
-
-        # Otel and APM methods called
-        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_called_once()
-        mock_fw_versions.assert_called_once()
-
-        # Extension methods called
-        mock_apmconfig_enabled.extension.Config.getVersionString.assert_called_once()
-        mock_apmconfig_enabled.extension.Metadata.makeRandom.assert_has_calls(
-            [
-                mocker.call(True,),  # makeRandom(True)
-            ]
-        )
-        mock_apmconfig_enabled.extension.Context.set.assert_called_once()
-        mock_apmconfig_enabled.extension.Metadata.makeRandom().createEvent().addInfo.assert_has_calls(
-            [
-                mocker.call("Layer", "Python"),
-                mocker.call("__Init", True),
-                mocker.call("process.runtime.name", "foo-name"),
-                mocker.call("process.runtime.description", "foo-runtime"),
-                mocker.call("process.executable.path", "/foo/path"),
-                mocker.call("APM.Version", "0.0.0"),
-                mocker.call("APM.Extension.Version", "1.1.1"),
-                mocker.call("foo-fw", "bar-version")
-            ]
-        )
-        mock_extension.Reporter.sendStatus.assert_called_once()
-
     def test_configurator_report_init(
         self,
         mocker,
-        mock_sys,
-        mock_apm_version,
-        mock_fw_versions,
         mock_extension,
-        mock_apmconfig_enabled,
     ):
-        trace_mocks = get_trace_mocks(mocker)
+        mock_log_info = mocker.Mock()
+        mock_logger = mocker.patch(
+            "solarwinds_apm.configurator.logger"
+        )
+        mock_logger.configure_mock(
+            **{
+                "info": mock_log_info,
+            }
+        )
+        mock_event = mocker.Mock()
 
-        # Test!
         test_configurator = configurator.SolarWindsConfigurator()
         test_configurator._report_init_event(
             mock_extension.Reporter,
-            mock_apmconfig_enabled,
+            mock_event,
         )
-
-        # Otel and APM methods called
-        trace_mocks.get_tracer_provider().get_tracer().resource.attributes.items.assert_called_once()
-        mock_fw_versions.assert_called_once()
-
-        # Extension methods called
-        mock_apmconfig_enabled.extension.Config.getVersionString.assert_called_once()
-        mock_apmconfig_enabled.extension.Metadata.makeRandom.assert_has_calls(
-            [
-                mocker.call(True,),  # makeRandom(True)
-            ]
-        )
-        mock_apmconfig_enabled.extension.Context.set.assert_called_once()
-        mock_apmconfig_enabled.extension.Metadata.makeRandom().createEvent().addInfo.assert_has_calls(
-            [
-                mocker.call("Layer", "Python"),
-                mocker.call("__Init", True),
-                mocker.call("process.runtime.version", "3.11.12"),
-                mocker.call("process.runtime.name", "foo-name"),
-                mocker.call("process.runtime.description", "foo-runtime"),
-                mocker.call("process.executable.path", "/foo/path"),
-                mocker.call("APM.Version", "0.0.0"),
-                mocker.call("APM.Extension.Version", "1.1.1"),
-                mocker.call("foo-fw", "bar-version")
-            ]
-        )
-        mock_extension.Reporter.sendStatus.assert_called_once()
+        mock_extension.Reporter.sendStatus.assert_called_once_with(mock_event)
+        mock_log_info.assert_called_once()


### PR DESCRIPTION
Splits the creation vs report of the c-lib Reporter init event (outside lambda, all at startup). Also logs at `info` level the resulting send status of `True` or `False`. Most of the changes are unit tests from renaming a method.