### PR TITLE
NH-95071 Remove CodeQL deprecated setup-python-dependencies input

### DIFF
--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -48,7 +48,6 @@ jobs:
           languages: ${{ matrix.language }}
           # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           queries: security-extended,security-and-quality
-          setup-python-dependencies: false
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3


### PR DESCRIPTION
Removes CodeQL deprecated `setup-python-dependencies` input to stop this warning at workflow runs:

> The setup-python-dependencies input is deprecated and no longer has any effect. We recommend removing any references from your workflows. See https://github.blog/changelog/2024-01-23-codeql-2-16-python-dependency-installation-disabled-new-queries-and-bug-fixes/ for more information.

Example run, now without warning: https://github.com/solarwinds/apm-python/actions/runs/11673881050