### PR TITLE
NH-80452 Add OTLP logs export from lambda

### DIFF
--- a/lambda/solarwinds-apm/wrapper
+++ b/lambda/solarwinds-apm/wrapper
@@ -28,9 +28,12 @@ export PYTHONPATH="$LAMBDA_LAYER_PKGS_DIR:$PYTHONPATH";
 export PYTHONPATH="$LAMBDA_RUNTIME_DIR:$PYTHONPATH";
 
 # Default OTEL_EXPORTER_OTLP_PROTOCOL for APM Python in lambda
-# for all of logs/trace/metrics is HTTP
+# for all of logs/trace/metrics is HTTP through otelcollector
 if [ -z "${OTEL_EXPORTER_OTLP_PROTOCOL}" ]; then
     export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+fi
+if [ -z "${OTEL_EXPORTER_OTLP_LOGS_ENDPOINT}" ]; then
+    export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://0.0.0.0:4318/v1/logs
 fi
 
 # Lambda function is default service name

--- a/lambda/solarwinds-apm/wrapper
+++ b/lambda/solarwinds-apm/wrapper
@@ -28,6 +28,7 @@ export PYTHONPATH="$LAMBDA_LAYER_PKGS_DIR:$PYTHONPATH";
 export PYTHONPATH="$LAMBDA_RUNTIME_DIR:$PYTHONPATH";
 
 # Default OTEL_EXPORTER_OTLP_PROTOCOL for APM Python in lambda
+# for all of logs/trace/metrics is HTTP
 if [ -z "${OTEL_EXPORTER_OTLP_PROTOCOL}" ]; then
     export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 fi

--- a/lambda/solarwinds-apm/wrapper
+++ b/lambda/solarwinds-apm/wrapper
@@ -32,6 +32,7 @@ export PYTHONPATH="$LAMBDA_RUNTIME_DIR:$PYTHONPATH";
 if [ -z "${OTEL_EXPORTER_OTLP_PROTOCOL}" ]; then
     export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 fi
+# Set default for LOGS specifically because of regular default
 if [ -z "${OTEL_EXPORTER_OTLP_LOGS_ENDPOINT}" ]; then
     export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://0.0.0.0:4318/v1/logs
 fi

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -37,10 +37,7 @@ from opentelemetry.propagate import set_global_textmap
 from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk._configuration import _OTelSDKConfigurator
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
-from opentelemetry.sdk._logs.export import (
-    BatchLogRecordProcessor,
-    SimpleLogRecordProcessor,
-)
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.environment_variables import (
     _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
 )
@@ -520,18 +517,11 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                 )
                 raise
 
-            if apm_config.is_lambda:
-                logger.debug(
-                    "Setting logs with SimpleLogRecordProcessor using %s",
-                    exporter_name,
-                )
-                logs_processor = SimpleLogRecordProcessor(exporter)
-            else:
-                logger.debug(
-                    "Setting logs with BatchLogRecordProcessor using %s",
-                    exporter_name,
-                )
-                logs_processor = BatchLogRecordProcessor(exporter)
+            logger.debug(
+                "Setting logs with BatchLogRecordProcessor using %s",
+                exporter_name,
+            )
+            logs_processor = BatchLogRecordProcessor(exporter)
 
             logger_provider.add_log_record_processor(logs_processor)
 

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -90,19 +90,16 @@ class SolarWindsDistro(BaseDistro):
 
         # Set defaults for OTLP logs export by HTTP to SWO
         header_token = self._get_token_from_service_key()
-
         environ.setdefault(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL, "http/protobuf")
+        environ.setdefault(
+            OTEL_LOGS_EXPORTER, _EXPORTER_BY_OTLP_PROTOCOL["http/protobuf"]
+        )
+        environ.setdefault(
+            OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
+            "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs",
+        )
 
-        if SolarWindsApmConfig.calculate_is_lambda():
-            environ.setdefault(
-                OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
-                "http://0.0.0.0:4318/v1/logs",
-            )
-        else:
-            environ.setdefault(
-                OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
-                "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs",
-            )
+        if not SolarWindsApmConfig.calculate_is_lambda():
             if not header_token:
                 logger.debug(
                     "Setting OTLP logging defaults without valid SWO token"
@@ -111,10 +108,6 @@ class SolarWindsDistro(BaseDistro):
                 OTEL_EXPORTER_OTLP_LOGS_HEADERS,
                 f"authorization=Bearer%20{header_token}",
             )
-
-        environ.setdefault(
-            OTEL_LOGS_EXPORTER, _EXPORTER_BY_OTLP_PROTOCOL["http/protobuf"]
-        )
 
         otlp_protocol = environ.get(OTEL_EXPORTER_OTLP_PROTOCOL)
         if otlp_protocol in _EXPORTER_BY_OTLP_PROTOCOL:

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -90,14 +90,7 @@ class SolarWindsDistro(BaseDistro):
 
         # Set defaults for OTLP logs export by HTTP to SWO
         header_token = self._get_token_from_service_key()
-        if not header_token:
-            logger.debug(
-                "Setting OTLP logging defaults without valid SWO token"
-            )
-        environ.setdefault(
-            OTEL_EXPORTER_OTLP_LOGS_HEADERS,
-            f"authorization=Bearer%20{header_token}",
-        )
+
         environ.setdefault(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL, "http/protobuf")
 
         if SolarWindsApmConfig.calculate_is_lambda():
@@ -109,6 +102,14 @@ class SolarWindsDistro(BaseDistro):
             environ.setdefault(
                 OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
                 "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs",
+            )
+            if not header_token:
+                logger.debug(
+                    "Setting OTLP logging defaults without valid SWO token"
+                )
+            environ.setdefault(
+                OTEL_EXPORTER_OTLP_LOGS_HEADERS,
+                f"authorization=Bearer%20{header_token}",
             )
 
         environ.setdefault(

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -89,7 +89,6 @@ class SolarWindsDistro(BaseDistro):
         self._log_runtime()
 
         # Set defaults for OTLP logs export by HTTP to SWO
-        header_token = self._get_token_from_service_key()
         environ.setdefault(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL, "http/protobuf")
         environ.setdefault(
             OTEL_LOGS_EXPORTER, _EXPORTER_BY_OTLP_PROTOCOL["http/protobuf"]
@@ -98,16 +97,15 @@ class SolarWindsDistro(BaseDistro):
             OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
             "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs",
         )
-
-        if not SolarWindsApmConfig.calculate_is_lambda():
-            if not header_token:
-                logger.debug(
-                    "Setting OTLP logging defaults without valid SWO token"
-                )
-            environ.setdefault(
-                OTEL_EXPORTER_OTLP_LOGS_HEADERS,
-                f"authorization=Bearer%20{header_token}",
+        header_token = self._get_token_from_service_key()
+        if not header_token:
+            logger.debug(
+                "Setting OTLP logging defaults without valid SWO token"
             )
+        environ.setdefault(
+            OTEL_EXPORTER_OTLP_LOGS_HEADERS,
+            f"authorization=Bearer%20{header_token}",
+        )
 
         otlp_protocol = environ.get(OTEL_EXPORTER_OTLP_PROTOCOL)
         if otlp_protocol in _EXPORTER_BY_OTLP_PROTOCOL:

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -100,7 +100,12 @@ class SolarWindsDistro(BaseDistro):
         )
         environ.setdefault(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL, "http/protobuf")
 
-        if not SolarWindsApmConfig.calculate_is_lambda():
+        if SolarWindsApmConfig.calculate_is_lambda():
+            environ.setdefault(
+                OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
+                "http://0.0.0.0:4318/v1/logs",
+            )
+        else:
             environ.setdefault(
                 OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
                 "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs",

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -99,10 +99,13 @@ class SolarWindsDistro(BaseDistro):
             f"authorization=Bearer%20{header_token}",
         )
         environ.setdefault(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL, "http/protobuf")
-        environ.setdefault(
-            OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
-            "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs",
-        )
+
+        if not SolarWindsApmConfig.calculate_is_lambda():
+            environ.setdefault(
+                OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
+                "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs",
+            )
+
         environ.setdefault(
             OTEL_LOGS_EXPORTER, _EXPORTER_BY_OTLP_PROTOCOL["http/protobuf"]
         )

--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -96,12 +96,6 @@ def mock_blprocessor(mocker):
         "solarwinds_apm.configurator.BatchLogRecordProcessor",
     )
 
-@pytest.fixture(name="mock_slprocessor")
-def mock_slprocessor(mocker):
-    return mocker.patch(
-        "solarwinds_apm.configurator.SimpleLogRecordProcessor",
-    )
-
 @pytest.fixture(name="mock_tracerprovider")
 def mock_tracerprovider(mocker):
     return mocker.patch(

--- a/tests/unit/test_configurator/test_configurator_logs_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_logs_exporter.py
@@ -45,7 +45,6 @@ class TestConfiguratorLogsExporter:
         mocker,
         mock_apmconfig_enabled,
         mock_blprocessor,
-        mock_slprocessor,
         mock_loggerprovider,
         mock_logginghandler,
     ):
@@ -66,7 +65,6 @@ class TestConfiguratorLogsExporter:
         trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
         mock_loggerprovider.assert_not_called()
         mock_blprocessor.assert_not_called()
-        mock_slprocessor.assert_not_called()
         mock_logginghandler.assert_not_called()
 
     def test_configure_logs_exporter_otel_none_sw_false(
@@ -74,7 +72,6 @@ class TestConfiguratorLogsExporter:
         mocker,
         mock_apmconfig_logs_enabled_false,
         mock_blprocessor,
-        mock_slprocessor,
         mock_loggerprovider,
         mock_logginghandler,
     ):
@@ -95,7 +92,6 @@ class TestConfiguratorLogsExporter:
         trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
         mock_loggerprovider.assert_not_called()
         mock_blprocessor.assert_not_called()
-        mock_slprocessor.assert_not_called()
         mock_logginghandler.assert_not_called()
 
     def test_configure_logs_exporter_otel_true_sw_false(
@@ -103,7 +99,6 @@ class TestConfiguratorLogsExporter:
         mocker,
         mock_apmconfig_logs_enabled_false,
         mock_blprocessor,
-        mock_slprocessor,
         mock_loggerprovider,
         mock_logginghandler,
     ):
@@ -124,7 +119,6 @@ class TestConfiguratorLogsExporter:
         trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
         mock_loggerprovider.assert_not_called()
         mock_blprocessor.assert_not_called()
-        mock_slprocessor.assert_not_called()
         mock_logginghandler.assert_not_called()
 
     def test_configure_logs_exporter_otel_true_sw_none(
@@ -132,7 +126,6 @@ class TestConfiguratorLogsExporter:
         mocker,
         mock_apmconfig_logs_enabled_none,
         mock_blprocessor,
-        mock_slprocessor,
         mock_loggerprovider,
         mock_logginghandler,
     ):
@@ -153,7 +146,6 @@ class TestConfiguratorLogsExporter:
         trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
         mock_loggerprovider.assert_not_called()
         mock_blprocessor.assert_not_called()
-        mock_slprocessor.assert_not_called()
         mock_logginghandler.assert_not_called()
 
     def test_configure_logs_exporter_otel_true_sw_true_no_exporter(
@@ -161,7 +153,6 @@ class TestConfiguratorLogsExporter:
         mocker,
         mock_apmconfig_enabled,
         mock_blprocessor,
-        mock_slprocessor,
         mock_loggerprovider,
         mock_logginghandler,
     ):
@@ -183,7 +174,6 @@ class TestConfiguratorLogsExporter:
         trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
         mock_loggerprovider.assert_not_called()
         mock_blprocessor.assert_not_called()
-        mock_slprocessor.assert_not_called()
         mock_logginghandler.assert_not_called()
 
     def test_configure_logs_exporter_otel_true_sw_true_invalid_exporter(
@@ -191,7 +181,6 @@ class TestConfiguratorLogsExporter:
         mocker,
         mock_apmconfig_enabled,
         mock_blprocessor,
-        mock_slprocessor,
         mock_loggerprovider,
         mock_logginghandler,
     ):
@@ -224,68 +213,13 @@ class TestConfiguratorLogsExporter:
         mock_loggerprovider.assert_called_once()
 
         mock_blprocessor.assert_not_called()
-        mock_slprocessor.assert_not_called()
         mock_logginghandler.assert_not_called()
-
-    def test_configure_logs_exporter_otel_true_sw_true_is_lambda(
-        self,
-        mocker,
-        mock_apmconfig_enabled_is_lambda,
-        mock_blprocessor,
-        mock_slprocessor,
-        mock_loggerprovider,
-        mock_logginghandler,
-    ):
-        # Mock entry points
-        mock_exporter = mocker.Mock()
-        mock_exporter_class = mocker.Mock()
-        mock_exporter_class.configure_mock(return_value=mock_exporter)
-        mock_load = mocker.Mock()
-        mock_load.configure_mock(return_value=mock_exporter_class)
-        mock_exporter_entry_point = mocker.Mock()
-        mock_exporter_entry_point.configure_mock(
-            **{
-                "load": mock_load,
-            }
-        )
-        mock_points = iter([mock_exporter_entry_point])
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
-        )
-        mock_iter_entry_points.configure_mock(
-            return_value=mock_points
-        )
-
-        mocker.patch.dict(
-            os.environ,
-            {
-                _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED: "true",
-                "OTEL_LOGS_EXPORTER": "valid-exporter",
-            }
-        )
-        get_resource_mocks(mocker)
-        trace_mocks = get_trace_mocks(mocker)
-        get_logging_mocks(mocker)
-
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_logs_exporter(
-            mock_apmconfig_enabled_is_lambda,
-        )
-
-        trace_mocks.get_tracer_provider.assert_called_once()
-        trace_mocks.get_tracer_provider().get_tracer.assert_called_once()
-        mock_loggerprovider.assert_called_once()
-
-        mock_blprocessor.assert_not_called()
-        mock_slprocessor.assert_called_once()
-        mock_logginghandler.assert_called_once()
 
     def test_configure_logs_exporter_otel_true_sw_true_not_lambda(
         self,
         mocker,
         mock_apmconfig_enabled,
         mock_blprocessor,
-        mock_slprocessor,
         mock_loggerprovider,
         mock_logginghandler,
     ):
@@ -330,5 +264,4 @@ class TestConfiguratorLogsExporter:
         mock_loggerprovider.assert_called_once()
 
         mock_blprocessor.assert_called_once()
-        mock_slprocessor.assert_not_called()
         mock_logginghandler.assert_called_once()


### PR DESCRIPTION
Adjusts APM Python to support OTLP logs processing and export while in lambda.

Had to switch to always init `BatchLogRecordProcessor` because `SimpleLogRecordProcessor` keeps timing out, plus I will be changing the metrics processor like this soon too. Updates the lambda wrapper to set a different default collector endpoint for logs.

See ticket comment for manual testing.