### PR TITLE
NH-82784 Fix builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ packages = [
   "solarwinds_apm.certs",
   "solarwinds_apm.extension",
   "solarwinds_apm.extension.bson",
+  "solarwinds_apm.semconv",
+  "solarwinds_apm.semconv.trace",
   "solarwinds_apm.trace",
 ]
 


### PR DESCRIPTION
Fixes builds (testpypi and lambda) that were failing because package wasn't including new internal APM semconv.trace module.