### PR TITLE
NH-80234 Sampler inits with Reporter

### DIFF
--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -123,7 +123,11 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         oboe_api: "OboeAPI",
     ) -> None:
         """Configure OTel sampler, exporter, propagator, response propagator"""
-        self._configure_sampler(apm_config, oboe_api)
+        self._configure_sampler(
+            apm_config,
+            reporter,
+            oboe_api,
+        )
         if apm_config.agent_enabled:
             # set MeterProvider first via metrics_exporter config
             self._configure_metrics_exporter(apm_config)
@@ -165,6 +169,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
     def _configure_sampler(
         self,
         apm_config: SolarWindsApmConfig,
+        reporter: "Reporter",
         oboe_api: "OboeAPI",
     ) -> None:
         """Always configure SolarWinds OTel sampler, or none if disabled"""
@@ -177,7 +182,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                 "solarwinds_apm",
                 "opentelemetry_traces_sampler",
                 self._DEFAULT_SW_TRACES_SAMPLER,
-            )(apm_config, oboe_api)
+            )(apm_config, reporter, oboe_api)
         except Exception as ex:
             logger.exception("A exception was raised: %s", ex)
             logger.exception(

--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -41,7 +41,7 @@ from solarwinds_apm.w3c_transformer import W3CTransformer
 
 if TYPE_CHECKING:
     from solarwinds_apm.apm_config import SolarWindsApmConfig
-    from solarwinds_apm.extension.oboe import OboeAPI
+    from solarwinds_apm.extension.oboe import OboeAPI, Reporter
 
 logger = logging.getLogger(__name__)
 
@@ -68,9 +68,11 @@ class _SwSampler(Sampler):
     def __init__(
         self,
         apm_config: "SolarWindsApmConfig",
+        reporter: "Reporter",
         oboe_api: "OboeAPI",
     ):
         self.apm_config = apm_config
+        self.reporter = reporter
         # SW_APM_TRANSACTION_NAME and AWS_LAMBDA_FUNCTION_NAME
         self.env_transaction_name = apm_config.get("transaction_name")
         self.lambda_function_name = apm_config.lambda_function_name
@@ -622,6 +624,7 @@ class ParentBasedSwSampler(ParentBased):
     def __init__(
         self,
         apm_config: "SolarWindsApmConfig",
+        reporter: "Reporter",
         oboe_api: "OboeAPI",
     ):
         """
@@ -630,9 +633,11 @@ class ParentBasedSwSampler(ParentBased):
         Uses OTEL defaults if parent span is_local.
         """
         super().__init__(
-            root=_SwSampler(apm_config, oboe_api),
-            remote_parent_sampled=_SwSampler(apm_config, oboe_api),
-            remote_parent_not_sampled=_SwSampler(apm_config, oboe_api),
+            root=_SwSampler(apm_config, reporter, oboe_api),
+            remote_parent_sampled=_SwSampler(apm_config, reporter, oboe_api),
+            remote_parent_not_sampled=_SwSampler(
+                apm_config, reporter, oboe_api
+            ),
         )
 
     # should_sample defined by ParentBased

--- a/tests/integration/test_base_sw_headers_attrs.py
+++ b/tests/integration/test_base_sw_headers_attrs.py
@@ -96,7 +96,7 @@ class TestBaseSwHeadersAndAttributes(TestBase):
         # except use TestBase InMemorySpanExporter
         apm_config = SolarWindsApmConfig()
         configurator = SolarWindsConfigurator()
-        configurator._initialize_solarwinds_reporter(apm_config)
+        reporter = configurator._initialize_solarwinds_reporter(apm_config)
         configurator._configure_propagator()
         configurator._configure_response_propagator()
         # This is done because set_tracer_provider cannot override the
@@ -106,7 +106,7 @@ class TestBaseSwHeadersAndAttributes(TestBase):
             "solarwinds_apm",
             "opentelemetry_traces_sampler",
             configurator._DEFAULT_SW_TRACES_SAMPLER
-        )(apm_config, OboeAPI())
+        )(apm_config, reporter, OboeAPI())
         self.tracer_provider = TracerProvider(sampler=sampler)
         # Set InMemorySpanExporter for testing
         # We do NOT use SolarWindsSpanExporter

--- a/tests/unit/test_configurator/test_configurator_sampler.py
+++ b/tests/unit/test_configurator/test_configurator_sampler.py
@@ -29,6 +29,7 @@ class TestConfiguratorSampler:
         test_configurator = configurator.SolarWindsConfigurator()
         test_configurator._configure_sampler(
             mock_apmconfig_disabled,
+            mocker.Mock(),
             mock_oboe_api_obj,
         )
 
@@ -64,6 +65,7 @@ class TestConfiguratorSampler:
         with pytest.raises(Exception):
             test_configurator._configure_sampler(
                 mock_apmconfig_enabled,
+                mocker.Mock(),
                 mock_oboe_api_obj,
             )
 
@@ -99,6 +101,7 @@ class TestConfiguratorSampler:
         test_configurator = configurator.SolarWindsConfigurator()
         test_configurator._configure_sampler(
             mock_apmconfig_enabled,
+            mocker.Mock(),
             mock_oboe_api_obj,
         )
 
@@ -164,6 +167,7 @@ class TestConfiguratorSampler:
         test_configurator = configurator.SolarWindsConfigurator()
         test_configurator._configure_sampler(
             mock_apmconfig_enabled,
+            mocker.Mock(),
             mock_oboe_api_obj,
         )
 

--- a/tests/unit/test_sampler/fixtures/sampler.py
+++ b/tests/unit/test_sampler/fixtures/sampler.py
@@ -62,7 +62,7 @@ def fixture_swsampler(mocker):
             "lambda_function_name": "foo-lambda",
         }
     )
-    return _SwSampler(mock_apm_config, mocker.Mock())
+    return _SwSampler(mock_apm_config, mocker.Mock(), mocker.Mock())
 
 @pytest.fixture(name="fixture_swsampler_is_lambda")
 def fixture_swsampler_is_lambda(mocker):
@@ -109,7 +109,7 @@ def fixture_swsampler_is_lambda(mocker):
             "lambda_function_name": "foo-lambda",
         }
     )
-    return _SwSampler(mock_apm_config, mocker.Mock())
+    return _SwSampler(mock_apm_config, mocker.Mock(), mocker.Mock())
 
 
 # Sampler fixtures with Transaction Filters =================
@@ -167,4 +167,4 @@ def fixture_swsampler_txnfilters(mocker):
             "get": mock_get,
         }
     )
-    return _SwSampler(mock_apm_config, mocker.Mock())
+    return _SwSampler(mock_apm_config, mocker.Mock(), mocker.Mock())

--- a/tests/unit/test_sampler/test_sampler.py
+++ b/tests/unit/test_sampler/test_sampler.py
@@ -217,8 +217,9 @@ class Test_SwSampler():
                 "lambda_function_name": "foo-lambda",
             }
         )
+        mock_reporter = mocker.Mock()
         mock_oboe_api = mocker.Mock()
-        sampler = _SwSampler(mock_apm_config, mock_oboe_api)
+        sampler = _SwSampler(mock_apm_config, mock_reporter, mock_oboe_api)
         assert sampler.apm_config == mock_apm_config
         assert sampler.oboe_settings_api == mock_oboe_api
         assert sampler.env_transaction_name == "foo-txn"
@@ -245,6 +246,7 @@ class Test_SwSampler():
                 "getTracingDecision": mock_get_tracing_decision
             }
         )
+        mock_reporter = mocker.Mock()
 
         mock_apm_config.configure_mock(
             **{
@@ -253,7 +255,7 @@ class Test_SwSampler():
                 "is_lambda": True,
             }
         )
-        test_sampler = _SwSampler(mock_apm_config, mock_oboe_api)
+        test_sampler = _SwSampler(mock_apm_config, mock_reporter, mock_oboe_api)
 
         result = test_sampler.calculate_liboboe_decision(
             parent_span_context_invalid,
@@ -721,7 +723,7 @@ class Test_SwSampler():
 
 class TestParentBasedSwSampler():
     def test_init(self, mocker):
-        sampler = ParentBasedSwSampler(mocker.Mock(), mocker.Mock())
+        sampler = ParentBasedSwSampler(mocker.Mock(), mocker.Mock(), mocker.Mock())
         assert type(sampler._root) == _SwSampler
         assert type(sampler._remote_parent_sampled) == _SwSampler
         assert type(sampler._remote_parent_not_sampled) == _SwSampler

--- a/tests/unit/test_sampler/test_sampler_calculate_attributes.py
+++ b/tests/unit/test_sampler/test_sampler_calculate_attributes.py
@@ -246,8 +246,9 @@ class Test_SwSampler_calculate_attributes():
     """
     def test_init(self, mocker):
         mock_apm_config = mocker.Mock()
+        mock_reporter = mocker.Mock()
         mock_oboe_api = mocker.Mock()
-        sampler = _SwSampler(mock_apm_config, mock_oboe_api)
+        sampler = _SwSampler(mock_apm_config, mock_reporter, mock_oboe_api)
         assert sampler.apm_config == mock_apm_config
         assert sampler.oboe_settings_api == mock_oboe_api
 
@@ -966,8 +967,9 @@ class Test_SwSampler_is_lambda_calculate_attributes():
     """
     def test_init(self, mocker):
         mock_apm_config = mocker.Mock()
+        mock_reporter = mocker.Mock()
         mock_oboe_api = mocker.Mock()
-        sampler = _SwSampler(mock_apm_config, mock_oboe_api)
+        sampler = _SwSampler(mock_apm_config, mock_reporter, mock_oboe_api)
         assert sampler.apm_config == mock_apm_config
         assert sampler.oboe_settings_api == mock_oboe_api
 

--- a/tests/unit/test_sampler/test_sampler_calculate_otlp_tname.py
+++ b/tests/unit/test_sampler/test_sampler_calculate_otlp_tname.py
@@ -29,8 +29,9 @@ class Test_SwSampler_calculate_otlp_tname():
                 "lambda_function_name": "foo-lambda",
             }
         )
+        mock_reporter = mocker.Mock()
         mock_oboe_api = mocker.Mock()
-        sampler = _SwSampler(mock_apm_config, mock_oboe_api)
+        sampler = _SwSampler(mock_apm_config, mock_reporter, mock_oboe_api)
         assert sampler.calculate_otlp_transaction_name("foo-span") == "foo-txn"
 
     def test_calculate_otlp_name_env_var_truncated(self, mocker):
@@ -51,8 +52,9 @@ class Test_SwSampler_calculate_otlp_tname():
                 "lambda_function_name": "foo-lambda",
             }
         )
+        mock_reporter = mocker.Mock()
         mock_oboe_api = mocker.Mock()
-        sampler = _SwSampler(mock_apm_config, mock_oboe_api)
+        sampler = _SwSampler(mock_apm_config, mock_reporter, mock_oboe_api)
         assert sampler.calculate_otlp_transaction_name("foo-span") == "foo-txn-ffoooofofooooooofooofooooofofofofoooooofoooooooooffoffooooooffffofooooofffooooooofoooooffoofofoooooofffofooofoffoooofooofoooooooooooooofooffoooofofooofoooofoofooffooooofoofooooofoooooffoofffoffoooooofoooofoooffooffooofofooooooffffooofoooooofoooooo"
 
     def test_calculate_otlp_name_lambda(self, mocker):
@@ -70,8 +72,9 @@ class Test_SwSampler_calculate_otlp_tname():
                 "lambda_function_name": "foo-lambda",
             }
         )
+        mock_reporter = mocker.Mock()
         mock_oboe_api = mocker.Mock()
-        sampler = _SwSampler(mock_apm_config, mock_oboe_api)
+        sampler = _SwSampler(mock_apm_config, mock_reporter, mock_oboe_api)
         assert sampler.calculate_otlp_transaction_name("foo-span") == "foo-lambda"
 
     def test_calculate_otlp_name_lambda_truncated(self, mocker):
@@ -89,8 +92,9 @@ class Test_SwSampler_calculate_otlp_tname():
                 "lambda_function_name": "foo-lambda-ffoooofofooooooofooofooooofofofofoooooofoooooooooffoffooooooffffofooooofffooooooofoooooffoofofoooooofffofooofoffoooofooofoooooooooooooofooffoooofofooofoooofoofooffooooofoofooooofoooooffoofffoffoooooofoooofoooffooffooofofooooooffffooofoooooofoooooofooofoooofoo",
             }
         )
+        mock_reporter = mocker.Mock()
         mock_oboe_api = mocker.Mock()
-        sampler = _SwSampler(mock_apm_config, mock_oboe_api)
+        sampler = _SwSampler(mock_apm_config, mock_reporter, mock_oboe_api)
         assert sampler.calculate_otlp_transaction_name("foo-span") == "foo-lambda-ffoooofofooooooofooofooooofofofofoooooofoooooooooffoffooooooffffofooooofffooooooofoooooffoofofoooooofffofooofoffoooofooofoooooooooooooofooffoooofofooofoooofoofooffooooofoofooooofoooooffoofffoffoooooofoooofoooffooffooofofooooooffffooofoooooofooo"
 
     def test_calculate_otlp_name_span_name(self, mocker):
@@ -108,8 +112,9 @@ class Test_SwSampler_calculate_otlp_tname():
                 "lambda_function_name": None,
             }
         )
+        mock_reporter = mocker.Mock()
         mock_oboe_api = mocker.Mock()
-        sampler = _SwSampler(mock_apm_config, mock_oboe_api)
+        sampler = _SwSampler(mock_apm_config, mock_reporter, mock_oboe_api)
         assert sampler.calculate_otlp_transaction_name("foo-span") == "foo-span"
 
     def test_calculate_otlp_name_span_name_truncated(self, mocker):
@@ -127,8 +132,9 @@ class Test_SwSampler_calculate_otlp_tname():
                 "lambda_function_name": None,
             }
         )
+        mock_reporter = mocker.Mock()
         mock_oboe_api = mocker.Mock()
-        sampler = _SwSampler(mock_apm_config, mock_oboe_api)
+        sampler = _SwSampler(mock_apm_config, mock_reporter, mock_oboe_api)
         assert sampler.calculate_otlp_transaction_name(
             "foo-span-ffoooofofooooooofooofooooofofofofoooooofoooooooooffoffooooooffffofooooofffooooooofoooooffoofofoooooofffofooofoffoooofooofoooooooooooooofooffoooofofooofoooofoofooffooooofoofooooofoooooffoofffoffoooooofoooofoooffooffooofofooooooffffooofoooooofoooooofooofoooofoo"
         ) == "foo-span-ffoooofofooooooofooofooooofofofofoooooofoooooooooffoffooooooffffofooooofffooooooofoooooffoofofoooooofffofooofoffoooofooofoooooooooooooofooffoooofofooofoooofoofooffooooofoofooooofoooooffoofffoffoooooofoooofoooffooffooofofooooooffffooofoooooofooooo"
@@ -148,6 +154,7 @@ class Test_SwSampler_calculate_otlp_tname():
                 "lambda_function_name": None,
             }
         )
+        mock_reporter = mocker.Mock()
         mock_oboe_api = mocker.Mock()
-        sampler = _SwSampler(mock_apm_config, mock_oboe_api)
+        sampler = _SwSampler(mock_apm_config, mock_reporter, mock_oboe_api)
         assert sampler.calculate_otlp_transaction_name("") == "unknown"


### PR DESCRIPTION
Sampler inits with Reporter to keep it alive after Configuration, else it dies if `solarwinds_exporter` not set and sampling don't work.