### PR TITLE
NH-82791 Remove deprecated docker-compose `version`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@
 
 # Build development environments (manylinux x86 or aarch, 64-bit)
 # to locally build and publish solarwinds_apm Python APM library
-version: '2.4'
-
 services:
   x86_64:
     image: quay.io/pypa/manylinux_2_28_x86_64

--- a/tests/docker/install/docker-compose.yml
+++ b/tests/docker/install/docker-compose.yml
@@ -4,8 +4,6 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-version: '2.4'
-
 x-command-install-test: &command-install-test
   command: sh _helper_run_install_tests.sh
 


### PR DESCRIPTION
Removes docker-compose `version` key because now warned as obsolete (see [dc spec](https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements)).