### PR TITLE
NH-96758 Change /lambda/tests deps check to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,7 @@ updates:
 - package-ecosystem: pip
   directory: "/lambda/tests"
   schedule:
-    interval: daily
-    time: "11:00"
-    timezone: "America/Vancouver"
+    interval: weekly
 
   groups:
     otel-instrumentors:


### PR DESCRIPTION
Change the new `/lambda/tests` deps Dependabot check to weekly. It looks like [it works](https://github.com/solarwinds/apm-python/actions/runs/11978203976/job/33397733401) and should be done weekly with all the other checks now.