### PR TITLE
NH-80452 Ignore export logs config when AO collector

### DIFF
--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -341,7 +341,7 @@ class TestSolarWindsApmConfig:
             "solarwinds_apm.apm_config.SolarWindsApmConfig._calculate_logs_enabled"
         )
 
-        config = apm_config.SolarWindsApmConfig()
+        apm_config.SolarWindsApmConfig()
         mock_metric_format.assert_called_once()
         mock_certs.assert_called_once()
         mock_logs_enabled.assert_called_once()

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -330,6 +330,22 @@ class TestSolarWindsApmConfig:
         mock_type.assert_called_once_with(1)
         mock_oboe_api_swig.assert_called_once()
 
+    def test__init_ao_settings_helpers_called(self, mocker):
+        mock_metric_format = mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig._calculate_metric_format"
+        )
+        mock_certs = mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig._calculate_certificates"
+        )
+        mock_logs_enabled = mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig._calculate_logs_enabled"
+        )
+
+        config = apm_config.SolarWindsApmConfig()
+        mock_metric_format.assert_called_once()
+        mock_certs.assert_called_once()
+        mock_logs_enabled.assert_called_once()
+
     def test_calculate_metric_format_no_collector(self, mocker):
         assert apm_config.SolarWindsApmConfig()._calculate_metric_format() == 2
 
@@ -480,6 +496,55 @@ class TestSolarWindsApmConfig:
         )
         mock_get_public_cert.configure_mock(return_value="foo")
         assert apm_config.SolarWindsApmConfig()._calculate_certificates() == "bar"
+
+    def test_calculate_logs_enabled_no_collector_enabled(self, mocker):
+        mocker.patch.dict(os.environ, {
+            "SW_APM_COLLECTOR": "",
+            "SW_APM_EXPORT_LOGS_ENABLED": "true",
+        })
+        assert apm_config.SolarWindsApmConfig()._calculate_logs_enabled() == True
+
+    def test_calculate_logs_enabled_no_collector_disabled(self, mocker):
+        mocker.patch.dict(os.environ, {
+            "SW_APM_COLLECTOR": "",
+            "SW_APM_EXPORT_LOGS_ENABLED": "false",
+        })
+        assert apm_config.SolarWindsApmConfig()._calculate_logs_enabled() == False
+
+    def test_calculate_logs_enabled_not_ao_enabled(self, mocker):
+        mocker.patch.dict(os.environ, {
+            "SW_APM_COLLECTOR": "some-other-collector",
+            "SW_APM_EXPORT_LOGS_ENABLED": "true",
+        })
+        assert apm_config.SolarWindsApmConfig()._calculate_logs_enabled() == True
+
+    def test_calculate_logs_enabled_not_ao_disabled(self, mocker):
+        mocker.patch.dict(os.environ, {
+            "SW_APM_COLLECTOR": "some-other-collector",
+            "SW_APM_EXPORT_LOGS_ENABLED": "false",
+        })
+        assert apm_config.SolarWindsApmConfig()._calculate_logs_enabled() == False
+
+    def test_calculate_logs_enabled_ao_prod(self, mocker):
+        mocker.patch.dict(os.environ, {
+            "SW_APM_COLLECTOR": INTL_SWO_AO_COLLECTOR,
+            "SW_APM_EXPORT_LOGS_ENABLED": "true",
+        })
+        assert apm_config.SolarWindsApmConfig()._calculate_logs_enabled() == False
+
+    def test_calculate_logs_enabled_ao_staging(self, mocker):
+        mocker.patch.dict(os.environ, {
+            "SW_APM_COLLECTOR": INTL_SWO_AO_STG_COLLECTOR,
+            "SW_APM_EXPORT_LOGS_ENABLED": "true",
+        })
+        assert apm_config.SolarWindsApmConfig()._calculate_logs_enabled() == False
+
+    def test_calculate_logs_enabled_ao_prod_with_port(self, mocker):
+        mocker.patch.dict(os.environ, {
+            "SW_APM_COLLECTOR": "{}:123".format(INTL_SWO_AO_COLLECTOR),
+            "SW_APM_EXPORT_LOGS_ENABLED": "true",
+        })
+        assert apm_config.SolarWindsApmConfig()._calculate_logs_enabled() == False
 
     def test_mask_service_key_no_key_empty_default(self, mocker):
         mock_iter_entry_points = mocker.patch(


### PR DESCRIPTION
Ignores `SW_APM_EXPORT_LOGS_ENABLED` / `exportLogsEnabled` if collector is AO, then sets internally to `False`. Customer can still manually configure OTLP logs export with `OTEL_*` env vars that take precedence (see https://github.com/solarwinds/apm-python/pull/393).