### PR TITLE
NH-98561 Add ApmConfig.calculate_is_legacy

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -246,6 +246,20 @@ class SolarWindsApmConfig:
         )
 
     @classmethod
+    def calculate_is_legacy(cls) -> bool:
+        """Checks if agent is running in a legacy environment.
+        Order of precedence: Environment Variable > config file > default False
+        """
+        is_legacy = False
+        cnf_dict = cls.get_cnf_dict()
+        if cnf_dict:
+            is_legacy = cls.convert_to_bool(cnf_dict.get("legacy", is_legacy))
+        is_legacy = cls.convert_to_bool(
+            os.environ.get("SW_APM_LEGACY", is_legacy)
+        )
+        return is_legacy
+
+    @classmethod
     def calculate_is_lambda(cls) -> bool:
         """Checks if agent is running in an AWS Lambda environment."""
         if os.environ.get("AWS_LAMBDA_FUNCTION_NAME") and os.environ.get(
@@ -730,13 +744,14 @@ class SolarWindsApmConfig:
         )
         return value if value is not None else default
 
-    def get_cnf_dict(self) -> Any:
+    @classmethod
+    def get_cnf_dict(cls) -> Any:
         """Load Python dict from confg file (json), if any"""
         cnf_filepath = os.environ.get("SW_APM_CONFIG_FILE")
         cnf_dict = None
 
         if not cnf_filepath:
-            cnf_filepath = self._CONFIG_FILE_DEFAULT
+            cnf_filepath = cls._CONFIG_FILE_DEFAULT
             if not os.path.isfile(cnf_filepath):
                 logger.debug("No config file at %s; skipping", cnf_filepath)
                 return cnf_dict

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -248,16 +248,16 @@ class SolarWindsApmConfig:
     @classmethod
     def calculate_is_legacy(cls) -> bool:
         """Checks if agent is running in a legacy environment.
+        Invalid boolean values are ignored.
         Order of precedence: Environment Variable > config file > default False
         """
         is_legacy = False
         cnf_dict = cls.get_cnf_dict()
         if cnf_dict:
-            is_legacy = cls.convert_to_bool(cnf_dict.get("legacy", is_legacy))
-        is_legacy = cls.convert_to_bool(
-            os.environ.get("SW_APM_LEGACY", is_legacy)
-        )
-        return is_legacy
+            cnf_legacy = cls.convert_to_bool(cnf_dict.get("legacy"))
+            is_legacy = cnf_legacy if cnf_legacy is not None else is_legacy
+        env_legacy = cls.convert_to_bool(os.environ.get("SW_APM_LEGACY"))
+        return env_legacy if env_legacy is not None else is_legacy
 
     @classmethod
     def calculate_is_lambda(cls) -> bool:

--- a/tests/unit/test_apm_config/test_apm_config_is_legacy.py
+++ b/tests/unit/test_apm_config/test_apm_config_is_legacy.py
@@ -17,6 +17,10 @@ class TestSolarWindsApmConfigIsLegacy:
         )
         assert SolarWindsApmConfig.calculate_is_legacy() is False
 
+    def test_calculate_is_legacy_with_env_var_not_boolean(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "foo-bar"})
+        assert SolarWindsApmConfig.calculate_is_legacy() is False
+
     def test_calculate_is_legacy_with_env_var_false(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "false"})
         assert SolarWindsApmConfig.calculate_is_legacy() is False
@@ -24,6 +28,13 @@ class TestSolarWindsApmConfigIsLegacy:
     def test_calculate_is_legacy_with_env_var_true(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "true"})
         assert SolarWindsApmConfig.calculate_is_legacy() is True
+
+    def test_calculate_is_legacy_with_config_not_boolean(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "foo-bar"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is False
 
     def test_calculate_is_legacy_with_config_false(self, mocker):
         mocker.patch(
@@ -38,6 +49,14 @@ class TestSolarWindsApmConfigIsLegacy:
             return_value={"legacy": "true"},
         )
         assert SolarWindsApmConfig.calculate_is_legacy() is True
+
+    def test_calculate_is_legacy_with_config_not_bool_env_var_not_bool(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "foo-bar"})
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "foo-bar"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is False
 
     def test_calculate_is_legacy_with_config_false_env_var_false(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "false"})
@@ -55,6 +74,14 @@ class TestSolarWindsApmConfigIsLegacy:
         )
         assert SolarWindsApmConfig.calculate_is_legacy() is True
 
+    def test_calculate_is_legacy_with_config_not_bool_env_var_true(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "true"})
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "foo-bar"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is True
+
     def test_calculate_is_legacy_with_config_true_env_var_false(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "false"})
         mocker.patch(
@@ -62,6 +89,14 @@ class TestSolarWindsApmConfigIsLegacy:
             return_value={"legacy": "true"},
         )
         assert SolarWindsApmConfig.calculate_is_legacy() is False
+
+    def test_calculate_is_legacy_with_config_true_env_var_not_bool(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "foo-bar"})
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "true"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is True
 
     def test_calculate_is_legacy_with_config_true_env_var_true(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "true"})

--- a/tests/unit/test_apm_config/test_apm_config_is_legacy.py
+++ b/tests/unit/test_apm_config/test_apm_config_is_legacy.py
@@ -1,0 +1,72 @@
+# © 2025 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+import os
+import pytest
+
+from solarwinds_apm.apm_config import SolarWindsApmConfig
+
+class TestSolarWindsApmConfigIsLegacy:
+    def test_calculate_is_legacy_default(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={}
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is False
+
+    def test_calculate_is_legacy_with_env_var_false(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "false"})
+        assert SolarWindsApmConfig.calculate_is_legacy() is False
+
+    def test_calculate_is_legacy_with_env_var_true(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "true"})
+        assert SolarWindsApmConfig.calculate_is_legacy() is True
+
+    def test_calculate_is_legacy_with_config_false(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "false"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is False
+
+    def test_calculate_is_legacy_with_config_true(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "true"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is True
+
+    def test_calculate_is_legacy_with_config_false_env_var_false(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "false"})
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "false"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is False
+
+    def test_calculate_is_legacy_with_config_false_env_var_true(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "true"})
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "false"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is True
+
+    def test_calculate_is_legacy_with_config_true_env_var_false(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "false"})
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "true"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is False
+
+    def test_calculate_is_legacy_with_config_true_env_var_true(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "true"})
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "true"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is True


### PR DESCRIPTION
Note: this will merge into epic feature branch `NH-79025-otlp-by-default`.

Adds first parts for APM Python to support `SW_APM_LEGACY` by reading from environment variable (highest precedence) or `legacy` in JSON config file, else default `False`. APM Python does not use this for anything yet.

Why are `calculate_is_legacy` and now `get_cnf_dict` classmethods in ApmConfig? Because:
1. Distro needs them to change its `setdefault` calls in a future PR
2. Distro and Configurator can't share one ApmConfig due to lifecycles when [sitecustomize](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/748c92592d2f476199667629defce4a3bca9ecc9/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py#L37-L39) is used for auto-instrumentation. So the config file does get read twice now at instrumented service startup.