### PR TITLE
NH-95072 Address CodeQL notes, warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,22 @@ def is_alpine_distro():
             releases = [l[:-1] for l in releases]
         if 'NAME="Alpine Linux"' in releases:
             return True
-    except Exception:
-        pass
+    except (FileNotFoundError, IsADirectoryError) as ecp:
+        logger.info(
+            "[SETUP] Could not find /etc/os-release file. "
+            "Assuming distro not Alpine: {e}".format(e=ecp))
+    except PermissionError as ecp:
+        logger.info(
+            "[SETUP] Permission denied for /etc/os-release. "
+            "Assuming distro not Alpine: {e}".format(e=ecp))
+    except (IOError, ValueError) as ecp:
+        logger.info(
+            "[SETUP] Could not open or read /etc/os-release file. "
+            "Assuming distro not Alpine: {e}".format(e=ecp))
+    except Exception as ecp:
+        logger.info(
+            "[SETUP] Something went wrong at is_alpine_distro. "
+            "Assuming distro not Alpine:: {e}".format(e=ecp))
 
     return False
 

--- a/tests/docker/install/client.py
+++ b/tests/docker/install/client.py
@@ -30,7 +30,7 @@ def request_server(attempts=10):
         ))
         logger.debug("Response headers from Flask server:")
         logger.debug(resp.headers)
-    except:
+    except Exception:
         logger.debug("Server not responding. Will try up to {} more times".format(attempts))
         attempts -= 1
         if attempts > 0:
@@ -38,6 +38,8 @@ def request_server(attempts=10):
             request_server(attempts)
         else:
             sys.exit("ERROR: No response from instrumented test server after several attempts.")
+    except (KeyboardInterrupt, SystemExit) as exc:
+        logger.debug("Exiting with: {e}".format(e=exc))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_apm_config/test_apm_config_get_extension.py
+++ b/tests/unit/test_apm_config/test_apm_config_get_extension.py
@@ -9,11 +9,6 @@ import sys
 
 from solarwinds_apm import apm_config
 import solarwinds_apm.apm_noop as NoopExtension
-from solarwinds_apm.apm_noop import (
-    Context as NoopContext,
-    OboeAPI as NoopOboeApi,
-    OboeAPIOptions as NoopOboeApiOptions,
-)
 from solarwinds_apm.extension import oboe as Extension
 from solarwinds_apm.extension.oboe import (
     Context,
@@ -21,9 +16,12 @@ from solarwinds_apm.extension.oboe import (
     OboeAPIOptions,
 )
 
-
 # pylint: disable=unused-import
 from .fixtures.env_vars import fixture_mock_env_vars
+
+NoopContext = NoopExtension.Context
+NoopOboeApi = NoopExtension.OboeAPI
+NoopOboeApiOptions = NoopExtension.OboeAPIOptions
 
 
 real_import = builtins.__import__

--- a/tests/unit/test_configurator/fixtures/resource.py
+++ b/tests/unit/test_configurator/fixtures/resource.py
@@ -4,8 +4,6 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-import pytest
-
 def get_resource_mocks(mocker):
     mock_new_res = mocker.Mock()
     mock_new_res.configure_mock(

--- a/tests/unit/test_configurator/fixtures/trace.py
+++ b/tests/unit/test_configurator/fixtures/trace.py
@@ -4,8 +4,6 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-import pytest
-
 def get_trace_mocks(mocker):
     mock_add_span_processor = mocker.Mock()
   

--- a/tests/unit/test_configurator/test_configurator_metrics_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_metrics_exporter.py
@@ -327,7 +327,6 @@ class TestConfiguratorMetricsExporter:
             del os.environ["OTEL_METRICS_EXPORTER"]
 
         # Mock entry points
-        mock_exporter_class = mocker.MagicMock()
         mock_exporter_entry_point = mocker.Mock()
         mock_exporter_class_invalid = mocker.Mock()
         mock_exporter_class_invalid.configure_mock(
@@ -361,7 +360,7 @@ class TestConfiguratorMetricsExporter:
         # Mock Otel
         get_resource_mocks(mocker)
         trace_mocks = get_trace_mocks(mocker)
-        mock_histogram = mocker.patch(
+        mocker.patch(
             "solarwinds_apm.configurator.Histogram"
         )
         mock_agg_temp = mocker.patch(

--- a/tests/unit/test_configurator/test_configurator_sampler.py
+++ b/tests/unit/test_configurator/test_configurator_sampler.py
@@ -83,7 +83,7 @@ class TestConfiguratorSampler:
         mock_tracerprovider,
     ):
         # Mock entry points
-        mock_load_entry_point = mocker.patch(
+        mocker.patch(
             "solarwinds_apm.configurator.load_entry_point"
         )
 

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -627,7 +627,6 @@ class Test_SolarWindsSpanExporter():
         mock_event,
         mock_create_event,
     ):
-        pass
         # mock liboboe event
         mock_event, mock_add_info, _ \
              = configure_event_mocks(

--- a/tests/unit/test_processors/test_inbound_metrics_processor.py
+++ b/tests/unit/test_processors/test_inbound_metrics_processor.py
@@ -4,8 +4,6 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-import pytest  # pylint: disable=unused-import
-
 from solarwinds_apm.trace import SolarWindsInboundMetricsSpanProcessor
 from solarwinds_apm.trace.tnames import TransactionNames
 

--- a/tests/unit/test_processors/test_otlp_metrics_processor.py
+++ b/tests/unit/test_processors/test_otlp_metrics_processor.py
@@ -4,10 +4,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-from os import environ
-
 from solarwinds_apm.apm_meter_manager import SolarWindsMeterManager
-from solarwinds_apm.apm_noop import SolarWindsMeterManager as NoopMeterManager
 
 from solarwinds_apm.trace import SolarWindsOTLPMetricsSpanProcessor
 from solarwinds_apm.trace.tnames import TransactionNames

--- a/tests/unit/test_propagator.py
+++ b/tests/unit/test_propagator.py
@@ -4,7 +4,6 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-import pytest  # pylint: disable=unused-import
 from unittest.mock import call
 
 from opentelemetry.context.context import Context

--- a/tests/unit/test_response_propagator.py
+++ b/tests/unit/test_response_propagator.py
@@ -4,7 +4,6 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-import pytest  # pylint: disable=unused-import
 from unittest.mock import call
 
 from solarwinds_apm.response_propagator import SolarWindsTraceResponsePropagator

--- a/tests/unit/test_sampler/fixtures/parent_span_context.py
+++ b/tests/unit/test_sampler/fixtures/parent_span_context.py
@@ -5,8 +5,8 @@ from opentelemetry.trace.span import SpanContext, TraceState
 @pytest.fixture(name="parent_span_context_invalid")
 def fixture_parent_span_context_invalid():
     return SpanContext(
-        trace_id=00000000000000000000000000000000,
-        span_id=0000000000000000,
+        trace_id=0o0000000000000000000000000000000,
+        span_id=0o000000000000000,
         is_remote=False,
         trace_flags=0,
         trace_state=None,

--- a/tests/unit/test_sampler/fixtures/parent_span_context.py
+++ b/tests/unit/test_sampler/fixtures/parent_span_context.py
@@ -5,8 +5,8 @@ from opentelemetry.trace.span import SpanContext, TraceState
 @pytest.fixture(name="parent_span_context_invalid")
 def fixture_parent_span_context_invalid():
     return SpanContext(
-        trace_id=0o0000000000000000000000000000000,
-        span_id=0o000000000000000,
+        trace_id=0x0000000000000000000000000000000,
+        span_id=0x000000000000000,
         is_remote=False,
         trace_flags=0,
         trace_state=None,

--- a/tests/unit/test_xtraceoptions.py
+++ b/tests/unit/test_xtraceoptions.py
@@ -4,8 +4,6 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-import pytest  # pylint: disable=unused-import
-
 from solarwinds_apm.traceoptions import XTraceOptions
 
 


### PR DESCRIPTION
Much-needed scrub. Addresses these old CodeQL notes and warnings, one under a build helper and the rest under tests:

1. https://github.com/solarwinds/apm-python/security/code-scanning/2
2. https://github.com/solarwinds/apm-python/security/code-scanning/51
3. https://github.com/solarwinds/apm-python/security/code-scanning/52
4. https://github.com/solarwinds/apm-python/security/code-scanning/1
5. https://github.com/solarwinds/apm-python/security/code-scanning/281
6. https://github.com/solarwinds/apm-python/security/code-scanning/241
7. https://github.com/solarwinds/apm-python/security/code-scanning/39
8. https://github.com/solarwinds/apm-python/security/code-scanning/40
9. https://github.com/solarwinds/apm-python/security/code-scanning/113
10. https://github.com/solarwinds/apm-python/security/code-scanning/174
11. https://github.com/solarwinds/apm-python/security/code-scanning/182
12. https://github.com/solarwinds/apm-python/security/code-scanning/203
13. https://github.com/solarwinds/apm-python/security/code-scanning/128
14. https://github.com/solarwinds/apm-python/security/code-scanning/173
15. https://github.com/solarwinds/apm-python/security/code-scanning/181
16. https://github.com/solarwinds/apm-python/security/code-scanning/279
17. https://github.com/solarwinds/apm-python/security/code-scanning/53