### PR TITLE
NH-92062 Lint existing code for pylint 3.0.0 upgrade

### DIFF
--- a/.pylintrc_py38
+++ b/.pylintrc_py38
@@ -75,7 +75,6 @@ disable=missing-docstring,
       too-few-public-methods, # Might be good to re-enable this later.
       too-many-instance-attributes,
       too-many-arguments,
-      too-many-positional-arguments, # TODO remove when drop py38 support
       duplicate-code,
       ungrouped-imports, # Leave this up to isort
       wrong-import-order, # Leave this up to isort

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,8 @@ services:
        # boto3 for interaction with AWS
        # twine to upload to TestPyPi
        # tox for automated tests
-       python3.8 -m pip install boto3 twine tox
+       python3.8 -m pip install --upgrade pip
+       python3.8 -m pip install --default-timeout=100 boto3 twine tox
        /bin/bash
 
   aarch64:
@@ -44,5 +45,6 @@ services:
        # boto3 for interaction with AWS
        # twine to upload to TestPyPi
        # tox for automated tests
-       python3.8 -m pip install boto3 twine tox
+       python3.8 -m pip install --upgrade pip
+       python3.8 -m pip install --default-timeout=100 boto3 twine tox
        /bin/bash

--- a/scripts/lint_and_format.py
+++ b/scripts/lint_and_format.py
@@ -16,7 +16,6 @@ def parse_args(args=None):
     parser = argparse.ArgumentParser(description="Lint and format everything, autofixing if possible.")
     parser.add_argument("--check-only", action="store_true")
     parser.add_argument("--allowexitcodes", action="append", default=[0])
-    parser.add_argument("--rcfile", type=str)
     parser.set_defaults(parser=parser)
     parser.set_defaults(func=lint_and_format)
     return parser.parse_args(args)

--- a/scripts/lint_and_format.py
+++ b/scripts/lint_and_format.py
@@ -7,6 +7,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 import argparse
+import os
 import subprocess
 import sys
 
@@ -15,6 +16,7 @@ def parse_args(args=None):
     parser = argparse.ArgumentParser(description="Lint and format everything, autofixing if possible.")
     parser.add_argument("--check-only", action="store_true")
     parser.add_argument("--allowexitcodes", action="append", default=[0])
+    parser.add_argument("--rcfile", type=str)
     parser.set_defaults(parser=parser)
     parser.set_defaults(func=lint_and_format)
     return parser.parse_args(args)
@@ -47,10 +49,25 @@ def lint_and_format(args):
         args.allowexitcodes,
     )
 
-    run_subprocess(
-        ("pylint", "--ignore", "solarwinds_apm/extension", "solarwinds_apm"),
-        args.allowexitcodes,
-    )
+    # pylint 3.3.0 is not available for py38, nor is `too-many-positional-argument`
+    # so we give it a different pylintrc file for now
+    # TODO update pylint disable when drop py38 support
+    if "py38" in os.getenv('TOX_ENV_NAME'):
+        run_subprocess(
+            (
+                "pylint",
+                "--rcfile=.pylintrc_py38",
+                "--ignore",
+                "solarwinds_apm/extension",
+                "solarwinds_apm",
+            ),
+            args.allowexitcodes,
+        ) 
+    else:
+        run_subprocess(
+            ("pylint", "--ignore", "solarwinds_apm/extension", "solarwinds_apm"),
+            args.allowexitcodes,
+        )
 
     print("Done.")
 

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -673,7 +673,7 @@ class SolarWindsApmConfig:
             "context": self.context,
             "service_name": self.service_name,
         }
-        return f"{apm_config}"
+        return json.dumps(apm_config)
 
     def __setitem__(self, key: str, value: str) -> None:
         """Refresh the configurations in liboboe global struct while user changes settings."""

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -670,7 +670,7 @@ class SolarWindsApmConfig:
         apm_config = {
             "__config": self._config_mask_service_key(),
             "agent_enabled": self.agent_enabled,
-            "context": self.context,
+            "context": str(self.context),
             "service_name": self.service_name,
         }
         return json.dumps(apm_config)

--- a/solarwinds_apm/apm_fwkv_manager.py
+++ b/solarwinds_apm/apm_fwkv_manager.py
@@ -4,6 +4,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
+import json
 import logging
 from typing import Any
 
@@ -27,7 +28,7 @@ class SolarWindsFrameworkKvManager:
         self.__cache[key] = value
 
     def __str__(self) -> str:
-        return f"{self.__cache}"
+        return json.dumps(self.__cache)
 
     def get(self, key: str, default: Any = None) -> Any:
         return self.__cache.get(key, default)

--- a/solarwinds_apm/apm_txname_manager.py
+++ b/solarwinds_apm/apm_txname_manager.py
@@ -4,6 +4,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
+import json
 import logging
 from typing import Any
 
@@ -27,7 +28,7 @@ class SolarWindsTxnNameManager:
         self.__cache[key] = value
 
     def __str__(self) -> str:
-        return f"{self.__cache}"
+        return json.dumps(self.__cache)
 
     def get(self, key: str, default: Any = None) -> Any:
         return self.__cache.get(key, default)

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -123,7 +123,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                 "There was an issue with generating the reporter init message."
             )
 
-    # pylint: disable=too-many-positional-arguments
+    # TODO update pylint disable when drop py38 support
     def _configure_otel_components(
         self,
         apm_txname_manager: SolarWindsTxnNameManager,

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -123,6 +123,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                 "There was an issue with generating the reporter init message."
             )
 
+    # pylint: disable=too-many-positional-arguments
     def _configure_otel_components(
         self,
         apm_txname_manager: SolarWindsTxnNameManager,

--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -144,7 +144,8 @@ class _SwSampler(Sampler):
         logger.debug("Using global tracing_mode as %s", self.tracing_mode)
         return self.tracing_mode
 
-    # pylint: disable=too-many-locals,too-many-positional-arguments
+    # TODO update pylint disable when drop py38 support
+    # pylint: disable=too-many-locals
     def calculate_liboboe_decision(
         self,
         parent_span_context: SpanContext,

--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -144,7 +144,7 @@ class _SwSampler(Sampler):
         logger.debug("Using global tracing_mode as %s", self.tracing_mode)
         return self.tracing_mode
 
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals,too-many-positional-arguments
     def calculate_liboboe_decision(
         self,
         parent_span_context: SpanContext,


### PR DESCRIPTION
[pylint 3.3.0](https://github.com/pylint-dev/pylint/releases/tag/v3.3.0) came out last Friday and APM Python always uses latest. Fixes issues or update `ignore` statements.

Splitting `.pylintrc` files until Python 3.8 support is dropped because pylint 3.3.0 Requires-Python >=3.9.0

Also adds some `pip install` longer timeouts to build container (top docker-compose) for when downloads are slow 💀 