### PR TITLE
NH-96831 Run tox tests with Flask 3.1, except Python 3.8

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,6 @@ pytest
 pytest-cov
 pytest-mock
 requests
-flask~=3.0
+flask~=3.1; python_version >= '3.9'
+flask~=3.0; python_version < '3.9'
 werkzeug


### PR DESCRIPTION
Flask 3.1 came out this month. It drops Python 3.8 support! https://flask.palletsprojects.com/en/stable/changes/

Runs APM Python tox tests with Flask 3.1, except Python 3.8 which sticks to Flask 3.0. See ticket for manual testing with Flask 3.1.

A user trying to install Flask 3.1 on Python <=3.8 will see pip install errors early before instrumentation is attempted.