### PR TITLE
NH-75964 Add lambda production publish workflow

### DIFF
--- a/.github/workflows/build_publish_lambda_layer.yaml
+++ b/.github/workflows/build_publish_lambda_layer.yaml
@@ -8,12 +8,25 @@ name: Publish APM Python lambda layer
 
 on:
   workflow_dispatch:
-
+    inputs:
+      publish-dest:
+        required: true
+        description: 'Publish destination, one of: staging, production'
+        type: choice
+        default: 'staging'
+        options:
+        - staging
+        - production
+  
 jobs:
   build_publish_layer_x86_64:
     uses: ./.github/workflows/build_publish_lambda_layer_x86_64.yaml
+    with:
+      publish-dest: ${{ inputs.publish-dest }}
     secrets: inherit
 
   build_publish_layer_aarch64:
     uses: ./.github/workflows/build_publish_lambda_layer_aarch64.yaml
+    with:
+      publish-dest: ${{ inputs.publish-dest }}
     secrets: inherit

--- a/.github/workflows/build_publish_lambda_layer_aarch64.yaml
+++ b/.github/workflows/build_publish_lambda_layer_aarch64.yaml
@@ -4,10 +4,15 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-name: Publish APM Python lambda layer for aarch64
+name: "Workflow call: Publish APM Python lambda layer for aarch64"
 
 on:
   workflow_call:
+    inputs:
+      publish-dest:
+        description: 'Publish destination, one of: staging, production'
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -51,6 +56,11 @@ jobs:
       SW_APM_VERSION: ${{ steps.save-apm-python-version.outputs.SW_APM_VERSION }}
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+      with:
+        repository: tammy-baylis-swi/opentelemetry-python-contrib
+        ref: build-lambda-handler-exceptions
+        path: contrib-custom
     - uses: ./.github/actions/package_lambda_solarwinds_apm_aarch64
     - name: Save APM Python Version for naming
       id: save-apm-python-version
@@ -95,4 +105,5 @@ jobs:
       component-version: ${{ needs.build_layer_aarch64.outputs.SW_APM_VERSION }}
       architecture: arm64
       runtimes: "python3.8 python3.9 python3.10 python3.11"
+      publish-dest: ${{ inputs.publish-dest }}
     secrets: inherit

--- a/.github/workflows/build_publish_lambda_layer_x86_64.yaml
+++ b/.github/workflows/build_publish_lambda_layer_x86_64.yaml
@@ -4,10 +4,15 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-name: Publish APM Python lambda layer for x86_64
+name: "Workflow call: Publish APM Python lambda layer for x86_64"
 
 on:
   workflow_call:
+    inputs:
+      publish-dest:
+        description: 'Publish destination, one of: staging, production'
+        required: true
+        type: string
 
 jobs:
   build_layer_x86_64:
@@ -16,6 +21,11 @@ jobs:
       SW_APM_VERSION: ${{ steps.save-apm-python-version.outputs.SW_APM_VERSION }}
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+      with:
+        repository: tammy-baylis-swi/opentelemetry-python-contrib
+        ref: build-lambda-handler-exceptions
+        path: contrib-custom
     - uses: ./.github/actions/package_lambda_solarwinds_apm_x86_64
     - name: Save APM Python Version for naming
       id: save-apm-python-version
@@ -35,4 +45,5 @@ jobs:
       component-version: ${{ needs.build_layer_x86_64.outputs.SW_APM_VERSION }}
       architecture: x86_64
       runtimes: "python3.7 python3.8 python3.9 python3.10 python3.11"
+      publish-dest: ${{ inputs.publish-dest }}
     secrets: inherit

--- a/.github/workflows/publish_lambda_layer.yaml
+++ b/.github/workflows/publish_lambda_layer.yaml
@@ -4,7 +4,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-name: Publish Lambda Layer to staging
+name: "Workflow call: Publish Lambda Layer"
 
 on:
   workflow_call:
@@ -23,6 +23,10 @@ on:
         type: string
       runtimes:
         description: 'Space-delimited list of compatible runtimes'
+        required: true
+        type: string
+      publish-dest:
+        description: 'Publish destination, one of: staging, production'
         required: true
         type: string
 
@@ -79,9 +83,16 @@ jobs:
         with:
           name: ${{ inputs.artifact-name }}
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - if: ${{ inputs.publish-dest == 'staging' }}
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.LAMBDA_PUBLISHER_ARN }}
+          role-to-assume: ${{ secrets.LAMBDA_PUBLISHER_ARN_STAGING }}
+          aws-region: ${{ matrix.aws_region }}
+
+      - if: ${{ inputs.publish-dest == 'production' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.LAMBDA_PUBLISHER_ARN_PROD }}
           aws-region: ${{ matrix.aws_region }}
 
       - name: Publish Lambda Layer


### PR DESCRIPTION
Adds lambda production publish workflow by adding a new `publish-dest` input param to the existing workflow for staging. The input determines whether we use the existing staging publish role or the new role for prod. I've also renamed the reused workflows to make it a bit more clear which one is for dispatch: `Publish APM Python lambda layer`.

Tested [production publish](https://github.com/solarwinds/apm-python/actions/runs/8381326109) resulting in layers ending in `1_6_0_2:1`. Tested [staging publish](https://github.com/solarwinds/apm-python/actions/runs/8381120357) resulting in layers ending in `1_6_0_2:2`. I did these on [another PR](https://github.com/solarwinds/apm-python/pull/340) for the custom build branch and this PR ports over those changes for `main`.