### PR TITLE
NH-90488 lint for all supported Python versions

### DIFF
--- a/.github/workflows/run_tox_lint_format.yaml
+++ b/.github/workflows/run_tox_lint_format.yaml
@@ -17,12 +17,15 @@ on:
 jobs:
   run_tox_lint_format:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-minor: ["8", "9", "10", "11", "12"]
     steps:
     - uses: actions/checkout@v4
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.${{ matrix.python-minor }}
         cache: 'pip' # caching pip dependencies
         cache-dependency-path: '**/dev-requirements.txt'
     - name: Install tox
@@ -30,4 +33,4 @@ jobs:
     - name: Build extension
       run: make wrapper
     - name: Run tox lint
-      run: tox -e lint -- --check-only
+      run: tox -e py3${{ matrix.python-minor }}-lint -- --check-only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,15 +68,15 @@ The unit and integration tests are also run on GitHub with the [Run tox tests](h
 Code formatting and linting are run using `black`, `isort`, `flake8`, and `pylint` via [tox](https://tox.readthedocs.io). First, create and run a Docker build container as described above. Then use the container to run formatting and linting in one of these ways:
 
 ```
-# Run formatting and linting tools,
+# Run formatting and linting tools for Python 3.12,
 # without trying to fix issues:
 ./run_docker_dev.sh
-make tox OPTIONS="-e lint -- --check-only"
+make tox OPTIONS="-e py312-lint -- --check-only"
 
-# Run formatting and linting tools,
+# Run formatting and linting tools for Python 3.8,
 # and automatically fix issues if possible:
 ./run_docker_dev.sh
-make tox OPTIONS="-e lint"
+make tox OPTIONS="-e py38-lint"
 ```
 
 Remotely, CodeQL can be run on GitHub with the [CodeQL Analysis](https://github.com/solarwinds/apm-python/actions/workflows/codeql_analysis.yaml) workflow.

--- a/solarwinds_apm/propagator.py
+++ b/solarwinds_apm/propagator.py
@@ -4,6 +4,9 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
+# TODO: Remove when Python < 3.10 support dropped
+from __future__ import annotations
+
 import logging
 import typing
 from re import split
@@ -40,7 +43,7 @@ class SolarWindsPropagator(textmap.TextMapPropagator):
     def extract(
         self,
         carrier: textmap.CarrierT,
-        context: typing.Optional[Context] = None,
+        context: Context | None = None,
         getter: textmap.Getter = textmap.default_getter,
     ) -> Context:
         """Extracts sw trace options and signature from carrier into OTel
@@ -66,7 +69,7 @@ class SolarWindsPropagator(textmap.TextMapPropagator):
     def inject(
         self,
         carrier: textmap.CarrierT,
-        context: typing.Optional[Context] = None,
+        context: Context | None = None,
         setter: textmap.Setter = textmap.default_setter,
     ) -> None:
         """Injects valid sw tracestate from carrier into carrier for HTTP request, to get

--- a/solarwinds_apm/response_propagator.py
+++ b/solarwinds_apm/response_propagator.py
@@ -4,8 +4,10 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
+# TODO: Remove when Python < 3.10 support dropped
+from __future__ import annotations
+
 import logging
-import typing
 
 from opentelemetry import trace
 from opentelemetry.context.context import Context
@@ -37,7 +39,7 @@ class SolarWindsTraceResponsePropagator(ResponsePropagator):
     def inject(
         self,
         carrier: textmap.CarrierT,
-        context: typing.Optional[Context] = None,
+        context: Context | None = None,
         setter: textmap.Setter = textmap.default_setter,
     ) -> None:
         """Injects x-trace and options-response into the HTTP response carrier."""

--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -9,6 +9,9 @@
 The custom sampler will fetch sampling configurations for the SolarWinds backend.
 """
 
+# TODO: Remove when Python < 3.10 support dropped
+from __future__ import annotations
+
 import enum
 import logging
 from types import MappingProxyType
@@ -148,7 +151,7 @@ class _SwSampler(Sampler):
         name: str,
         kind: SpanKind = None,
         attributes: Attributes = None,
-        xtraceoptions: Optional[XTraceOptions] = None,
+        xtraceoptions: XTraceOptions | None = None,
     ) -> dict:
         """Calculates oboe trace decision based on parent span context and APM config."""
         tracestring = None
@@ -363,7 +366,7 @@ class _SwSampler(Sampler):
         self,
         decision: dict,
         parent_span_context: SpanContext,
-        xtraceoptions: Optional[XTraceOptions] = None,
+        xtraceoptions: XTraceOptions | None = None,
     ) -> TraceState:
         """Calculates trace_state based on x-trace-options if provided -- for non-existent or remote parent spans only."""
         # No valid parent i.e. root span, or parent is remote
@@ -561,6 +564,7 @@ class _SwSampler(Sampler):
     #       for compatibility with Python3.8 else TypeError.
     def should_sample(
         self,
+        # pylint: disable=consider-alternative-union-syntax
         parent_context: Optional[OtelContext],
         trace_id: int,
         name: str,

--- a/solarwinds_apm/trace/serviceentry_processor.py
+++ b/solarwinds_apm/trace/serviceentry_processor.py
@@ -4,8 +4,11 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
+# TODO: Remove when Python < 3.10 support dropped
+from __future__ import annotations
+
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from opentelemetry import baggage, context
 from opentelemetry.sdk.trace import SpanProcessor
@@ -23,7 +26,7 @@ class ServiceEntryIdSpanProcessor(SpanProcessor):
     def on_start(
         self,
         span: "ReadableSpan",
-        parent_context: Optional[context.Context] = None,
+        parent_context: context.Context | None = None,
     ) -> None:
         """Caches current trace ID and entry span ID in span context baggage for API set_transaction_name"""
         # Only caches for service entry spans

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
   py3{8,9,10,11,12}-ao-prod
   py3{8,9,10,11,12}-nh-staging
   py3{8,9,10,11,12}-lambda
-  lint
+  py3{8,9,10,11,12}-lint
 
 [testenv]
 setenv =
@@ -41,8 +41,7 @@ changedir = lambda/tests
 commands_pre =
   py3{8,9,10,11,12}-lambda: pip install -r requirements.txt
 
-[testenv:lint]
-basepython: python3.9
+[testenv:py3{8,9,10,11,12}-lint]
 deps =
   opentelemetry-api
   opentelemetry-sdk


### PR DESCRIPTION
Update linting to run on all supported Python versions.

Lints some code to meet Python 3.12 recommendations, with `from __future__` import so Python 3.8, 3.9 still work.

 Example GH workflow run: https://github.com/solarwinds/apm-python/actions/runs/10727514035

Local command is slightly different: `make tox OPTIONS="-e lint"` is now `make tox OPTIONS="-e py312 lint"` etc