### PR TITLE
NH-81797 Add get_url_attrs from new or old semconv

### DIFF
--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -35,7 +35,7 @@ from solarwinds_apm.apm_constants import (
     INTL_SWO_X_OPTIONS_KEY,
     INTL_SWO_X_OPTIONS_RESPONSE_KEY,
 )
-from solarwinds_apm.semconv.trace import get_new_or_old_url_attrs
+from solarwinds_apm.semconv.trace import get_url_attrs
 from solarwinds_apm.traceoptions import XTraceOptions
 from solarwinds_apm.w3c_transformer import W3CTransformer
 
@@ -101,7 +101,7 @@ class _SwSampler(Sampler):
         # Upstream OTel instrumentation libraries are individually updating
         # to implement support of HTTP semconv opt-in, so APM Python checks both
         # https://github.com/open-telemetry/opentelemetry-python-contrib/issues/936
-        scheme, host, port, target = get_new_or_old_url_attrs(attributes)
+        scheme, host, port, target = get_url_attrs(attributes)
 
         if scheme and host and target and port:
             url = f"{scheme}://{host}:{port}{target}"

--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -21,7 +21,6 @@ from opentelemetry.sdk.trace.sampling import (
     Sampler,
     SamplingResult,
 )
-from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import Link, SpanKind, get_current_span
 from opentelemetry.trace.span import SpanContext, TraceState
 from opentelemetry.util.types import Attributes
@@ -36,6 +35,7 @@ from solarwinds_apm.apm_constants import (
     INTL_SWO_X_OPTIONS_KEY,
     INTL_SWO_X_OPTIONS_RESPONSE_KEY,
 )
+from solarwinds_apm.semconv.trace import get_new_or_old_url_attrs
 from solarwinds_apm.traceoptions import XTraceOptions
 from solarwinds_apm.w3c_transformer import W3CTransformer
 
@@ -93,17 +93,16 @@ class _SwSampler(Sampler):
         attributes: Attributes = None,
     ) -> str:
         """Construct url"""
-        # TODO (NH-34752) Check http scheme, http target, net host name `attributes`
-        #   availability after OTel instrumentation library updates released
-        #   https://github.com/open-telemetry/opentelemetry-python-contrib/issues/936
         if not attributes:
             return ""
 
         url = ""
-        scheme = attributes.get(SpanAttributes.HTTP_SCHEME)
-        host = attributes.get(SpanAttributes.NET_HOST_NAME)
-        port = attributes.get(SpanAttributes.NET_HOST_PORT)
-        target = attributes.get(SpanAttributes.HTTP_TARGET)
+
+        # Upstream OTel instrumentation libraries are individually updating
+        # to implement support of HTTP semconv opt-in, so APM Python checks both
+        # https://github.com/open-telemetry/opentelemetry-python-contrib/issues/936
+        scheme, host, port, target = get_new_or_old_url_attrs(attributes)
+
         if scheme and host and target and port:
             url = f"{scheme}://{host}:{port}{target}"
             logger.debug("Constructed url for filtering: %s", url)

--- a/solarwinds_apm/semconv/trace/__init__.py
+++ b/solarwinds_apm/semconv/trace/__init__.py
@@ -13,7 +13,7 @@ from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.util.types import Attributes
 
 
-def get_new_or_old_url_attrs(
+def get_url_attrs(
     attributes: Attributes = None,
 ) -> (Any, Any, Any, Any):
     """Returns URL scheme, host, target, port from span attributes. Order of precedence is new semconv > old semconv > none"""

--- a/solarwinds_apm/semconv/trace/__init__.py
+++ b/solarwinds_apm/semconv/trace/__init__.py
@@ -1,0 +1,43 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+"""Helpers to handle trace from upstream instrumentors conforming to new or old semantic conventions
+"""
+
+from typing import Any
+
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.util.types import Attributes
+
+
+def get_new_or_old_url_attrs(
+    attributes: Attributes = None,
+) -> (Any, Any, Any, Any):
+    """Returns URL scheme, host, target, port from span attributes. Order of precedence is new semconv > old semconv > none"""
+    # Upstream OTel instrumentation libraries are individually updating
+    # to implement support of HTTP semconv opt-in, so APM Python checks both
+    # https://github.com/open-telemetry/opentelemetry-python-contrib/issues/936
+
+    scheme = attributes.get(SpanAttributes.URL_SCHEME)
+    if not scheme:
+        scheme = attributes.get(SpanAttributes.HTTP_SCHEME)
+
+    host = attributes.get(SpanAttributes.SERVER_ADDRESS)
+    if not host:
+        host = attributes.get(SpanAttributes.NET_HOST_NAME)
+
+    port = attributes.get(SpanAttributes.SERVER_PORT)
+    if not port:
+        port = attributes.get(SpanAttributes.NET_HOST_PORT)
+
+    # If new, it could be either URL_PATH or URL_QUERY
+    target = attributes.get(SpanAttributes.URL_PATH)
+    if not target:
+        target = attributes.get(SpanAttributes.URL_QUERY)
+    if not target:
+        target = attributes.get(SpanAttributes.HTTP_TARGET)
+
+    return scheme, host, port, target

--- a/tests/unit/test_sampler/test_sampler_calculate_tracing_mode.py
+++ b/tests/unit/test_sampler/test_sampler_calculate_tracing_mode.py
@@ -36,7 +36,7 @@ class Test_SwSampler_construct_url():
         assert fixture_swsampler.construct_url({"net.host.port": "bar"}) == ""
         assert fixture_swsampler.construct_url({"http.target": "bar"}) == ""
 
-    def test_construct_url_all_attrs(
+    def test_construct_url_all_attrs_old(
         self,
         fixture_swsampler,
     ):
@@ -49,7 +49,7 @@ class Test_SwSampler_construct_url():
             }
         ) == "foo://bar:baz/qux"
 
-    def test_construct_url_all_attrs_except_port(
+    def test_construct_url_all_attrs_old_except_port(
         self,
         fixture_swsampler,
     ):
@@ -61,6 +61,55 @@ class Test_SwSampler_construct_url():
             }
         ) == "foo://bar/qux"
 
+    def test_construct_url_all_attrs_new_from_path(
+        self,
+        fixture_swsampler,
+    ):
+        assert fixture_swsampler.construct_url(
+            {
+                "url.scheme": "foo",
+                "server.address": "bar",
+                "server.port": "baz",
+                "url.path": "/qux"
+            }
+        ) == "foo://bar:baz/qux"
+
+    def test_construct_url_all_attrs_new_from_query(
+        self,
+        fixture_swsampler,
+    ):
+        assert fixture_swsampler.construct_url(
+            {
+                "url.scheme": "foo",
+                "server.address": "bar",
+                "server.port": "baz",
+                "url.query": "/qux"
+            }
+        ) == "foo://bar:baz/qux"
+
+    def test_construct_url_all_attrs_new_from_path_except_port(
+        self,
+        fixture_swsampler,
+    ):
+        assert fixture_swsampler.construct_url(
+            {
+                "url.scheme": "foo",
+                "server.address": "bar",
+                "url.path": "/qux"
+            }
+        ) == "foo://bar/qux"
+
+    def test_construct_url_all_attrs_new_from_query_except_port(
+        self,
+        fixture_swsampler,
+    ):
+        assert fixture_swsampler.construct_url(
+            {
+                "url.scheme": "foo",
+                "server.address": "bar",
+                "url.query": "/qux"
+            }
+        ) == "foo://bar/qux"
 
 class Test_SwSampler_calculate_tracing_mode():
     def test_calculate_tracing_mode_no_filters(

--- a/tests/unit/test_semconv/__init__.py
+++ b/tests/unit/test_semconv/__init__.py
@@ -1,0 +1,5 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/tests/unit/test_semconv/test_trace.py
+++ b/tests/unit/test_semconv/test_trace.py
@@ -1,0 +1,72 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+from solarwinds_apm.semconv.trace import get_url_attrs
+
+class Test_semconv_trace:
+    def test_get_url_attrs__new_path(self):
+        attributes = {
+            "url.scheme": "foo",
+            "server.address": "bar",
+            "server.port": "baz",
+            "url.path": "/qux"
+        }
+        scheme, host, port, target = get_url_attrs(attributes)
+        assert scheme == "foo"
+        assert host == "bar"
+        assert port == "baz"
+        assert target == "/qux"
+
+    def test_get_url_attrs__new_query(self):
+        attributes = {
+            "url.scheme": "foo",
+            "server.address": "bar",
+            "server.port": "baz",
+            "url.query": "/qux"
+        }
+        scheme, host, port, target = get_url_attrs(attributes)
+        assert scheme == "foo"
+        assert host == "bar"
+        assert port == "baz"
+        assert target == "/qux"
+
+    def test_get_url_attrs__old(self):
+        attributes = {
+            "http.scheme": "foo",
+            "net.host.name": "bar",
+            "net.host.port": "baz",
+            "http.target": "/qux"
+        }
+        scheme, host, port, target = get_url_attrs(attributes)
+        assert scheme == "foo"
+        assert host == "bar"
+        assert port == "baz"
+        assert target == "/qux"
+
+    def test_get_url_attrs__neither(self):
+        attributes = {}
+        scheme, host, port, target = get_url_attrs(attributes)
+        assert scheme == None
+        assert host == None
+        assert port == None
+        assert target == None
+
+    def test_get_url_attrs__prefer_new(self):
+        attributes = {
+            "url.scheme": "foo",
+            "server.address": "bar",
+            "server.port": "baz",
+            "url.path": "/qux",
+            "http.scheme": "OLD",
+            "net.host.name": "OLD",
+            "net.host.port": "OLD",
+            "http.target": "/OLD"
+        }
+        scheme, host, port, target = get_url_attrs(attributes)
+        assert scheme == "foo"
+        assert host == "bar"
+        assert port == "baz"
+        assert target == "/qux"

--- a/tests/unit/test_semconv/test_trace.py
+++ b/tests/unit/test_semconv/test_trace.py
@@ -49,10 +49,10 @@ class Test_semconv_trace:
     def test_get_url_attrs__neither(self):
         attributes = {}
         scheme, host, port, target = get_url_attrs(attributes)
-        assert scheme == None
-        assert host == None
-        assert port == None
-        assert target == None
+        assert scheme is None
+        assert host is None
+        assert port is None
+        assert target is None
 
     def test_get_url_attrs__prefer_new(self):
         attributes = {


### PR DESCRIPTION
Adds new "semconv helper" to collect url-related span attributes by order of precedence: new HTTP semconv > old HTTP semconv > None. This is to continue to support tracing mode per-request, if configured.