### PR TITLE
NH-98561 Add ApmConfig support for SW_APM_LEGACY

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -113,6 +113,7 @@ class SolarWindsApmConfig:
             "transaction_name": None,
             "export_logs_enabled": False,
             "export_metrics_enabled": False,
+            "legacy": False,
         }
         self.is_lambda = self.calculate_is_lambda()
         self.lambda_function_name = os.environ.get("AWS_LAMBDA_FUNCTION_NAME")
@@ -961,7 +962,11 @@ class SolarWindsApmConfig:
                 self.__config[key] = val
             elif keys == ["transaction_name"]:
                 self.__config[key] = val
-            elif keys in [["export_logs_enabled"], ["export_metrics_enabled"]]:
+            elif keys in [
+                ["export_logs_enabled"],
+                ["export_metrics_enabled"],
+                ["legacy"],
+            ]:
                 val = self.convert_to_bool(val)
                 if val not in (True, False):
                     raise ValueError

--- a/tests/unit/test_apm_config/fixtures/cnf_dict.py
+++ b/tests/unit/test_apm_config/fixtures/cnf_dict.py
@@ -25,6 +25,7 @@ def fixture_cnf_dict():
         "logTraceId": "always",
         "proxy": "http://foo-bar",
         "exportLogsEnabled": True,
+        "legacy": True,
     }
 
 @pytest.fixture
@@ -52,6 +53,7 @@ def fixture_cnf_dict_enabled_false():
         "logTraceId": "always",
         "proxy": "http://foo-bar",
         "exportLogsEnabled": False,
+        "legacy": False,
     }
 
 @pytest.fixture
@@ -78,4 +80,5 @@ def fixture_cnf_dict_enabled_false_mixed_case():
         "reporterFileSingle": 2,
         "proxy": "http://foo-bar",
         "exportLogsEnabled": "fALsE",
+        "legacy": "tRUe",
     }

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -62,6 +62,9 @@ class TestSolarWindsApmConfig:
         old_expt_metrics = os.environ.get("SW_APM_EXPORT_METRICS_ENABLED", None)
         if old_expt_metrics:
             del os.environ["SW_APM_EXPORT_METRICS_ENABLED"]
+        old_legacy = os.environ.get("SW_APM_LEGACY", None)
+        if old_legacy:
+            del os.environ["SW_APM_LEGACY"]
 
         # Wait for test
         yield
@@ -85,6 +88,8 @@ class TestSolarWindsApmConfig:
             os.environ["SW_APM_EXPORT_LOGS_ENABLED"] = old_expt_logs
         if old_expt_metrics:
             os.environ["SW_APM_EXPORT_METRICS_ENABLED"] = old_expt_metrics
+        if old_legacy:
+            os.environ["SW_APM_LEGACY"] = old_legacy
 
     def _mock_service_key(self, mocker, service_key):
         mocker.patch.dict(os.environ, {
@@ -853,6 +858,67 @@ class TestSolarWindsApmConfig:
         test_config = apm_config.SolarWindsApmConfig()
         test_config._set_config_value("export_metrics_enabled", "tRUe")
         assert test_config.get("export_metrics_enabled") == True
+        assert "Ignore config option" not in caplog.text
+
+    def test_set_config_value_default_legacy(
+        self,
+    ):
+        test_config = apm_config.SolarWindsApmConfig()
+        assert test_config.get("legacy") == False
+
+    def test_set_config_value_ignore_legacy(
+        self,
+        caplog,
+        setup_caplog,
+        mock_env_vars,
+    ):
+        test_config = apm_config.SolarWindsApmConfig()
+        test_config._set_config_value("legacy", "not-valid")
+        assert test_config.get("legacy") == False
+        assert "Ignore config option" in caplog.text
+
+    def test_set_config_value_set_legacy_false(
+        self,
+        caplog,
+        setup_caplog,
+        mock_env_vars,
+    ):
+        test_config = apm_config.SolarWindsApmConfig()
+        test_config._set_config_value("legacy", "false")
+        assert test_config.get("legacy") == False
+        assert "Ignore config option" not in caplog.text
+
+    def test_set_config_value_set_legacy_false_mixed_case(
+        self,
+        caplog,
+        setup_caplog,
+        mock_env_vars,
+    ):
+        test_config = apm_config.SolarWindsApmConfig()
+        test_config._set_config_value("legacy", "fALsE")
+        assert test_config.get("legacy") == False
+        assert "Ignore config option" not in caplog.text
+
+    def test_set_config_value_set_legacy_true(
+        self,
+        caplog,
+        setup_caplog,
+        mock_env_vars,
+    ):
+        test_config = apm_config.SolarWindsApmConfig()
+        test_config._set_config_value("legacy", "true")
+        assert test_config.get("legacy") == True
+        assert "Ignore config option" not in caplog.text
+
+    def test_set_config_value_set_legacy_true_mixed_case(
+        self,
+        caplog,
+        setup_caplog,
+        mock_env_vars,
+    ):
+        test_config = apm_config.SolarWindsApmConfig()
+        test_config._set_config_value("legacy", "tRUe")
+        assert test_config.get("legacy") == True
         assert "Ignore config option" not in caplog.text
 
     def test__update_service_key_name_not_agent_enabled(self):

--- a/tests/unit/test_apm_config/test_apm_config_cnf_file.py
+++ b/tests/unit/test_apm_config/test_apm_config_cnf_file.py
@@ -144,6 +144,7 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("reporter_file_single") == 2
         assert resulting_config.get("proxy") == "http://foo-bar"
         assert resulting_config.get("export_logs_enabled") == True
+        assert resulting_config.get("legacy") == True
 
         # update_transaction_filters was called
         mock_update_txn_filters.assert_called_once_with(fixture_cnf_dict)
@@ -190,6 +191,7 @@ class TestSolarWindsApmConfigCnfFile:
             "reporterFileSingle": "foo",
             "proxy": "foo",
             "exportLogsEnabled": "foo",
+            "legacy": "foo",
         }
         mock_get_cnf_dict = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict"
@@ -232,6 +234,7 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("reporter_file_single") == 0
         assert resulting_config.get("proxy") == ""
         assert resulting_config.get("export_logs_enabled") == False
+        assert resulting_config.get("legacy") == False
         # Meanwhile these are pretty open
         assert resulting_config.get("collector") == "False"
         assert resulting_config.get("hostname_alias") == "False"
@@ -277,6 +280,7 @@ class TestSolarWindsApmConfigCnfFile:
             "SW_APM_REPORTER_FILE_SINGLE": "3",
             "SW_APM_PROXY": "http://other-foo-bar",
             "SW_APM_EXPORT_LOGS_ENABLED": "true",
+            "SW_APM_LEGACY": "true",
         })
         mock_update_txn_filters = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.update_transaction_filters"
@@ -328,6 +332,7 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("reporter_file_single") == 3
         assert resulting_config.get("proxy") == "http://other-foo-bar"
         assert resulting_config.get("export_logs_enabled") == True
+        assert resulting_config.get("legacy") == True
 
         # Restore old collector
         if old_collector:
@@ -366,6 +371,7 @@ class TestSolarWindsApmConfigCnfFile:
             "SW_APM_REPORTER_FILE_SINGLE": "other-foo-bar",
             "SW_APM_PROXY": "other-foo-bar",
             "SW_APM_EXPORT_LOGS_ENABLED": "not-a-bool",
+            "SW_APM_LEGACY": "not-a-bool",
         })
         mock_update_txn_filters = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.update_transaction_filters"
@@ -414,6 +420,7 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("reporter_file_single") == 2
         assert resulting_config.get("proxy") == "http://foo-bar"
         assert resulting_config.get("export_logs_enabled") == True
+        assert resulting_config.get("legacy") == True
 
         # These are still valid, so env_var > cnf_file
         assert resulting_config.get("collector") == "False"


### PR DESCRIPTION
Note: this will merge into epic feature branch `NH-79025-otlp-by-default`.

Adds ApmConfig support for reading `SW_APM_LEGACY` env var and `legacy` in JSON config file. Default is `False`. Just stores the value internally for now.

This is needed for future PRs to e.g. decide when to init components like Reporter and InboundMetricsSpanProcessor. This is similar to https://github.com/solarwinds/apm-python/pull/497 but to make the value available internally to the Configurator and the rest of APM's life cycle (see also [sitecustomize](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/748c92592d2f476199667629defce4a3bca9ecc9/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py#L37-L39) used for auto-instrumentation).