### PR TITLE
NH-100298 Add docker scout cves for autoinstrumentation-python

### DIFF
--- a/.github/workflows/build_publish_image_autoinstrumentation.yaml
+++ b/.github/workflows/build_publish_image_autoinstrumentation.yaml
@@ -7,9 +7,6 @@
 name: "Publish APM Python Auto-Instrumentation"
 
 on:
-  push:
-    branches:
-      - NH-100298-docker-scout-autoinst-image
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build_publish_image_autoinstrumentation.yaml
+++ b/.github/workflows/build_publish_image_autoinstrumentation.yaml
@@ -30,6 +30,20 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_CI_USER }}
           password: ${{ secrets.DOCKER_HUB_CI_PASSWORD }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ github.repository_owner }}/autoinstrumentation-python
+          tags: |
+            type=raw,value=${{ env.VERSION }}
+            type=raw,value=latest
+          labels: |
+            maintainer=swo-librarians
+            org.opencontainers.image.title=apm-python
+            org.opencontainers.image.description=Solarwinds OTEL distro Python agent
+            org.opencontainers.image.vendor=SolarWinds Worldwide, LLC
+
       - name: Login to GitHub Package Registry
         uses: docker/login-action@v3
         if: ${{ github.event_name == 'push' }}
@@ -45,7 +59,27 @@ jobs:
           context: image
           platforms: linux/amd64,linux/arm64
           build-args: version=${{ env.VERSION }}
-          tags: ${{ github.repository_owner }}/autoinstrumentation-python:${{ env.VERSION }},${{ github.repository_owner }}/autoinstrumentation-python:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Analyze for critical and high CVEs - local Dockerfile
+        id: docker-scout-cves
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: "fs://./"
+          platform: "linux/amd64"
+          ignore-base: true
+          only-package-types: pip
+
+      - name: Analyze for critical and high CVEs - tagged image
+        id: docker-scout-image-cves
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: ${{ steps.meta.outputs.tags[0] }}
+          platform: "linux/amd64"
+  
 
   ghcr_io:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_publish_image_autoinstrumentation.yaml
+++ b/.github/workflows/build_publish_image_autoinstrumentation.yaml
@@ -1,6 +1,9 @@
 name: "Publish APM Python Auto-Instrumentation"
 
 on:
+  push:
+    branches:
+      - NH-100298-docker-scout-autoinst-image
   workflow_dispatch:
 
 permissions:

--- a/image/requirements-nodeps.txt
+++ b/image/requirements-nodeps.txt
@@ -1,1 +1,1 @@
-solarwinds_apm==3.3.3.5
+solarwinds_apm==3.3.2

--- a/image/requirements-nodeps.txt
+++ b/image/requirements-nodeps.txt
@@ -1,1 +1,1 @@
-solarwinds_apm==3.3.2
+solarwinds_apm==3.3.3.5


### PR DESCRIPTION
Adds Docker Scout cves scan to build-publish workflow. Example run with summary: https://github.com/solarwinds/apm-python/actions/runs/13000262293