### PR TITLE
NH-82238 Don't inject baggage header if empty

### DIFF
--- a/solarwinds_apm/propagator.py
+++ b/solarwinds_apm/propagator.py
@@ -123,7 +123,16 @@ class SolarWindsPropagator(textmap.TextMapPropagator):
             baggage_header = self.remove_custom_naming_baggage_header(
                 baggage_header,
             )
-            setter.set(carrier, self._BAGGAGE_HEADER_NAME, baggage_header)
+            # Re-inject if sanitized baggage non-empty
+            if baggage_header != "":
+                setter.set(
+                    carrier,
+                    self._BAGGAGE_HEADER_NAME,
+                    baggage_header,
+                )
+            # Or, remove baggage from carrier to prevent empty header
+            else:
+                del carrier[self._BAGGAGE_HEADER_NAME]
 
     def remove_custom_naming_baggage_header(
         self,


### PR DESCRIPTION
In SW propagator `inject` method for outgoing requests, do not re-inject `baggage` header if value is empty, i.e. if `"baggage": ""`

I think technically `"baggage": ""` is allowed according to HTTP [RFC 7230 section 3.2](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2) where

> `field-value    = *( field-content / obs-fold )`

and 

> HTTP does not place a predefined limit on the length of each header field or on the length of the header section as a whole

The [W3C Candidate Recommendation for Baggage](https://www.w3.org/TR/baggage/) does not explicitly mention a separate header length requirement.

For the [W3C Recommendation for tracestate](https://www.w3.org/TR/trace-context/#tracestate-header-field-values), it says this, which is not for Baggage but seems like a good guide for not continuing `baggage` propagation if empty:

> Empty and whitespace-only list members are allowed. Vendors MUST accept empty tracestate headers but SHOULD avoid sending them. Empty list members are allowed in tracestate because it is difficult for a vendor to recognize the empty value when multiple tracestate headers are sent. Whitespace characters are allowed for a similar reason, as some vendors automatically inject whitespace after a comma separator, even in the case of an empty header.