### PR TITLE
NH-77561 Remove early dev debug line

### DIFF
--- a/solarwinds_apm/exporter.py
+++ b/solarwinds_apm/exporter.py
@@ -87,7 +87,7 @@ class SolarWindsSpanExporter(SpanExporter):
                 if span.parent.is_remote:
                     self._add_info_transaction_name(span, evt)
             else:
-                # In OpenTelemrtry, there are no events with individual IDs, but only a span ID
+                # In OpenTelemetry, there are no events with individual IDs, but only a span ID
                 # and trace ID. Thus, the entry event needs to be generated such that it has the
                 # same op ID as the span ID of the OTel span.
                 logger.debug("Start a new trace %s", md.toString())

--- a/solarwinds_apm/w3c_transformer.py
+++ b/solarwinds_apm/w3c_transformer.py
@@ -6,14 +6,10 @@
 
 """Provides functionality to transform OpenTelemetry Data to SolarWinds Observability data."""
 
-import logging
-
 from opentelemetry.sdk.trace import SpanContext
 from opentelemetry.trace.span import TraceState
 
 from solarwinds_apm.apm_constants import INTL_SWO_X_OPTIONS_RESPONSE_KEY
-
-logger = logging.getLogger(__name__)
 
 
 class W3CTransformer:
@@ -42,7 +38,7 @@ class W3CTransformer:
 
     @classmethod
     def traceparent_from_context(cls, span_context: SpanContext) -> str:
-        """Generates a liboboe W3C compatible trace_context from
+        """Maps a liboboe W3C compatible trace_context from
         provided OTel span context."""
         template = "-".join(
             [
@@ -56,11 +52,6 @@ class W3CTransformer:
             span_context.trace_id,
             span_context.span_id,
             span_context.trace_flags,
-        )
-        logger.debug(
-            "Generated traceparent %s from %s",
-            xtr,
-            span_context,
         )
         return xtr
 


### PR DESCRIPTION
Removes a debug line from early development of APM Python that I would argue is no longer useful and is misleading because it's logged twice by custom exporter and response propagator for one span. Example:

> `2024-04-30 16:18:18,592 [ solarwinds_apm.w3c_transformer DEBUG    p#1.281472921751584] Generated traceparent 00-b9675c6c50a9331392aad6fa3f6a3512-32c0d62f1ef75148-01 from SpanContext(trace_id=0xb9675c6c50a9331392aad6fa3f6a3512, span_id=0x32c0d62f1ef75148, trace_flags=0x01, trace_state=[], is_remote=False)`

Without that, we can still debug with these logs:
1. Sampling decision is logged with `Got liboboe decision outputs`.
2. trace_id/span_id for APM-proto export is logged with `Start a new trace` or `Continue trace from`.
3. If it's an instrumented http service, use `curl -v` and check `x-trace` response header.
