### PR TITLE
NH-100646 Internal service_key updates more general

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -127,12 +127,11 @@ class SolarWindsApmConfig:
             self.agent_enabled,
             otel_resource,
         )
-        if not self.is_lambda:
-            self.__config["service_key"] = self._update_service_key_name(
-                self.agent_enabled,
-                self.__config["service_key"],
-                self.service_name,
-            )
+        self.__config["service_key"] = self._update_service_key_name(
+            self.agent_enabled,
+            self.__config["service_key"],
+            self.service_name,
+        )
 
         # Update and apply logging settings to Python logger
         self.update_log_settings()
@@ -516,8 +515,15 @@ class SolarWindsApmConfig:
     ) -> str:
         """Update service key with service name"""
         if agent_enabled and service_key and service_name:
-            # Only update if service_name and service_key exist and non-empty.
-            # When agent_enabled, assume service_key is formatted correctly.
+            # Only update if service_name and service_key exist and non-empty,
+            # and service_key in correct format.
+            key_parts = service_key.split(":")
+            if len(key_parts) < 2:
+                logger.debug(
+                    "Service key is not in the correct format to update its own service name. Skipping."
+                )
+                return service_key
+
             return ":".join([service_key.split(":")[0], service_name])
 
         # Else no need to update service_key when not reporting

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -891,6 +891,43 @@ class TestSolarWindsApmConfig:
         )
         assert result == "valid_key_with:bar-service"
 
+    def test__update_service_key_name_agent_enabled_and_service_name_ok_but_service_key_missing(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        result = test_config._update_service_key_name(
+            True,
+            None,
+            "bar-service"
+        )
+        assert result == None
+
+    def test__update_service_key_name_agent_enabled_and_service_name_ok_but_service_key_empty(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        result = test_config._update_service_key_name(
+            True,
+            "",
+            "bar-service"
+        )
+        assert result == ""
+
+    def test__update_service_key_name_agent_enabled_and_service_name_ok_but_service_key_no_delimiter(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        result = test_config._update_service_key_name(
+            True,
+            "weird-key-no-delimiter",
+            "bar-service"
+        )
+        assert result == "weird-key-no-delimiter"
+
+    def test__update_service_key_name_agent_enabled_and_service_name_ok_service_key_multiple_delimiter(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        result = test_config._update_service_key_name(
+            True,
+            "weird-key:with:2-delimiters",
+            "bar-service"
+        )
+        # Updates everything after first delim
+        assert result == "weird-key:bar-service"
+
     def test_update_log_settings(self, mocker):
         mock_log_filepath = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.update_log_filepath"

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -898,7 +898,7 @@ class TestSolarWindsApmConfig:
             None,
             "bar-service"
         )
-        assert result == None
+        assert result is None
 
     def test__update_service_key_name_agent_enabled_and_service_name_ok_but_service_key_empty(self):
         test_config = apm_config.SolarWindsApmConfig()


### PR DESCRIPTION
Changes APM-internal service_key updates to be more general. Removes is_lambda check so that `_update_service_key_name` is always called. Updates that function to avoid `IndexError` for cases like when in Lambda and `SW_APM_SERVICE_KEY` is unnecessarily set as a weird value. Adds missing test coverage.