### PR TITLE
NH-100215 Update init event version lookup logs

### DIFF
--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -697,7 +697,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                         and conflict.found is None
                     ):
                         logger.debug(
-                            "Version lookup for library %s skipped due to known pydantic/tortoiseorm bootstrap conflice: %s",
+                            "Version lookup for library %s skipped due to known pydantic/tortoiseorm bootstrap conflict: %s",
                             entry_point.name,
                             conflict,
                         )

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -658,7 +658,8 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
     ) -> dict:
         """Updates version_keys with versions of Python frameworks that have been
         instrumented with installed (bootstrapped) OTel instrumentation libraries.
-        Borrowed from opentelemetry-instrumentation sitecustomize.
+        Borrowed from opentelemetry-instrumentation sitecustomize. Intended for
+        creating init event.
 
         Example output:
         {
@@ -697,20 +698,20 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                         and conflict.found is None
                     ):
                         logger.debug(
-                            "Version lookup for library %s skipped due to known pydantic/tortoiseorm bootstrap conflict: %s",
+                            "Init event version lookup for library %s skipped due to known pydantic/tortoiseorm bootstrap conflict: %s",
                             entry_point.name,
                             conflict,
                         )
                     else:
-                        logger.warning(
-                            "Version lookup for library %s skipped due to conflict: %s",
+                        logger.debug(
+                            "Init event version lookup for library %s skipped due to conflict: %s",
                             entry_point.name,
                             conflict,
                         )
                     continue
             except Exception as ex:  # pylint: disable=broad-except
-                logger.warning(
-                    "Version conflict check of %s failed, so skipping: %s",
+                logger.debug(
+                    "Init event version conflict check of %s failed, so skipping: %s",
                     entry_point.name,
                     ex,
                 )


### PR DESCRIPTION
Changes version lookup issue logs from `warning` to `debug`. My argument is that they are currently misleading when in Lambda or k8s operator, which both manually pre-install as many instrumentors as possible instead of bootstrapping only what's needed based on frameworks installed in the current environment. If there is conflict that actually prevents instrumentation, it [will be logged by upstream](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/ec3c51dcd18fa747c567708d8aead21cd9081dca/opentelemetry-instrumentation/src/opentelemetry/instrumentation/dependencies.py#L72-L76). Meanwhile the logs should still be kept if there are reporter init event issues that need deeper investigation. See ticket description for more details. Let me know what you think 😺 