### PR TITLE
NH-92060 Add support for individual sqlcommenter enabling; deprecate all-or-none

### DIFF
--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -259,24 +259,39 @@ class SolarWindsDistro(BaseDistro):
         return env_commenter_map
 
     def detect_commenter_options(self):
-        """Returns commenter options dict parsed from environment, if any"""
+        """Returns commenter options dict parsed from environment, if any
+
+        OTEL_SQLCOMMENTER_OPTIONS is deprecated (along with OTEL_SQLCOMMENTER_ENABLED).
+        Users should update to use SW_APM_OPTIONS_SQLCOMMENT instead"""
         commenter_opts = {}
-        commenter_opts_env = environ.get("OTEL_SQLCOMMENTER_OPTIONS")
-        if commenter_opts_env:
-            for opt_item in commenter_opts_env.split(","):
-                opt_k = ""
-                opt_v = ""
-                try:
-                    opt_k, opt_v = opt_item.split("=", maxsplit=1)
-                except ValueError as exc:
-                    logger.warning(
-                        "Invalid key-value pair for sqlcommenter option %s: %s",
-                        opt_item,
-                        exc,
-                    )
-                opt_v_bool = SolarWindsApmConfig.convert_to_bool(opt_v.strip())
-                if opt_v_bool is not None:
-                    commenter_opts[opt_k.strip()] = opt_v_bool
+        commenter_opts_env_depr = environ.get("OTEL_SQLCOMMENTER_OPTIONS")
+        commenter_opts_env = environ.get("SW_APM_OPTIONS_SQLCOMMENT")
+
+        opt_items = []
+        if commenter_opts_env_depr:
+            logger.warning(
+                "Deprecated: OTEL_SQLCOMMENTER_OPTIONS support will be removed in a future release. Please use SW_APM_OPTIONS_SQLCOMMENT instead."
+            )
+            opt_items = commenter_opts_env_depr.split(",")
+        elif commenter_opts_env:
+            opt_items = commenter_opts_env.split(",")
+        else:
+            return commenter_opts
+
+        for opt_item in opt_items:
+            opt_k = ""
+            opt_v = ""
+            try:
+                opt_k, opt_v = opt_item.split("=", maxsplit=1)
+            except ValueError as exc:
+                logger.warning(
+                    "Invalid key-value pair for sqlcommenter option %s: %s",
+                    opt_item,
+                    exc,
+                )
+            opt_v_bool = SolarWindsApmConfig.convert_to_bool(opt_v.strip())
+            if opt_v_bool is not None:
+                commenter_opts[opt_k.strip()] = opt_v_bool
 
         return commenter_opts
 

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -224,6 +224,9 @@ class SolarWindsDistro(BaseDistro):
         # https://github.com/open-telemetry/opentelemetry-specification/issues/3560
         enable_commenter = environ.get("OTEL_SQLCOMMENTER_ENABLED", "")
         if enable_commenter.lower() == "true":
+            logger.warning(
+                "Deprecated: OTEL_SQLCOMMENTER_ENABLED support will be removed in a future release. Please use SW_APM_ENABLED_SQLCOMMENT instead."
+            )
             return True
         return False
 

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -158,7 +158,7 @@ class SolarWindsDistro(BaseDistro):
         - OTEL_SQLCOMMENTER_ENABLED is deprecated
         - All instrumentors enabled if OTEL_SQLCOMMENTER_ENABLED=true
         - If OTEL_SQLCOMMENTER_ENABLED=false, SW_APM_ENABLED_SQLCOMMENT enables
-          individual instrumentors (each is false by default)
+          individual instrumentors if in _SQLCOMMENTERS (each is false by default)
         """
         # If we're in Lambda environment, then we skip loading
         # AwsLambdaInstrumentor because we assume the wrapper
@@ -188,7 +188,7 @@ class SolarWindsDistro(BaseDistro):
             )
 
         elif entry_point.name in _SQLCOMMENTERS:
-            entry_point_setting = self.enable_commenter_settings().get(
+            entry_point_setting = self.get_enable_commenter_env_map().get(
                 entry_point.name
             )
             if entry_point_setting is True:
@@ -229,14 +229,12 @@ class SolarWindsDistro(BaseDistro):
             return True
         return False
 
-    def enable_commenter_settings(self) -> dict:
+    def get_enable_commenter_env_map(self) -> dict:
         """Return a map of which instrumentors will have sqlcomment enabled,
-        if implemented. Default is False for each instrumentor.
+        if implemented. Default is False for each instrumentor in _SQLCOMMENTERS.
 
-        Expects SW_APM_ENABLED_SQLCOMMENT as a comma-separate string of kvs
-        paired by equals signs, e.g. 'django=true,sqlalchemy=false'. Keys for
-        instrumentors that currently support sqlcommenting upstream are:
-        django, flask, psycopg, psycopg2, sqlalchemy."""
+        Reads env SW_APM_ENABLED_SQLCOMMENT as a comma-separated string of KVs
+        paired by equals signs, e.g. 'django=true,sqlalchemy=false'."""
         env_commenter_items = environ.get("SW_APM_ENABLED_SQLCOMMENT", "")
         env_commenter_map = {instr: False for instr in _SQLCOMMENTERS}
         if env_commenter_items:

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -164,7 +164,6 @@ class SolarWindsDistro(BaseDistro):
         if self.enable_commenter():
             # Assumes kwargs ignored if not implemented for current
             # instrumentation library
-            # TODO: this and the `else` should set kwargs the same way
 
             # instrumentation for Flask ORM, sqlalchemy, psycopg2
             kwargs["enable_commenter"] = True
@@ -177,9 +176,8 @@ class SolarWindsDistro(BaseDistro):
             # https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/django/django.html
             kwargs["commenter_options"] = self.detect_commenter_options()
 
-            # TODO should be debug
-            logger.warning(
-                "(Blanket) Enabling sqlcommenter for %s with kwargs %s",
+            logger.debug(
+                "(Deprecated) Enabling sqlcommenter for %s with %s",
                 entry_point.name,
                 kwargs,
             )
@@ -202,9 +200,8 @@ class SolarWindsDistro(BaseDistro):
                         self.detect_commenter_options()
                     )
 
-                # TODO should be debug
-                logger.warning(
-                    "(Individually) Enabling sqlcommenter for %s with kwargs %s",
+                logger.debug(
+                    "Enabling sqlcommenter for %s with %s",
                     entry_point.name,
                     kwargs,
                 )
@@ -239,9 +236,8 @@ class SolarWindsDistro(BaseDistro):
         instrumentors that currently support sqlcommenting upstream are:
         django, flask, psycopg, psycopg2, sqlalchemy.
 
-        OTEL_SQLCOMMENTER_ENABLED (deprecated) takes precedence over
-        SW_APM_ENABLED_SQLCOMMENT until support for OTEL_SQLCOMMENTER_ENABLED
-        is removed."""
+        SW_APM_ENABLED_SQLCOMMENT takes precedence over OTEL_SQLCOMMENTER_ENABLED
+        (deprecated) until support for OTEL_SQLCOMMENTER_ENABLED is removed."""
         env_commenter_items = environ.get("SW_APM_ENABLED_SQLCOMMENT", "")
         env_commenter_map = {instr: False for instr in _SQLCOMMENTERS}
         if env_commenter_items:

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -171,7 +171,7 @@ class SolarWindsDistro(BaseDistro):
             kwargs["commenter_options"] = self.detect_commenter_options()
 
             logger.warning(
-                "(Blanket) Enabling sqlcommenter for %s with kwargs",
+                "(Blanket) Enabling sqlcommenter for %s with kwargs %s",
                 entry_point.name,
                 kwargs,
             )
@@ -200,7 +200,7 @@ class SolarWindsDistro(BaseDistro):
                 kwargs["commenter_options"] = self.detect_commenter_options()
 
                 logger.warning(
-                    "(Individually) Enabling sqlcommenter for %s with kwargs",
+                    "(Individually) Enabling sqlcommenter for %s with kwargs %s",
                     entry_point.name,
                     kwargs,
                 )

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -831,12 +831,12 @@ class TestDistro:
         result = distro.SolarWindsDistro().detect_commenter_options()
         assert result == {}
 
-    def test_detect_commenter_options_invalid_kv_ignored(self, mocker):
+    def test_detect_commenter_options_invalid_kv_ignored_deprecated(self, mocker):
         mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_OPTIONS": "invalid-kv,foo=bar"})
         result = distro.SolarWindsDistro().detect_commenter_options()
         assert result == {}
 
-    def test_detect_commenter_options_valid_kvs(self, mocker):
+    def test_detect_commenter_options_valid_kvs_deprecated(self, mocker):
         mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_OPTIONS": "foo=true,bar=FaLSe"})
         result = distro.SolarWindsDistro().detect_commenter_options()
         assert result == {
@@ -844,7 +844,7 @@ class TestDistro:
             "bar": False,
         }
 
-    def test_detect_commenter_options_strip_whitespace_ok(self, mocker):
+    def test_detect_commenter_options_strip_whitespace_ok_deprecated(self, mocker):
         mocker.patch.dict(
             os.environ,
             {
@@ -855,8 +855,51 @@ class TestDistro:
         assert result.get("foo") == True
         assert result.get("bar") == False
 
-    def test_detect_commenter_options_strip_mix(self, mocker):
+    def test_detect_commenter_options_strip_mix_deprecated(self, mocker):
         mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_OPTIONS": "invalid-kv,   foo=TrUe   ,bar  =  faLSE,   baz=qux  "})
+        result = distro.SolarWindsDistro().detect_commenter_options()
+        assert result.get("foo") == True
+        assert result.get("bar") == False
+        assert result.get("baz") is None
+
+    def test_detect_commenter_options_strip_mix_deprecated_and_new(self, mocker):
+        mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_OPTIONS": "invalid-kv,   foo=TrUe   ,bar  =  faLSE,   baz=qux  "})
+        mocker.patch.dict(os.environ, {"SW_APM_OPTIONS_SQLCOMMENT": "invalid-kv,   foofoo=TrUe   ,barbar  =  faLSE,   bazbaz=qux  "})
+        result = distro.SolarWindsDistro().detect_commenter_options()
+        assert result.get("foo") == True
+        assert result.get("bar") == False
+        assert result.get("baz") is None
+        # SW_APM_OPTIONS_SQLCOMMENT is not used
+        assert result.get("foofoo") is None
+        assert result.get("barbar") is None
+        assert result.get("bazbaz") is None
+
+    def test_detect_commenter_options_invalid_kv_ignored(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_OPTIONS_SQLCOMMENT": "invalid-kv,foo=bar"})
+        result = distro.SolarWindsDistro().detect_commenter_options()
+        assert result == {}
+
+    def test_detect_commenter_options_valid_kvs(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_OPTIONS_SQLCOMMENT": "foo=true,bar=FaLSe"})
+        result = distro.SolarWindsDistro().detect_commenter_options()
+        assert result == {
+            "foo": True,
+            "bar": False,
+        }
+
+    def test_detect_commenter_options_strip_whitespace_ok(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_OPTIONS_SQLCOMMENT": "   foo   =   tRUe   , bar = falsE "
+            }
+        )
+        result = distro.SolarWindsDistro().detect_commenter_options()
+        assert result.get("foo") == True
+        assert result.get("bar") == False
+
+    def test_detect_commenter_options_strip_mix(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_OPTIONS_SQLCOMMENT": "invalid-kv,   foo=TrUe   ,bar  =  faLSE,   baz=qux  "})
         result = distro.SolarWindsDistro().detect_commenter_options()
         assert result.get("foo") == True
         assert result.get("bar") == False

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -816,7 +816,7 @@ class TestDistro:
             "sqlalchemy": True,
         }
 
-    def test_enable_commenter_settings_valid_add_new(self, mocker):
+    def test_enable_commenter_settings_valid_ignores_if_not_on_list(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "flask=true,foobar=true"})
         assert distro.SolarWindsDistro().enable_commenter_settings() == {
             "django": False,
@@ -824,7 +824,6 @@ class TestDistro:
             "psycopg": False,
             "psycopg2": False,
             "sqlalchemy": False,
-            "foobar": True,
         }
 
     def test_detect_commenter_options_not_set(self, mocker):

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -478,7 +478,52 @@ class TestDistro:
             foo="bar",
         )
 
-    def test_load_instrumentor_enable_commenting_all_and_individual(self, mocker):
+    def test_load_instrumentor_enable_commenting_all_false_and_individual_false(self, mocker):
+        mock_instrument = mocker.Mock()
+        mock_instrumentor = mocker.Mock()
+        mock_instrumentor.configure_mock(
+            return_value=mocker.Mock(
+                **{
+                    "instrument": mock_instrument
+                }
+            )
+        )
+        mock_load = mocker.Mock()
+        mock_load.configure_mock(return_value=mock_instrumentor)
+        mock_entry_point = mocker.Mock()
+        mock_entry_point.configure_mock(
+            **{
+                "name": "foo-instrumentor",
+                "load": mock_load,
+            }
+        )
+        mocker.patch(
+            "solarwinds_apm.distro._SQLCOMMENTERS",
+            [
+                "foo-instrumentor"
+            ]
+        )   
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter",
+            return_value=False
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter_settings",
+            return_value={
+                "foo-instrumentor": False,
+            }
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.detect_commenter_options",
+            return_value="foo-options"
+        )
+        distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
+        # Commenting still enabled for individual even if catch-all is False
+        mock_instrument.assert_called_once_with(
+            foo="bar",
+        )
+
+    def test_load_instrumentor_enable_commenting_all_false_and_individual_true(self, mocker):
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -522,6 +567,54 @@ class TestDistro:
         mock_instrument.assert_called_once_with(
             commenter_options="foo-options",
             enable_commenter=True,
+            foo="bar",
+        )
+
+    def test_load_instrumentor_enable_commenting_all_true_and_individual_false(self, mocker):
+        mock_instrument = mocker.Mock()
+        mock_instrumentor = mocker.Mock()
+        mock_instrumentor.configure_mock(
+            return_value=mocker.Mock(
+                **{
+                    "instrument": mock_instrument
+                }
+            )
+        )
+        mock_load = mocker.Mock()
+        mock_load.configure_mock(return_value=mock_instrumentor)
+        mock_entry_point = mocker.Mock()
+        mock_entry_point.configure_mock(
+            **{
+                "name": "foo-instrumentor",
+                "load": mock_load,
+            }
+        )
+        mocker.patch(
+            "solarwinds_apm.distro._SQLCOMMENTERS",
+            [
+                "foo-instrumentor"
+            ]
+        )   
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter",
+            return_value=True
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter_settings",
+            return_value={
+                "foo-instrumentor": False,
+            }
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.detect_commenter_options",
+            return_value="foo-options"
+        )
+        distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
+        # Commenting enabled with all kwargs because catch-all true
+        mock_instrument.assert_called_once_with(
+            commenter_options="foo-options",
+            enable_commenter=True,
+            is_sql_commentor_enabled=True,
             foo="bar",
         )
 

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -378,7 +378,7 @@ class TestDistro:
         distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
         mock_instrument.assert_not_called()
 
-    def test_load_instrumentor_no_commenting(self, mocker):
+    def test_load_instrumentor_no_commenting_configured(self, mocker):
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -403,7 +403,7 @@ class TestDistro:
             }
         )  
 
-    def test_load_instrumentor_enable_commenting(self, mocker):
+    def test_load_instrumentor_enable_commenting_all_only(self, mocker):
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -435,6 +435,178 @@ class TestDistro:
             enable_commenter=True,
             foo="bar",
             is_sql_commentor_enabled=True,
+        )
+
+    def test_load_instrumentor_enable_commenting_individual_only_not_on_list(self, mocker):
+        mock_instrument = mocker.Mock()
+        mock_instrumentor = mocker.Mock()
+        mock_instrumentor.configure_mock(
+            return_value=mocker.Mock(
+                **{
+                    "instrument": mock_instrument
+                }
+            )
+        )
+        mock_load = mocker.Mock()
+        mock_load.configure_mock(return_value=mock_instrumentor)
+        mock_entry_point = mocker.Mock()
+        mock_entry_point.configure_mock(
+            **{
+                "name": "not-on-list",
+                "load": mock_load,
+            }
+        )
+        mocker.patch(
+            "solarwinds_apm.distro._SQLCOMMENTERS",
+            [
+                "this-is-on-the-list"
+            ]
+        )       
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter_settings",
+            return_value={
+                "not-on-list": True,
+            }
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.detect_commenter_options",
+            return_value="foo-options"
+        )
+        distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
+        # Commenting not enabled because not on list
+        mock_instrument.assert_called_once_with(
+            foo="bar",
+        )
+
+    def test_load_instrumentor_enable_commenting_all_and_individual(self, mocker):
+        mock_instrument = mocker.Mock()
+        mock_instrumentor = mocker.Mock()
+        mock_instrumentor.configure_mock(
+            return_value=mocker.Mock(
+                **{
+                    "instrument": mock_instrument
+                }
+            )
+        )
+        mock_load = mocker.Mock()
+        mock_load.configure_mock(return_value=mock_instrumentor)
+        mock_entry_point = mocker.Mock()
+        mock_entry_point.configure_mock(
+            **{
+                "name": "foo-instrumentor",
+                "load": mock_load,
+            }
+        )
+        mocker.patch(
+            "solarwinds_apm.distro._SQLCOMMENTERS",
+            [
+                "foo-instrumentor"
+            ]
+        )   
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter",
+            return_value=False
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter_settings",
+            return_value={
+                "foo-instrumentor": True,
+            }
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.detect_commenter_options",
+            return_value="foo-options"
+        )
+        distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
+        # Commenting still enabled for individual even if catch-all is False
+        mock_instrument.assert_called_once_with(
+            commenter_options="foo-options",
+            enable_commenter=True,
+            foo="bar",
+        )
+
+    def test_load_instrumentor_enable_commenting_individual_only_not_django(self, mocker):
+        mock_instrument = mocker.Mock()
+        mock_instrumentor = mocker.Mock()
+        mock_instrumentor.configure_mock(
+            return_value=mocker.Mock(
+                **{
+                    "instrument": mock_instrument
+                }
+            )
+        )
+        mock_load = mocker.Mock()
+        mock_load.configure_mock(return_value=mock_instrumentor)
+        mock_entry_point = mocker.Mock()
+        mock_entry_point.configure_mock(
+            **{
+                "name": "foo-instrumentor",
+                "load": mock_load,
+            }
+        )
+        mocker.patch(
+            "solarwinds_apm.distro._SQLCOMMENTERS",
+            [
+                "foo-instrumentor"
+            ]
+        )       
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter_settings",
+            return_value={
+                "foo-instrumentor": True,
+            }
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.detect_commenter_options",
+            return_value="foo-options"
+        )
+        distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
+        mock_instrument.assert_called_once_with(
+            commenter_options="foo-options",
+            enable_commenter=True,
+            foo="bar",
+        )
+
+    def test_load_instrumentor_enable_commenting_individual_only_django(self, mocker):
+        mock_instrument = mocker.Mock()
+        mock_instrumentor = mocker.Mock()
+        mock_instrumentor.configure_mock(
+            return_value=mocker.Mock(
+                **{
+                    "instrument": mock_instrument
+                }
+            )
+        )
+        mock_load = mocker.Mock()
+        mock_load.configure_mock(return_value=mock_instrumentor)
+        mock_entry_point = mocker.Mock()
+        mock_entry_point.configure_mock(
+            **{
+                "name": "django",
+                "load": mock_load,
+            }
+        )
+        mocker.patch(
+            "solarwinds_apm.distro._SQLCOMMENTERS",
+            [
+                "django"
+            ]
+        )       
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter_settings",
+            return_value={
+                "django": True,
+            }
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsDistro.detect_commenter_options",
+            return_value="foo-options"
+        )
+        distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
+        # No commenter_options because Django reads settings.py instead
+        mock_instrument.assert_called_once_with(
+            is_sql_commentor_enabled=True,
+            foo="bar",
         )
 
     def test_enable_commenter_none(self, mocker):

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -461,6 +461,107 @@ class TestDistro:
         mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_ENABLED": "tRuE"})
         assert distro.SolarWindsDistro().enable_commenter() == True
 
+    def test_enable_commenter_settings_none(self, mocker):
+        mocker.patch.dict(os.environ, {})
+        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+            "django": False,
+            "flask": False,
+            "psycopg": False,
+            "psycopg2": False,
+            "sqlalchemy": False,
+        }
+
+    def test_enable_commenter_settings_invalid_just_a_comma(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": ","})
+        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+            "django": False,
+            "flask": False,
+            "psycopg": False,
+            "psycopg2": False,
+            "sqlalchemy": False,
+        }
+
+    def test_enable_commenter_settings_invalid_missing_equals_sign_single_val(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django"})
+        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+            "django": False,
+            "flask": False,
+            "psycopg": False,
+            "psycopg2": False,
+            "sqlalchemy": False,
+        }
+
+    def test_enable_commenter_settings_invalid_missing_equals_sign_multiple_first(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django,flask=true"})
+        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+            "django": False,
+            "flask": True,
+            "psycopg": False,
+            "psycopg2": False,
+            "sqlalchemy": False,
+        }
+
+    def test_enable_commenter_settings_invalid_missing_equals_sign_multiple_last(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "flask=true,django"})
+        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+            "django": False,
+            "flask": True,
+            "psycopg": False,
+            "psycopg2": False,
+            "sqlalchemy": False,
+        }
+
+    def test_enable_commenter_settings_valid_ignored_values(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django=true,flask=foobar,psycopg=123"})
+        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+            "django": True,
+            "flask": False,
+            "psycopg": False,
+            "psycopg2": False,
+            "sqlalchemy": False,
+        }
+
+    def test_enable_commenter_settings_valid_mixed_case(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django=tRuE,flask=TrUe"})
+        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+            "django": True,
+            "flask": True,
+            "psycopg": False,
+            "psycopg2": False,
+            "sqlalchemy": False,
+        }
+
+    def test_enable_commenter_settings_valid_whitespace_stripped(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django=  true  ,flask=  true  "})
+        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+            "django": True,
+            "flask": True,
+            "psycopg": False,
+            "psycopg2": False,
+            "sqlalchemy": False,
+        }
+
+    def test_enable_commenter_settings_valid_update_existing(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django=true,flask=true,psycopg=true,psycopg2=true,sqlalchemy=true"})
+        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+            "django": True,
+            "flask": True,
+            "psycopg": True,
+            "psycopg2": True,
+            "sqlalchemy": True,
+        }
+
+    def test_enable_commenter_settings_valid_add_new(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "flask=true,foobar=true"})
+        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+            "django": False,
+            "flask": True,
+            "psycopg": False,
+            "psycopg2": False,
+            "sqlalchemy": False,
+            "foobar": True,
+        }
+
     def test_detect_commenter_options_not_set(self, mocker):
         mocker.patch.dict(os.environ, {})
         result = distro.SolarWindsDistro().detect_commenter_options()

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -463,7 +463,7 @@ class TestDistro:
             ]
         )       
         mocker.patch(
-            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter_settings",
+            "solarwinds_apm.distro.SolarWindsDistro.get_enable_commenter_env_map",
             return_value={
                 "not-on-list": True,
             }
@@ -508,7 +508,7 @@ class TestDistro:
             return_value=False
         )
         mocker.patch(
-            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter_settings",
+            "solarwinds_apm.distro.SolarWindsDistro.get_enable_commenter_env_map",
             return_value={
                 "foo-instrumentor": False,
             }
@@ -553,7 +553,7 @@ class TestDistro:
             return_value=False
         )
         mocker.patch(
-            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter_settings",
+            "solarwinds_apm.distro.SolarWindsDistro.get_enable_commenter_env_map",
             return_value={
                 "foo-instrumentor": True,
             }
@@ -600,7 +600,7 @@ class TestDistro:
             return_value=True
         )
         mocker.patch(
-            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter_settings",
+            "solarwinds_apm.distro.SolarWindsDistro.get_enable_commenter_env_map",
             return_value={
                 "foo-instrumentor": False,
             }
@@ -644,7 +644,7 @@ class TestDistro:
             ]
         )       
         mocker.patch(
-            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter_settings",
+            "solarwinds_apm.distro.SolarWindsDistro.get_enable_commenter_env_map",
             return_value={
                 "foo-instrumentor": True,
             }
@@ -686,7 +686,7 @@ class TestDistro:
             ]
         )       
         mocker.patch(
-            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter_settings",
+            "solarwinds_apm.distro.SolarWindsDistro.get_enable_commenter_env_map",
             return_value={
                 "django": True,
             }
@@ -726,9 +726,9 @@ class TestDistro:
         mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_ENABLED": "tRuE"})
         assert distro.SolarWindsDistro().enable_commenter() == True
 
-    def test_enable_commenter_settings_none(self, mocker):
+    def test_get_enable_commenter_env_map_none(self, mocker):
         mocker.patch.dict(os.environ, {})
-        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+        assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": False,
             "flask": False,
             "psycopg": False,
@@ -736,9 +736,9 @@ class TestDistro:
             "sqlalchemy": False,
         }
 
-    def test_enable_commenter_settings_invalid_just_a_comma(self, mocker):
+    def test_get_enable_commenter_env_map_invalid_just_a_comma(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": ","})
-        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+        assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": False,
             "flask": False,
             "psycopg": False,
@@ -746,9 +746,9 @@ class TestDistro:
             "sqlalchemy": False,
         }
 
-    def test_enable_commenter_settings_invalid_missing_equals_sign_single_val(self, mocker):
+    def test_get_enable_commenter_env_map_invalid_missing_equals_sign_single_val(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django"})
-        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+        assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": False,
             "flask": False,
             "psycopg": False,
@@ -756,9 +756,9 @@ class TestDistro:
             "sqlalchemy": False,
         }
 
-    def test_enable_commenter_settings_invalid_missing_equals_sign_multiple_first(self, mocker):
+    def test_get_enable_commenter_env_map_invalid_missing_equals_sign_multiple_first(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django,flask=true"})
-        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+        assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": False,
             "flask": True,
             "psycopg": False,
@@ -766,9 +766,9 @@ class TestDistro:
             "sqlalchemy": False,
         }
 
-    def test_enable_commenter_settings_invalid_missing_equals_sign_multiple_last(self, mocker):
+    def test_get_enable_commenter_env_map_invalid_missing_equals_sign_multiple_last(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "flask=true,django"})
-        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+        assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": False,
             "flask": True,
             "psycopg": False,
@@ -776,9 +776,9 @@ class TestDistro:
             "sqlalchemy": False,
         }
 
-    def test_enable_commenter_settings_valid_ignored_values(self, mocker):
+    def test_get_enable_commenter_env_map_valid_ignored_values(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django=true,flask=foobar,psycopg=123"})
-        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+        assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": True,
             "flask": False,
             "psycopg": False,
@@ -786,9 +786,9 @@ class TestDistro:
             "sqlalchemy": False,
         }
 
-    def test_enable_commenter_settings_valid_mixed_case(self, mocker):
+    def test_get_enable_commenter_env_map_valid_mixed_case(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django=tRuE,flask=TrUe"})
-        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+        assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": True,
             "flask": True,
             "psycopg": False,
@@ -796,9 +796,9 @@ class TestDistro:
             "sqlalchemy": False,
         }
 
-    def test_enable_commenter_settings_valid_whitespace_stripped(self, mocker):
+    def test_get_enable_commenter_env_map_valid_whitespace_stripped(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django=  true  ,flask=  true  "})
-        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+        assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": True,
             "flask": True,
             "psycopg": False,
@@ -806,9 +806,9 @@ class TestDistro:
             "sqlalchemy": False,
         }
 
-    def test_enable_commenter_settings_valid_update_existing(self, mocker):
+    def test_get_enable_commenter_env_map_valid_update_existing(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django=true,flask=true,psycopg=true,psycopg2=true,sqlalchemy=true"})
-        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+        assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": True,
             "flask": True,
             "psycopg": True,
@@ -816,9 +816,9 @@ class TestDistro:
             "sqlalchemy": True,
         }
 
-    def test_enable_commenter_settings_valid_ignores_if_not_on_list(self, mocker):
+    def test_get_enable_commenter_env_map_valid_ignores_if_not_on_list(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "flask=true,foobar=true"})
-        assert distro.SolarWindsDistro().enable_commenter_settings() == {
+        assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": False,
             "flask": True,
             "psycopg": False,


### PR DESCRIPTION
Adds support for individual sqlcommenter enabling with new env var, `SW_APM_ENABLED_SQLCOMMENT`. It should be a comma-separated string of KVs paired by equals signs, where key is one of the known instrumentor names and value is a case-insensitive "boolean" string. Example: `SW_APM_ENABLED_SQLCOMMENT='django=true,sqlalchemy=false'`. False is the default, so isn't necessary to set.

Deprecates the env var `OTEL_SQLCOMMENTER_ENABLED` (documented [here](https://documentation.solarwinds.com/en/success_center/observability/content/configure/services/python/configure.htm#trace-queries)) for all-or-none enabling of sqlcommenting by instrumentors, via [this warning log](https://github.com/solarwinds/apm-python/blob/a175028cfa3ddcb695d312b23b0e70a82f63f462/solarwinds_apm/distro.py#L226-L228). There is a temporary order of precedence between both configs:

|  `OTEL_SQLCOMMENTER_ENABLED`  | `SW_APM_ENABLED_SQLCOMMENT`   |  Result  |
|----|----|---|
|  False/None  |  None  |  None enabled  |
|  False/None  |  django=true  |  Django sqlcommenting enabled   |
|  True  |  Any   |  All sqlcommenting enabled   |

For streamlining of naming, `OTEL_SQLCOMMENTER_OPTIONS` (documented [here](https://documentation.solarwinds.com/en/success_center/observability/content/configure/services/python/configure.htm#trace-queries-options)) is also deprecated in favour of new `SW_APM_OPTIONS_SQLCOMMENT`, via [this warning log](https://github.com/solarwinds/apm-python/blob/a175028cfa3ddcb695d312b23b0e70a82f63f462/solarwinds_apm/distro.py#L272-L274). They do the same thing and this is purely cosmetic. Temporary order of precedence is `OTEL_SQLCOMMENTER_OPTIONS` > `SW_APM_OPTIONS_SQLCOMMENT`.

Please let me know if any suggestions, including naming of config env vars!