### PR TITLE
NH-100646 Default OTLP auth header always in lambda

### DIFF
--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -187,13 +187,9 @@ class SolarWindsDistro(BaseDistro):
         """Configure default OTel exporters and propagators"""
         self._log_runtime()
 
-        header_token = None
-        if not SolarWindsApmConfig.calculate_is_lambda():
-            header_token = self._get_token_from_service_key()
-            if not header_token:
-                logger.debug("Setting OTLP export defaults without SWO token")
-        else:
-            logger.debug("Skipping OTLP export headers setdefaults in lambda.")
+        header_token = self._get_token_from_service_key()
+        if not header_token:
+            logger.debug("Setting OTLP export defaults without SWO token")
 
         # If users set OTEL_EXPORTER_OTLP_PROTOCOL
         # as one of Otel SDK's `http/protobuf` or `grpc`,

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -401,8 +401,9 @@ class TestDistro:
         )
         distro.SolarWindsDistro()._configure()
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
-        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
-        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        # Still get set for metrics and logs
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
 
     def test_configure_set_otlp_header_defaults_lambda_invalid_protocol(self, mocker):
         mocker.patch.dict(
@@ -416,8 +417,9 @@ class TestDistro:
         )
         distro.SolarWindsDistro()._configure()
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
-        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
-        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        # Still get set for metrics and logs
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
 
     def test_configure_set_otlp_header_defaults_lambda_valid_protocol(self, mocker):
         mocker.patch.dict(
@@ -430,9 +432,10 @@ class TestDistro:
             }
         )
         distro.SolarWindsDistro()._configure()
-        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
-        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
-        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        # Still get set traces, metrics, logs
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) == f"authorization=Bearer%20foo-token"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
 
     def test_configure_no_env(self, mocker):
         mocker.patch.dict(os.environ, {})

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -52,6 +52,9 @@ class TestDistro:
         if old_otel_ev_lh:
             del os.environ["OTEL_EXPORTER_OTLP_LOGS_HEADERS"]
         old_key = os.environ.get("SW_APM_SERVICE_KEY", None)
+        old_otel_ev_proto = os.environ.get("OTEL_EXPORTER_OTLP_PROTOCOL", None)
+        if old_otel_ev_proto:
+            del os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"]
         old_otel_ev_tp = os.environ.get("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", None)
         if old_otel_ev_tp: 
             del os.environ["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"]
@@ -93,6 +96,8 @@ class TestDistro:
             os.environ["OTEL_EXPORTER_OTLP_METRICS_HEADERS"] = old_otel_ev_mh
         if old_otel_ev_lh:
             os.environ["OTEL_EXPORTER_OTLP_LOGS_HEADERS"] = old_otel_ev_lh
+        if old_otel_ev_proto:
+            os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = old_otel_ev_proto
         if old_otel_ev_tp:
             os.environ["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] = old_otel_ev_tp
         if old_otel_ev_mp:

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -352,6 +352,18 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/traces"
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) == "authorization=Bearer%20foo-token"
 
+    def test_configure_set_otlp_header_defaults_not_lambda_no_header_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_SERVICE_KEY": "",
+            }
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+
     def test_configure_set_otlp_header_defaults_not_lambda_no_protocol(self, mocker):
         mocker.patch.dict(
             os.environ,
@@ -389,6 +401,20 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) == f"authorization=Bearer%20foo-token"
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
+
+    def test_configure_set_otlp_header_defaults_lambda_no_header_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_SERVICE_KEY": "",
+                "AWS_LAMBDA_FUNCTION_NAME": "foo",
+                "LAMBDA_TASK_ROOT": "foo",
+            }
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
 
     def test_configure_set_otlp_header_defaults_lambda_no_protocol(self, mocker):
         mocker.patch.dict(

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -407,6 +407,7 @@ class TestDistro:
             os.environ,
             {
                 "SW_APM_SERVICE_KEY": "",
+                "SW_APM_API_TOKEN": "not-used-for-header",
                 "AWS_LAMBDA_FUNCTION_NAME": "foo",
                 "LAMBDA_TASK_ROOT": "foo",
             }
@@ -420,22 +421,24 @@ class TestDistro:
         mocker.patch.dict(
             os.environ,
             {
-                "SW_APM_SERVICE_KEY": "foo-token:bar-name",
+                "SW_APM_SERVICE_KEY": "not-required-but-here:bar-name",
+                "SW_APM_API_TOKEN": "not-used-for-header",
                 "AWS_LAMBDA_FUNCTION_NAME": "foo",
                 "LAMBDA_TASK_ROOT": "foo",
             }
         )
         distro.SolarWindsDistro()._configure()
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
-        # Still get set for metrics and logs
-        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
-        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
+        # Currently still get set for metrics and logs
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20not-required-but-here"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20not-required-but-here"
 
     def test_configure_set_otlp_header_defaults_lambda_invalid_protocol(self, mocker):
         mocker.patch.dict(
             os.environ,
             {
-                "SW_APM_SERVICE_KEY": "foo-token:bar-name",
+                "SW_APM_SERVICE_KEY": "not-required-but-here:bar-name",
+                "SW_APM_API_TOKEN": "not-used-for-header",
                 "AWS_LAMBDA_FUNCTION_NAME": "foo",
                 "LAMBDA_TASK_ROOT": "foo",
                 OTEL_EXPORTER_OTLP_PROTOCOL: "not-valid",
@@ -443,15 +446,16 @@ class TestDistro:
         )
         distro.SolarWindsDistro()._configure()
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
-        # Still get set for metrics and logs
-        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
-        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
+        # Currently still get set for metrics and logs
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20not-required-but-here"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20not-required-but-here"
 
     def test_configure_set_otlp_header_defaults_lambda_valid_protocol(self, mocker):
         mocker.patch.dict(
             os.environ,
             {
-                "SW_APM_SERVICE_KEY": "foo-token:bar-name",
+                "SW_APM_SERVICE_KEY": "not-required-but-here:bar-name",
+                "SW_APM_API_TOKEN": "not-used-for-header",
                 "AWS_LAMBDA_FUNCTION_NAME": "foo",
                 "LAMBDA_TASK_ROOT": "foo",
                 OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf",
@@ -459,9 +463,9 @@ class TestDistro:
         )
         distro.SolarWindsDistro()._configure()
         # Still get set traces, metrics, logs
-        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) == f"authorization=Bearer%20foo-token"
-        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
-        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) == f"authorization=Bearer%20not-required-but-here"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20not-required-but-here"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20not-required-but-here"
 
     def test_configure_no_env(self, mocker):
         mocker.patch.dict(os.environ, {})


### PR DESCRIPTION
Simplifies APM Python custom distro by removing one unnecessary `is_lambda` check.

Change is that now, in lambda environment, default values for `OTEL_EXPORTER_OTLP_(TRACES|METRICS|LOGS)_HEADERS` always get set to `f"authorization=Bearer%20{header_token}"` even if `header_token` is empty, which should normally be the case. This does not affect export to otel-collector layer on localhost -- see ticket comment for more test info. This is again for default values, so user can always override with their own `HEADERS` set in environment.

Works the same as before outside of lambda.

Also adds more unit tests and clarifies existing ones.