### PR TITLE
NH-63282 Remove pkg_resources usage

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -18,7 +18,7 @@ from opentelemetry.environment_variables import (
     OTEL_TRACES_EXPORTER,
 )
 from opentelemetry.sdk.resources import Resource
-from pkg_resources import iter_entry_points
+from opentelemetry.util._importlib_metadata import entry_points
 
 import solarwinds_apm.apm_noop as noop_extension
 from solarwinds_apm import apm_logging
@@ -391,9 +391,12 @@ class SolarWindsApmConfig:
                         != INTL_SWO_DEFAULT_TRACES_EXPORTER
                     ):
                         next(
-                            iter_entry_points(
-                                "opentelemetry_traces_exporter",
-                                environ_exporter_name,
+                            iter(
+                                # pylint: disable=too-many-function-args
+                                entry_points(
+                                    group="opentelemetry_traces_exporter",
+                                    name=environ_exporter_name,
+                                )
                             )
                         )
                 except StopIteration:

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -37,7 +37,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
 )
 from opentelemetry.sdk.version import __version__ as sdk_version
-from pkg_resources import EntryPoint
+from opentelemetry.util._importlib_metadata import EntryPoint
 
 from solarwinds_apm.apm_config import SolarWindsApmConfig
 from solarwinds_apm.apm_constants import (

--- a/solarwinds_apm/exporter.py
+++ b/solarwinds_apm/exporter.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from opentelemetry.sdk.trace.export import SpanExporter
 from opentelemetry.trace import SpanKind
-from pkg_resources import get_distribution
+from opentelemetry.util._importlib_metadata import version
 
 from solarwinds_apm.apm_constants import (
     INTL_SWO_LIBOBOE_TXN_NAME_KEY_PREFIX,
@@ -251,7 +251,7 @@ class SolarWindsSpanExporter(SpanExporter):
                         f"{framework}.connector"
                     ].__version__
                 elif framework == "pyramid":
-                    version_str = get_distribution(framework).version
+                    version_str = version(framework)
                 elif framework == "sqlite3":
                     version_str = sys.modules[framework].sqlite_version
                 elif framework == "tornado":

--- a/tests/integration/test_base_sw_headers_attrs.py
+++ b/tests/integration/test_base_sw_headers_attrs.py
@@ -5,10 +5,6 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 import os
-from pkg_resources import (
-    iter_entry_points,
-    load_entry_point
-)
 import re
 
 import flask
@@ -26,6 +22,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 )
 from opentelemetry.test.globals_test import reset_trace_globals
 from opentelemetry.test.test_base import TestBase
+from opentelemetry.util._importlib_metadata import entry_points
 
 from solarwinds_apm.apm_config import SolarWindsApmConfig
 from solarwinds_apm.configurator import SolarWindsConfigurator
@@ -76,8 +73,10 @@ class TestBaseSwHeadersAndAttributes(TestBase):
         # Based on auto_instrumentation run() and sitecustomize.py
         # Load OTel env vars entry points
         argument_otel_environment_variable = {}
-        for entry_point in iter_entry_points(
-            "opentelemetry_environment_variables"
+        for entry_point in iter(
+            entry_points(
+                group="opentelemetry_environment_variables"
+            )
         ):
             environment_variable_module = entry_point.load()
             for attribute in dir(environment_variable_module):
@@ -102,11 +101,10 @@ class TestBaseSwHeadersAndAttributes(TestBase):
         # This is done because set_tracer_provider cannot override the
         # current tracer provider. Has to be done here.
         reset_trace_globals()
-        sampler = load_entry_point(
-            "solarwinds_apm",
-            "opentelemetry_traces_sampler",
-            configurator._DEFAULT_SW_TRACES_SAMPLER
-        )(apm_config, reporter, OboeAPI())
+        sampler = next(iter(entry_points(
+            group="opentelemetry_traces_sampler",
+            name=configurator._DEFAULT_SW_TRACES_SAMPLER,
+        ))).load()(apm_config, reporter, OboeAPI())
         self.tracer_provider = TracerProvider(sampler=sampler)
         # Set InMemorySpanExporter for testing
         # We do NOT use SolarWindsSpanExporter

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -90,12 +90,12 @@ class TestSolarWindsApmConfig:
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": service_key,
         })
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
 
@@ -601,12 +601,12 @@ class TestSolarWindsApmConfig:
         assert apm_config.SolarWindsApmConfig()._calculate_metrics_enabled() == False
 
     def test_mask_service_key_no_key_empty_default(self, mocker):
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         assert apm_config.SolarWindsApmConfig().mask_service_key() == ""

--- a/tests/unit/test_apm_config/test_apm_config_agent_enabled.py
+++ b/tests/unit/test_apm_config/test_apm_config_agent_enabled.py
@@ -25,12 +25,12 @@ class TestSolarWindsApmConfigAgentEnabled:
         mocker.patch.dict(os.environ, {
             "SW_APM_AGENT_ENABLED": "true",
         })
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch(
@@ -66,12 +66,12 @@ class TestSolarWindsApmConfigAgentEnabled:
         if old_collector:
             del os.environ["SW_APM_COLLECTOR"]
 
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch.dict(os.environ, {
@@ -124,12 +124,12 @@ class TestSolarWindsApmConfigAgentEnabled:
         if old_collector:
             del os.environ["SW_APM_COLLECTOR"]
 
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
 
@@ -171,12 +171,12 @@ class TestSolarWindsApmConfigAgentEnabled:
             "SW_APM_SERVICE_KEY": "invalidkey",
             "SW_APM_AGENT_ENABLED": "true",
         })
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch(
@@ -200,12 +200,12 @@ class TestSolarWindsApmConfigAgentEnabled:
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "valid:key",
         })
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch(
@@ -230,12 +230,12 @@ class TestSolarWindsApmConfigAgentEnabled:
             "SW_APM_SERVICE_KEY": "valid:key",
             "SW_APM_AGENT_ENABLED": "true",
         })
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch(
@@ -260,12 +260,12 @@ class TestSolarWindsApmConfigAgentEnabled:
             "SW_APM_SERVICE_KEY": "valid:key",
             "SW_APM_AGENT_ENABLED": "false",
         })
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch(
@@ -290,12 +290,12 @@ class TestSolarWindsApmConfigAgentEnabled:
             "SW_APM_SERVICE_KEY": "valid:key",
             "SW_APM_AGENT_ENABLED": "fALsE",
         })
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch(
@@ -320,12 +320,12 @@ class TestSolarWindsApmConfigAgentEnabled:
         mocker,
         fixture_cnf_dict_enabled_false,
     ):
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch.dict(os.environ, {
@@ -360,12 +360,12 @@ class TestSolarWindsApmConfigAgentEnabled:
         mocker,
         fixture_cnf_dict_enabled_false_mixed_case,
     ):
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch.dict(os.environ, {
@@ -400,12 +400,12 @@ class TestSolarWindsApmConfigAgentEnabled:
         mocker,
         fixture_cnf_dict_enabled_false,
     ):
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch.dict(os.environ, {
@@ -440,12 +440,12 @@ class TestSolarWindsApmConfigAgentEnabled:
         mocker,
         fixture_cnf_dict,
     ):
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch.dict(os.environ, {
@@ -484,12 +484,12 @@ class TestSolarWindsApmConfigAgentEnabled:
             "SW_APM_SERVICE_KEY": "valid:key",
             "SW_APM_AGENT_ENABLED": "true",
         })
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch(
@@ -624,10 +624,10 @@ class TestSolarWindsApmConfigAgentEnabled:
             "OTEL_TRACES_EXPORTER": "solarwinds_exporter,not-valid",
             "SW_APM_SERVICE_KEY": "valid:key",
         })
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             side_effect=StopIteration("mock error")
         )
         mocker.patch(
@@ -652,12 +652,12 @@ class TestSolarWindsApmConfigAgentEnabled:
             "OTEL_TRACES_EXPORTER": "foo,solarwinds_exporter,bar",
             "SW_APM_SERVICE_KEY": "valid:key",
         })
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
         mock_points = mocker.MagicMock()
         mock_points.__iter__.return_value = ["foo", "bar"]
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch(

--- a/tests/unit/test_configurator/test_configurator_add_all_instrumented_versions.py
+++ b/tests/unit/test_configurator/test_configurator_add_all_instrumented_versions.py
@@ -45,10 +45,10 @@ class TestConfiguratorAddAllInstrumentedFrameworkVersions:
             }
         )
         mock_points = iter([mock_instrumentor_entry_point])
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
 
@@ -384,16 +384,10 @@ class TestConfiguratorAddAllInstrumentedFrameworkVersions:
         self,
         mocker,
     ):
-        # mock get_distribution
-        mock_dist = mocker.Mock()
-        mock_dist.configure_mock(
-            **{
-                "version": "foo-version"
-            }
-        )
+        # mock util version
         mocker.patch(
-            "solarwinds_apm.configurator.get_distribution",
-            return_value=mock_dist,
+            "solarwinds_apm.configurator.version",
+            return_value="foo-version",
         )
 
         self.set_up_mocks(

--- a/tests/unit/test_configurator/test_configurator_logs_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_logs_exporter.py
@@ -206,10 +206,10 @@ class TestConfiguratorLogsExporter:
         mock_logginghandler,
     ):
         # Mock entry points
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             side_effect=StopIteration("mock error")
         )
 
@@ -257,10 +257,10 @@ class TestConfiguratorLogsExporter:
             }
         )
         mock_points = iter([mock_exporter_entry_point])
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
 

--- a/tests/unit/test_configurator/test_configurator_metrics_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_metrics_exporter.py
@@ -118,10 +118,10 @@ class TestConfiguratorMetricsExporter:
             del os.environ["OTEL_METRICS_EXPORTER"]
 
         # Mock entry points
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             side_effect=StopIteration("mock error")
         )
         mocker.patch.dict(
@@ -176,10 +176,10 @@ class TestConfiguratorMetricsExporter:
             }
         )
         mock_points = iter([mock_exporter_entry_point])
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch.dict(
@@ -257,10 +257,10 @@ class TestConfiguratorMetricsExporter:
             }
         )
         mock_points = iter([mock_exporter_entry_point])
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch.dict(
@@ -344,10 +344,10 @@ class TestConfiguratorMetricsExporter:
                 mock_exporter_entry_point,
             ]
         )
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch.dict(
@@ -375,9 +375,12 @@ class TestConfiguratorMetricsExporter:
                 mock_apmconfig_enabled,
             )
         # Only called once before exception
-        mock_iter_entry_points.assert_has_calls(
+        mock_entry_points.assert_has_calls(
             [
-                mocker.call("opentelemetry_metrics_exporter", "invalid_exporter"),
+                mocker.call(
+                    group="opentelemetry_metrics_exporter",
+                    name="invalid_exporter",
+                ),
             ]
         )
         mock_exporter_entry_point_invalid.load.assert_has_calls(
@@ -436,10 +439,10 @@ class TestConfiguratorMetricsExporter:
                 mock_exporter_entry_point_invalid,
             ]
         )
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch.dict(
@@ -466,10 +469,16 @@ class TestConfiguratorMetricsExporter:
             test_configurator._configure_metrics_exporter(
                 mock_apmconfig_enabled,
             )
-        mock_iter_entry_points.assert_has_calls(
+        mock_entry_points.assert_has_calls(
             [
-                mocker.call("opentelemetry_metrics_exporter", "valid_exporter"),
-                mocker.call("opentelemetry_metrics_exporter", "invalid_exporter"),
+                mocker.call(
+                    group="opentelemetry_metrics_exporter",
+                    name="valid_exporter",
+                ),
+                mocker.call(
+                    group="opentelemetry_metrics_exporter",
+                    name="invalid_exporter",
+                ),
             ]
         )
         mock_exporter_entry_point.load.assert_called_once()
@@ -548,10 +557,10 @@ class TestConfiguratorMetricsExporter:
                 mock_exporter_entry_point_invalid,
             ]
         )
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch.dict(
@@ -578,10 +587,16 @@ class TestConfiguratorMetricsExporter:
             test_configurator._configure_metrics_exporter(
                 mock_apmconfig_enabled_is_lambda,
             )
-        mock_iter_entry_points.assert_has_calls(
+        mock_entry_points.assert_has_calls(
             [
-                mocker.call("opentelemetry_metrics_exporter", "valid_exporter"),
-                mocker.call("opentelemetry_metrics_exporter", "invalid_exporter"),
+                mocker.call(
+                    group="opentelemetry_metrics_exporter",
+                    name="valid_exporter",
+                ),
+                mocker.call(
+                    group="opentelemetry_metrics_exporter",
+                    name="invalid_exporter",
+                ),
             ]
         )
         mock_exporter_entry_point.load.assert_called_once()

--- a/tests/unit/test_configurator/test_configurator_propagators.py
+++ b/tests/unit/test_configurator/test_configurator_propagators.py
@@ -38,21 +38,30 @@ class TestConfiguratorPropagators:
                 mock_propagator_entry_point,
             ]
         )
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
 
         # Test!
         test_configurator = configurator.SolarWindsConfigurator()
         test_configurator._configure_propagator()
-        mock_iter_entry_points.assert_has_calls(
+        mock_entry_points.assert_has_calls(
             [
-                mocker.call("opentelemetry_propagator", "tracecontext"),
-                mocker.call("opentelemetry_propagator","baggage"),
-                mocker.call("opentelemetry_propagator", "solarwinds_propagator"),
+                mocker.call(
+                    group="opentelemetry_propagator",
+                    name="tracecontext",
+                ),
+                mocker.call(
+                    group="opentelemetry_propagator",
+                    name="baggage"
+                ),
+                mocker.call(
+                    group="opentelemetry_propagator",
+                    name="solarwinds_propagator",
+                ),
             ]
         )
         mock_composite_propagator.assert_called_once()
@@ -74,10 +83,10 @@ class TestConfiguratorPropagators:
             del os.environ["OTEL_PROPAGATORS"]
 
         # Mock entry points
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             side_effect=StopIteration("mock error")
         )
         mocker.patch.dict(
@@ -91,9 +100,12 @@ class TestConfiguratorPropagators:
         test_configurator = configurator.SolarWindsConfigurator()
         with pytest.raises(Exception):
             test_configurator._configure_propagator()
-            mock_iter_entry_points.assert_has_calls(
+            mock_entry_points.assert_has_calls(
                 [
-                    mocker.call("opentelemetry_propagator", "invalid_propagator"),
+                    mocker.call(
+                        group="opentelemetry_propagator",
+                        name="invalid_propagator"
+                    ),
                 ]
             )
         mock_composite_propagator.assert_not_called()
@@ -127,10 +139,10 @@ class TestConfiguratorPropagators:
                 mock_propagator_entry_point,
             ]
         )
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
 
@@ -144,9 +156,12 @@ class TestConfiguratorPropagators:
         # Test!
         test_configurator = configurator.SolarWindsConfigurator()
         test_configurator._configure_propagator()
-        mock_iter_entry_points.assert_has_calls(
+        mock_entry_points.assert_has_calls(
             [
-                mocker.call("opentelemetry_propagator", "valid_propagator"),
+                mocker.call(
+                    group="opentelemetry_propagator",
+                    name="valid_propagator"
+                ),
             ]
         )
         mock_composite_propagator.assert_called_once()
@@ -182,10 +197,10 @@ class TestConfiguratorPropagators:
                 Exception("mock error invalid propagator")
             ]
         )
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
 
@@ -200,10 +215,16 @@ class TestConfiguratorPropagators:
         test_configurator = configurator.SolarWindsConfigurator()
         with pytest.raises(Exception):
             test_configurator._configure_propagator()
-        mock_iter_entry_points.assert_has_calls(
+        mock_entry_points.assert_has_calls(
             [
-                mocker.call("opentelemetry_propagator", "valid_propagator"),
-                mocker.call("opentelemetry_propagator", "invalid_propagator"),
+                mocker.call(
+                    group="opentelemetry_propagator", 
+                    name="valid_propagator",
+                ),
+                mocker.call(
+                    group="opentelemetry_propagator",
+                    name="invalid_propagator",
+                ),
             ]
         )
         mock_composite_propagator.assert_not_called()

--- a/tests/unit/test_configurator/test_configurator_sampler.py
+++ b/tests/unit/test_configurator/test_configurator_sampler.py
@@ -49,10 +49,10 @@ class TestConfiguratorSampler:
         mock_tracerprovider,
     ):
         # Mock entry points
-        mock_load_entry_point = mocker.patch(
-            "solarwinds_apm.configurator.load_entry_point"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_load_entry_point.configure_mock(
+        mock_entry_points.configure_mock(
             side_effect=Exception("mock error")
         )
 
@@ -83,8 +83,17 @@ class TestConfiguratorSampler:
         mock_tracerprovider,
     ):
         # Mock entry points
-        mocker.patch(
-            "solarwinds_apm.configurator.load_entry_point"
+        mock_entry_point = mocker.Mock()
+        mock_entry_point.configure_mock(
+            **{
+                "load": mocker.Mock()
+            }
+        )
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
+        )
+        mock_entry_points.configure_mock(
+            return_value=[mock_entry_point]
         )
 
         # Mock Otel
@@ -137,8 +146,17 @@ class TestConfiguratorSampler:
             del os.environ["OTEL_TRACES_SAMPLER"]
 
         # Mock entry points
-        mock_load_entry_point = mocker.patch(
-            "solarwinds_apm.configurator.load_entry_point"
+        mock_entry_point = mocker.Mock()
+        mock_entry_point.configure_mock(
+            **{
+                "load": mocker.Mock()
+            }
+        )
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
+        )
+        mock_entry_points.configure_mock(
+            return_value=[mock_entry_point]
         )
 
         # Mock Otel
@@ -172,10 +190,9 @@ class TestConfiguratorSampler:
         )
 
         # sampler loaded was solarwinds_sampler, not configured foo_sampler
-        mock_load_entry_point.assert_called_once_with(
-            "solarwinds_apm",
-            "opentelemetry_traces_sampler",
-            "solarwinds_sampler",
+        mock_entry_points.assert_called_once_with(
+            group="opentelemetry_traces_sampler",
+            name="solarwinds_sampler",
         )
 
         # tracer_provider set with new resource using configured service_name

--- a/tests/unit/test_configurator/test_configurator_traces_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_traces_exporter.py
@@ -84,10 +84,10 @@ class TestConfiguratorTracesExporter:
             del os.environ["OTEL_TRACES_EXPORTER"]
 
         # Mock entry points
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.apm_config.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             side_effect=StopIteration("mock error")
         )
         mocker.patch.dict(
@@ -142,10 +142,10 @@ class TestConfiguratorTracesExporter:
             }
         )
         mock_points = iter([mock_exporter_entry_point])
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch.dict(
@@ -198,10 +198,10 @@ class TestConfiguratorTracesExporter:
             }
         )
         mock_points = iter([mock_exporter_entry_point])
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
         mocker.patch.dict(
@@ -271,10 +271,10 @@ class TestConfiguratorTracesExporter:
                 mock_exporter_entry_point,
             ]
         )
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
 
@@ -298,9 +298,12 @@ class TestConfiguratorTracesExporter:
                 mock_apmconfig_enabled,
             )
         # Only called once before exception
-        mock_iter_entry_points.assert_has_calls(
+        mock_entry_points.assert_has_calls(
             [
-                mocker.call("opentelemetry_traces_exporter", "invalid_exporter"),
+                mocker.call(
+                    group="opentelemetry_traces_exporter",
+                    name="invalid_exporter",
+                ),
             ]
         )
         # Not called at all
@@ -351,10 +354,10 @@ class TestConfiguratorTracesExporter:
                 mock_exporter_entry_point_invalid,
             ]
         )
-        mock_iter_entry_points = mocker.patch(
-            "solarwinds_apm.configurator.iter_entry_points"
+        mock_entry_points = mocker.patch(
+            "solarwinds_apm.configurator.entry_points"
         )
-        mock_iter_entry_points.configure_mock(
+        mock_entry_points.configure_mock(
             return_value=mock_points
         )
 
@@ -377,10 +380,16 @@ class TestConfiguratorTracesExporter:
                 mock_fwkv_manager,
                 mock_apmconfig_enabled,
             )
-        mock_iter_entry_points.assert_has_calls(
+        mock_entry_points.assert_has_calls(
             [
-                mocker.call("opentelemetry_traces_exporter", "valid_exporter"),
-                mocker.call("opentelemetry_traces_exporter", "invalid_exporter"),
+                mocker.call(
+                    group="opentelemetry_traces_exporter",
+                    name="valid_exporter",
+                ),
+                mocker.call(
+                    group="opentelemetry_traces_exporter",
+                    name="invalid_exporter",
+                ),
             ]
         )
         # Ends up called once for the valid exporter

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -1301,16 +1301,10 @@ class Test_SolarWindsSpanExporter():
         mock_sys_modules = {
             "pyramid": mocker.Mock()
         }
-        # also mock get_distribution for pyramid for actual version check
-        mock_dist = mocker.Mock()
-        mock_dist.configure_mock(
-            **{
-                "version": "4.5.6"
-            }
-        )
+        # also mock util version for pyramid for actual version check
         mocker.patch(
-            "solarwinds_apm.exporter.get_distribution",
-            return_value=mock_dist
+            "solarwinds_apm.exporter.version",
+            return_value="4.5.6",
         )
         self.mock_and_assert_addinfo_for_instrumented_framework(
             mocker,


### PR DESCRIPTION
pkg_resource is [deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html#package-discovery-and-resource-access-using-pkg-resources). Replaces pkg_resource uses with an Otel Python util to map importlib depending on Python version.

Replaces https://github.com/solarwinds/apm-python/pull/429 following release of Otel Python 1.28.1/0.49b1. Being merged into https://github.com/solarwinds/apm-python/pull/450, not main, to get tests to pass.