### PR TITLE
NH-79315 Update log warning to error if Python 3.7

### DIFF
--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -51,14 +51,6 @@ class SolarWindsDistro(BaseDistro):
         python_vers = platform.python_version()
         logger.info("Python %s", python_vers)
 
-        # https://devguide.python.org/versions/
-        if sys.version_info.major == 3 and sys.version_info.minor < 8:
-            logger.warning(
-                "Deprecation: Python %s is at end-of-life and support "
-                "by APM Python will be dropped in a future release. Please upgrade.",
-                python_vers,
-            )
-
     def _log_runtime(self):
         """Logs APM Python runtime info (high debug level)"""
         logger.info("SolarWinds APM Python %s", apm_version)

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -51,6 +51,14 @@ class SolarWindsDistro(BaseDistro):
         python_vers = platform.python_version()
         logger.info("Python %s", python_vers)
 
+        # https://devguide.python.org/versions/
+        if sys.version_info.major == 3 and sys.version_info.minor < 8:
+            logger.error(
+                "Obsolete: Python %s is at end-of-life and support "
+                "by APM Python and OpenTelemetry has been dropped. Please upgrade.",
+                python_vers,
+            )
+
     def _log_runtime(self):
         """Logs APM Python runtime info (high debug level)"""
         logger.info("SolarWinds APM Python %s", apm_version)

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -80,18 +80,18 @@ class TestDistro:
             "solarwinds_apm.distro.logger"
         )
         mock_info = mocker.Mock()
-        mock_warning = mocker.Mock()
+        mock_error = mocker.Mock()
         mock_logger.configure_mock(
             **{
                 "info": mock_info,
-                "warning": mock_warning,
+                "error": mock_error,
             }
         )
 
         distro.SolarWindsDistro()._log_python_runtime()
         mock_py_vers.assert_called_once()
         mock_info.assert_called_once()
-        mock_warning.assert_called_once()
+        mock_error.assert_called_once()
 
     def test__log_runtime(self, mocker):
         mocker.patch(


### PR DESCRIPTION
Updates the startup case for logging a warning to logging an error if using Python 3.7, which neither APM Python nor OTel Python supports now.

APM Python will still continue to (try to) configure Otel and the SDK will run.

Is this too strong, or not strong enough?