### PR TITLE
NH-76217 Fix init event logging

### DIFF
--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -91,6 +91,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         apm_config = SolarWindsApmConfig()
         oboe_api = apm_config.oboe_api
 
+        # Reporter may be no-op e.g. disabled, lambda
         reporter = self._initialize_solarwinds_reporter(apm_config)
         self._configure_otel_components(
             apm_txname_manager,
@@ -99,6 +100,11 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             reporter,
             oboe_api,
         )
+
+        if apm_config.is_lambda:
+            logger.debug("No init event in lambda")
+            return
+
         # Report reporter init status event after everything is done.
         init_event = self._create_init_event(reporter, apm_config)
         if init_event:

--- a/tests/unit/test_configurator/test_configurator_configure.py
+++ b/tests/unit/test_configurator/test_configurator_configure.py
@@ -7,24 +7,63 @@
 from solarwinds_apm import configurator
 
 class TestConfiguratorConfigure:
-    def test_configurator_configure_init_success(
+    def test_configurator_configure_init_lambda(
         self,
         mocker,
         mock_txn_name_manager_init,
         mock_fwkv_manager_init,
-        mock_apmconfig_enabled,
         mock_init_sw_reporter,
         mock_config_otel_components,
         mock_create_init,
         mock_report_init,
     ):
+        mock_apmconfig = mocker.Mock(
+            **{
+                "is_lambda": True,
+            }
+        )
+        apmconfig_init = mocker.patch(
+            "solarwinds_apm.configurator.SolarWindsApmConfig",
+            return_value=mock_apmconfig,
+        )
+
         test_configurator = configurator.SolarWindsConfigurator()
         test_configurator._configure()
 
         mock_txn_name_manager_init.assert_called_once()
         mock_fwkv_manager_init.assert_called_once()
-        mock_apmconfig_enabled.assert_called_once()
+        apmconfig_init.assert_called_once()
+        mock_init_sw_reporter.assert_called_once()
+        mock_config_otel_components.assert_called_once()
+        mock_create_init.assert_not_called()
+        mock_report_init.assert_not_called()
 
+    def test_configurator_configure_init_success(
+        self,
+        mocker,
+        mock_txn_name_manager_init,
+        mock_fwkv_manager_init,
+        mock_init_sw_reporter,
+        mock_config_otel_components,
+        mock_create_init,
+        mock_report_init,
+    ):
+        mock_apmconfig = mocker.Mock(
+            **{
+                "is_lambda": False,
+            }
+        )
+        apmconfig_init = mocker.patch(
+            "solarwinds_apm.configurator.SolarWindsApmConfig",
+            return_value=mock_apmconfig,
+        )
+
+        test_configurator = configurator.SolarWindsConfigurator()
+        test_configurator._configure()
+
+        mock_txn_name_manager_init.assert_called_once()
+        mock_fwkv_manager_init.assert_called_once()
+        apmconfig_init.assert_called_once()
         mock_init_sw_reporter.assert_called_once()
         mock_config_otel_components.assert_called_once()
         mock_create_init.assert_called_once()
@@ -35,12 +74,21 @@ class TestConfiguratorConfigure:
         mocker,
         mock_txn_name_manager_init,
         mock_fwkv_manager_init,
-        mock_apmconfig_enabled,
         mock_init_sw_reporter,
         mock_config_otel_components,
         mock_create_init_fail,
         mock_report_init,
     ):
+        mock_apmconfig = mocker.Mock(
+            **{
+                "is_lambda": False,
+            }
+        )
+        apmconfig_init = mocker.patch(
+            "solarwinds_apm.configurator.SolarWindsApmConfig",
+            return_value=mock_apmconfig,
+        )
+
         mock_log_error = mocker.Mock()
         mock_logger = mocker.patch(
             "solarwinds_apm.configurator.logger"
@@ -56,8 +104,7 @@ class TestConfiguratorConfigure:
 
         mock_txn_name_manager_init.assert_called_once()
         mock_fwkv_manager_init.assert_called_once()
-        mock_apmconfig_enabled.assert_called_once()
-
+        apmconfig_init.assert_called_once()
         mock_init_sw_reporter.assert_called_once()
         mock_config_otel_components.assert_called_once()
         mock_create_init_fail.assert_called_once()


### PR DESCRIPTION
Stops logging this all the time in lambda:

> `2024-03-25 20:17:11,179 [ solarwinds_apm.configurator ERROR p#18.548324724752] There was an issue with generating the reporter init message.`

Instead, if debug level high, we see this instead:

> `2024-03-26 00:38:38,503 [ solarwinds_apm.configurator DEBUG    p#16.140177044481856] No init event in lambda`

See ticket comment for testing. The unit tests weren't set up properly so I had to make them over too.