### PR TITLE
NH-92060 Allow case-insensitive instrumentor names when enabling sqlcomment

### DIFF
--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -249,12 +249,13 @@ class SolarWindsDistro(BaseDistro):
                     )
                     continue
 
-                if key in _SQLCOMMENTERS:
+                instrumentor_name = key.strip().lower()
+                if instrumentor_name in _SQLCOMMENTERS:
                     env_v_bool = SolarWindsApmConfig.convert_to_bool(
                         value.strip()
                     )
                     if env_v_bool is not None:
-                        env_commenter_map[key.strip()] = env_v_bool
+                        env_commenter_map[instrumentor_name] = env_v_bool
 
         return env_commenter_map
 

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -787,7 +787,7 @@ class TestDistro:
         }
 
     def test_get_enable_commenter_env_map_valid_mixed_case(self, mocker):
-        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django=tRuE,flask=TrUe"})
+        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "dJAnGO=tRuE,FlaSK=TrUe"})
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": True,
             "flask": True,
@@ -797,7 +797,7 @@ class TestDistro:
         }
 
     def test_get_enable_commenter_env_map_valid_whitespace_stripped(self, mocker):
-        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django=  true  ,flask=  true  "})
+        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django  =  true  ,  flask=  true  "})
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": True,
             "flask": True,


### PR DESCRIPTION
Noticed a small inconvenience while updating docs. This change allows case-insensitive instrumentor names when enabling sqlcomment via `SW_APM_ENABLED_SQLCOMMENT`.