### PR TITLE
NH-98561 Update OTLP setdefaults with legacy check and cleanup

### DIFF
--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -163,6 +163,7 @@ class SolarWindsDistro(BaseDistro):
 
         # setdefaults for OTLP export if protocol is unset or valid,
         # with the exception of OTEL_TRACES_EXPORTER if legacy.
+        # Does not setdefaults if invalid protocol.
         # All values can still be configured by user (SolarWindsApmConfig).
         environ.setdefault(
             OTEL_EXPORTER_OTLP_PROTOCOL,
@@ -200,8 +201,8 @@ class SolarWindsDistro(BaseDistro):
                 )
 
             else:
-                logger.debug(
-                    "Invalid OTLP export protocol. Skipping setting of default export configuration."
+                logger.warning(
+                    "Invalid OTLP export protocol configured. Skipping setting of default export configuration."
                 )
 
     def load_instrumentor(self, entry_point: EntryPoint, **kwargs):

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -13,8 +13,6 @@ from os import environ
 from typing import Any
 
 from opentelemetry.environment_variables import (
-    OTEL_LOGS_EXPORTER,
-    OTEL_METRICS_EXPORTER,
     OTEL_PROPAGATORS,
     OTEL_TRACES_EXPORTER,
 )
@@ -24,18 +22,7 @@ from opentelemetry.instrumentation.logging.environment_variables import (
     OTEL_PYTHON_LOG_FORMAT,
 )
 from opentelemetry.instrumentation.version import __version__ as inst_version
-from opentelemetry.sdk.environment_variables import (
-    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
-    OTEL_EXPORTER_OTLP_LOGS_HEADERS,
-    OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
-    OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
-    OTEL_EXPORTER_OTLP_METRICS_HEADERS,
-    OTEL_EXPORTER_OTLP_METRICS_PROTOCOL,
-    OTEL_EXPORTER_OTLP_PROTOCOL,
-    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
-    OTEL_EXPORTER_OTLP_TRACES_HEADERS,
-    OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
-)
+from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_PROTOCOL
 from opentelemetry.sdk.version import __version__ as sdk_version
 from opentelemetry.util._importlib_metadata import EntryPoint
 
@@ -99,112 +86,69 @@ class SolarWindsDistro(BaseDistro):
             return None
         return key_parts[0]
 
-    def _configure_logs_export_env_defaults(
+    def _configure_otlp_env_defaults(
+        self,
+        signal_type: str,
+        header_token: str,
+        otlp_protocol: str,
+    ) -> None:
+        """Configure env defaults for OTLP signal export by HTTP or gRPC to SWO"""
+        protocol_env_var = f"OTEL_EXPORTER_OTLP_{signal_type.upper()}_PROTOCOL"
+        exporter_env_var = f"OTEL_{signal_type.upper()}_EXPORTER"
+        endpoint_env_var = f"OTEL_EXPORTER_OTLP_{signal_type.upper()}_ENDPOINT"
+        headers_env_var = f"OTEL_EXPORTER_OTLP_{signal_type.upper()}_HEADERS"
+
+        environ.setdefault(protocol_env_var, otlp_protocol)
+        environ.setdefault(
+            exporter_env_var, _EXPORTER_BY_OTLP_PROTOCOL[otlp_protocol]
+        )
+        environ.setdefault(
+            endpoint_env_var,
+            f"{INTL_SWO_DEFAULT_OTLP_COLLECTOR}/v1/{signal_type}",
+        )
+        if header_token:
+            environ.setdefault(
+                headers_env_var, f"authorization=Bearer%20{header_token}"
+            )
+
+    def _configure_logs_export_otlp_env_defaults(
         self,
         header_token: str,
         otlp_protocol: str,
     ) -> None:
         """Configure env defaults for OTLP logs signal export by HTTP or gRPC to SWO"""
-        if otlp_protocol in _EXPORTER_BY_OTLP_PROTOCOL:
-            environ.setdefault(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL, otlp_protocol)
-            environ.setdefault(
-                OTEL_LOGS_EXPORTER, _EXPORTER_BY_OTLP_PROTOCOL[otlp_protocol]
-            )
-            environ.setdefault(
-                OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
-                f"{INTL_SWO_DEFAULT_OTLP_COLLECTOR}/v1/logs",
-            )
-            if header_token:
-                environ.setdefault(
-                    OTEL_EXPORTER_OTLP_LOGS_HEADERS,
-                    f"authorization=Bearer%20{header_token}",
-                )
-        else:
-            logger.debug(
-                "Tried to setdefault for OTLP logs with invalid protocol. Skipping."
-            )
+        self._configure_otlp_env_defaults("logs", header_token, otlp_protocol)
 
-    def _configure_metrics_export_env_defaults(
+    def _configure_metrics_export_otlp_env_defaults(
         self,
         header_token: str,
         otlp_protocol: str,
     ) -> None:
         """Configure env defaults for OTLP metrics signal export by HTTP or gRPC to SWO"""
-        if otlp_protocol in _EXPORTER_BY_OTLP_PROTOCOL:
-            environ.setdefault(
-                OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, otlp_protocol
-            )
-            environ.setdefault(
-                OTEL_METRICS_EXPORTER,
-                _EXPORTER_BY_OTLP_PROTOCOL[otlp_protocol],
-            )
-            environ.setdefault(
-                OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
-                f"{INTL_SWO_DEFAULT_OTLP_COLLECTOR}/v1/metrics",
-            )
-            if header_token:
-                environ.setdefault(
-                    OTEL_EXPORTER_OTLP_METRICS_HEADERS,
-                    f"authorization=Bearer%20{header_token}",
-                )
-        else:
-            logger.debug(
-                "Tried to setdefault for OTLP metrics with invalid protocol. Skipping."
-            )
+        self._configure_otlp_env_defaults(
+            "metrics", header_token, otlp_protocol
+        )
 
-    def _configure_traces_export_env_defaults(
+    def _configure_traces_export_otlp_env_defaults(
         self,
         header_token: str,
         otlp_protocol: Any = None,
     ) -> None:
         """Configure env defaults for OTLP traces signal export by APM protocol
         to SWO, else follow provided OTLP protocol (HTTP or gRPC)"""
-        if otlp_protocol in _EXPORTER_BY_OTLP_PROTOCOL:
-            environ.setdefault(
-                OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, otlp_protocol
-            )
-            environ.setdefault(
-                OTEL_TRACES_EXPORTER, _EXPORTER_BY_OTLP_PROTOCOL[otlp_protocol]
-            )
-            environ.setdefault(
-                OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
-                f"{INTL_SWO_DEFAULT_OTLP_COLLECTOR}/v1/traces",
-            )
-            if header_token:
-                environ.setdefault(
-                    OTEL_EXPORTER_OTLP_TRACES_HEADERS,
-                    f"authorization=Bearer%20{header_token}",
-                )
-        else:
-            logger.debug(
-                "Called to setdefault for OTLP traces with empty or invalid protocol. Defaulting to SolarWinds exporter."
-            )
-            environ.setdefault(
-                OTEL_TRACES_EXPORTER, INTL_SWO_DEFAULT_TRACES_EXPORTER
-            )
-
-    def _configure(self, **kwargs):
-        """Configure default OTel exporters and propagators"""
-        self._log_runtime()
-
-        header_token = self._get_token_from_service_key()
-        if not header_token:
-            logger.debug("Setting OTLP export defaults without SWO token")
-
-        # If users set OTEL_EXPORTER_OTLP_PROTOCOL
-        # as one of Otel SDK's `http/protobuf` or `grpc`,
-        # then the matching exporters are mapped
-        otlp_protocol = environ.get(OTEL_EXPORTER_OTLP_PROTOCOL)
-        # For traces, the default is SWO APM - see helper
-        self._configure_traces_export_env_defaults(header_token, otlp_protocol)
-        # For metrics and logs, the default is `http/protobuf`
-        if otlp_protocol not in _EXPORTER_BY_OTLP_PROTOCOL:
-            otlp_protocol = "http/protobuf"
-        self._configure_logs_export_env_defaults(header_token, otlp_protocol)
-        self._configure_metrics_export_env_defaults(
-            header_token, otlp_protocol
+        self._configure_otlp_env_defaults(
+            "traces", header_token, otlp_protocol
         )
 
+    def _configure(self, **kwargs):
+        """Configure default OTel components for APM Python.
+
+        This is a sitecustomize callee of the opentelemetry-instrument entrypoint.
+        """
+        self._log_runtime()
+
+        # Propagators, log format defaults and semconv the same
+        # whether APM Python uses OTLP and/or legacy mode
         environ.setdefault(
             OTEL_PROPAGATORS, ",".join(INTL_SWO_DEFAULT_PROPAGATORS)
         )
@@ -213,10 +157,52 @@ class SolarWindsDistro(BaseDistro):
             OTEL_PYTHON_LOG_FORMAT,
             "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] [trace_id=%(otelTraceID)s span_id=%(otelSpanID)s trace_flags=%(otelTraceSampled)02d resource.service.name=%(otelServiceName)s] - %(message)s",
         )
-
         # TODO: Support other signal types when available
         # Always opt into new semconv for all instrumentors (if supported)
         environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = self.get_semconv_opt_in()
+
+        # setdefaults for OTLP export if protocol is unset or valid,
+        # with the exception of OTEL_TRACES_EXPORTER if legacy.
+        # All values can still be configured by user (SolarWindsApmConfig).
+        environ.setdefault(
+            OTEL_EXPORTER_OTLP_PROTOCOL,
+            "http/protobuf",
+        )
+        # Protocol is the above default or what user has set
+        otlp_protocol = environ.get(OTEL_EXPORTER_OTLP_PROTOCOL)
+
+        is_legacy = SolarWindsApmConfig.calculate_is_legacy()
+
+        if otlp_protocol:
+            if otlp_protocol in _EXPORTER_BY_OTLP_PROTOCOL:
+                header_token = self._get_token_from_service_key()
+                if not header_token:
+                    logger.debug(
+                        "Setting OTLP export defaults without SWO token"
+                    )
+
+                if is_legacy:
+                    environ.setdefault(
+                        OTEL_TRACES_EXPORTER, INTL_SWO_DEFAULT_TRACES_EXPORTER
+                    )
+                else:
+                    self._configure_traces_export_otlp_env_defaults(
+                        header_token, otlp_protocol
+                    )
+
+                # We do OTLP export setdefault if legacy or not
+                # in case SW_APM_EXPORT_METRICS_ENABLED
+                self._configure_logs_export_otlp_env_defaults(
+                    header_token, otlp_protocol
+                )
+                self._configure_metrics_export_otlp_env_defaults(
+                    header_token, otlp_protocol
+                )
+
+            else:
+                logger.debug(
+                    "Invalid OTLP export protocol. Skipping setting of default export configuration."
+                )
 
     def load_instrumentor(self, entry_point: EntryPoint, **kwargs):
         """Takes a collection of instrumentation entry points

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -497,7 +497,32 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
 
-    def test_configure_no_env_invalid_protocol_is_legacy(self, mocker):
+    def test_configure_no_env_no_protocol_is_legacy_no_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_LEGACY": "true",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ[OTEL_TRACES_EXPORTER] == "solarwinds_exporter"
+        assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_http"
+        assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_http"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        # Headers not set without API token
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+
+    def test_configure_no_env_invalid_protocol_is_legacy_no_token(self, mocker):
         mocker.patch.dict(
             os.environ,
             {
@@ -525,6 +550,281 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+
+    def test_configure_no_env_valid_protocol_http_is_legacy_no_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf",
+                "SW_APM_LEGACY": "true",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ[OTEL_TRACES_EXPORTER] == "solarwinds_exporter"
+        assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_http"
+        assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_http"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        # Headers not set without API token
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+
+    def test_configure_no_env_valid_protocol_grpc_is_legacy_no_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                OTEL_EXPORTER_OTLP_PROTOCOL: "grpc",
+                "SW_APM_LEGACY": "true",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ[OTEL_TRACES_EXPORTER] == "solarwinds_exporter"
+        assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_grpc"
+        assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        # Headers not set without API token
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+
+    def test_configure_no_env_no_protocol_is_legacy_invalid_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_LEGACY": "true",
+                "SW_APM_SERVICE_KEY": "invalid-token",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ[OTEL_TRACES_EXPORTER] == "solarwinds_exporter"
+        assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_http"
+        assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_http"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        # Headers not set without API token
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+
+    def test_configure_no_env_invalid_protocol_is_legacy_invalid_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                OTEL_EXPORTER_OTLP_PROTOCOL: "foo",
+                "SW_APM_LEGACY": "true",
+                "SW_APM_SERVICE_KEY": "invalid-token",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        # No exporter defaults get set
+        assert os.environ.get(OTEL_TRACES_EXPORTER) is None
+        assert os.environ.get(OTEL_METRICS_EXPORTER) is None
+        assert os.environ.get(OTEL_LOGS_EXPORTER) is None
+        assert os.environ.get(OTEL_TRACES_EXPORTER) is None
+        assert os.environ.get(OTEL_METRICS_EXPORTER) is None
+        assert os.environ.get(OTEL_LOGS_EXPORTER) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+
+    def test_configure_no_env_valid_protocol_http_is_legacy_invalid_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf",
+                "SW_APM_LEGACY": "true",
+                "SW_APM_SERVICE_KEY": "invalid-token",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ[OTEL_TRACES_EXPORTER] == "solarwinds_exporter"
+        assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_http"
+        assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_http"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        # Headers not set without API token
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+
+    def test_configure_no_env_valid_protocol_grpc_is_legacy_invalid_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                OTEL_EXPORTER_OTLP_PROTOCOL: "grpc",
+                "SW_APM_LEGACY": "true",
+                "SW_APM_SERVICE_KEY": "invalid-token",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ[OTEL_TRACES_EXPORTER] == "solarwinds_exporter"
+        assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_grpc"
+        assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        # Headers not set without API token
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+
+    def test_configure_no_env_no_protocol_is_legacy_valid_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_LEGACY": "true",
+                "SW_APM_SERVICE_KEY": "foo-token:bar-service",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        # Traces defaults set for APM-proto
+        assert os.environ[OTEL_TRACES_EXPORTER] == "solarwinds_exporter"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        # Metrics, logs defaults set for OTLP
+        assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_http"
+        assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_http"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
+
+    def test_configure_no_env_invalid_protocol_is_legacy_valid_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                OTEL_EXPORTER_OTLP_PROTOCOL: "foo",
+                "SW_APM_LEGACY": "true",
+                "SW_APM_SERVICE_KEY": "foo-token:bar-service",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        # No exporter defaults get set
+        assert os.environ.get(OTEL_TRACES_EXPORTER) is None
+        assert os.environ.get(OTEL_METRICS_EXPORTER) is None
+        assert os.environ.get(OTEL_LOGS_EXPORTER) is None
+        assert os.environ.get(OTEL_TRACES_EXPORTER) is None
+        assert os.environ.get(OTEL_METRICS_EXPORTER) is None
+        assert os.environ.get(OTEL_LOGS_EXPORTER) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+
+    def test_configure_no_env_valid_protocol_http_is_legacy_valid_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf",
+                "SW_APM_LEGACY": "true",
+                "SW_APM_SERVICE_KEY": "foo-token:bar-service",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        # Traces defaults set for APM-proto
+        assert os.environ[OTEL_TRACES_EXPORTER] == "solarwinds_exporter"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        # Metrics, logs defaults set for OTLP
+        assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_http"
+        assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_http"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
+
+    def test_configure_no_env_valid_protocol_grpc_is_legacy_valid_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                OTEL_EXPORTER_OTLP_PROTOCOL: "grpc",
+                "SW_APM_LEGACY": "true",
+                "SW_APM_SERVICE_KEY": "foo-token:bar-service",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        # Traces defaults set for APM-proto
+        assert os.environ[OTEL_TRACES_EXPORTER] == "solarwinds_exporter"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        # Metrics, logs defaults set for OTLP
+        assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_grpc"
+        assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
 
     def test_configure_no_env_valid_protocol_http_missing_token(self, mocker):
         mocker.patch.dict(

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -252,7 +252,7 @@ class TestDistro:
         )
         assert distro.SolarWindsDistro()._get_token_from_service_key() == "foo-token"
 
-    def test__configure_logs_export_env_defaults_valid_protocol_http(self, mocker):
+    def test__configure_logs_export_otlp_env_defaults_valid_protocol_http(self, mocker):
         distro.SolarWindsDistro()._configure_logs_export_otlp_env_defaults(
             "foo-token",
             "http/protobuf",
@@ -262,7 +262,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == "authorization=Bearer%20foo-token"
 
-    def test__configure_logs_export_env_defaults_valid_protocol_grpc(self, mocker):
+    def test__configure_logs_export_otlp_env_defaults_valid_protocol_grpc(self, mocker):
         distro.SolarWindsDistro()._configure_logs_export_otlp_env_defaults(
             "foo-token",
             "grpc",
@@ -272,7 +272,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == "authorization=Bearer%20foo-token"
 
-    def test__configure_metrics_export_env_defaults_valid_protocol_http(self, mocker):
+    def test__configure_metrics_export_otlp_env_defaults_valid_protocol_http(self, mocker):
         distro.SolarWindsDistro()._configure_metrics_export_otlp_env_defaults(
             "foo-token",
             "http/protobuf",
@@ -282,7 +282,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == "authorization=Bearer%20foo-token"
 
-    def test__configure_metrics_export_env_defaults_valid_protocol_grpc(self, mocker):
+    def test__configure_metrics_export_otlp_env_defaults_valid_protocol_grpc(self, mocker):
         distro.SolarWindsDistro()._configure_metrics_export_otlp_env_defaults(
             "foo-token",
             "grpc",
@@ -292,7 +292,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == "authorization=Bearer%20foo-token"
 
-    def test__configure_traces_export_env_defaults_valid_protocol_http(self, mocker):
+    def test__configure_traces_export_otlp_env_defaults_valid_protocol_http(self, mocker):
         distro.SolarWindsDistro()._configure_traces_export_otlp_env_defaults(
             "foo-token",
             "http/protobuf",
@@ -302,7 +302,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/traces"
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) == "authorization=Bearer%20foo-token"
 
-    def test__configure_traces_export_env_defaults_valid_protocol_grpc(self, mocker):
+    def test__configure_traces_export_otlp_env_defaults_valid_protocol_grpc(self, mocker):
         distro.SolarWindsDistro()._configure_traces_export_otlp_env_defaults(
             "foo-token",
             "grpc",
@@ -433,6 +433,16 @@ class TestDistro:
         assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_http"
         assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_http"
         assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/traces"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        # Headers not set without API token
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
 
     def test_configure_env_exporter(self, mocker):
         mocker.patch.dict(
@@ -444,11 +454,23 @@ class TestDistro:
                 }
         )
         distro.SolarWindsDistro()._configure()
-        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        # User configurations respected
         assert os.environ[OTEL_TRACES_EXPORTER] == "foobar"
         assert os.environ[OTEL_METRICS_EXPORTER] == "baz"
         assert os.environ[OTEL_LOGS_EXPORTER] == "qux"
+        # Other configurations set to defaults
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
         assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/traces"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        # Headers not set without API token
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
 
     def test_configure_no_env_invalid_protocol_not_legacy(self, mocker):
         mocker.patch.dict(
@@ -460,10 +482,20 @@ class TestDistro:
         )
         distro.SolarWindsDistro()._configure()
         assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        # No exporter defaults get set
         assert os.environ.get(OTEL_TRACES_EXPORTER) is None
         assert os.environ.get(OTEL_METRICS_EXPORTER) is None
         assert os.environ.get(OTEL_LOGS_EXPORTER) is None
-        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
 
     def test_configure_no_env_invalid_protocol_is_legacy(self, mocker):
         mocker.patch.dict(
@@ -476,12 +508,25 @@ class TestDistro:
         )
         distro.SolarWindsDistro()._configure()
         assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        # No exporter defaults get set
         assert os.environ.get(OTEL_TRACES_EXPORTER) is None
         assert os.environ.get(OTEL_METRICS_EXPORTER) is None
         assert os.environ.get(OTEL_LOGS_EXPORTER) is None
-        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ.get(OTEL_TRACES_EXPORTER) is None
+        assert os.environ.get(OTEL_METRICS_EXPORTER) is None
+        assert os.environ.get(OTEL_LOGS_EXPORTER) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
 
-    def test_configure_no_env_valid_protocol_http(self, mocker):
+    def test_configure_no_env_valid_protocol_http_missing_token(self, mocker):
         mocker.patch.dict(
             os.environ,
             {
@@ -491,12 +536,73 @@ class TestDistro:
         )
         distro.SolarWindsDistro()._configure()
         assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
         assert os.environ[OTEL_TRACES_EXPORTER] == "otlp_proto_http"
         assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_http"
         assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_http"
-        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/traces"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        # Headers not set without API token
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
 
-    def test_configure_no_env_valid_protocol_grpc(self, mocker):
+    def test_configure_no_env_valid_protocol_http_with_invalid_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf",
+                "SW_APM_SERVICE_KEY": "not-valid",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ[OTEL_TRACES_EXPORTER] == "otlp_proto_http"
+        assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_http"
+        assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_http"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/traces"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        # Headers not set without API token
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+
+    def test_configure_no_env_valid_protocol_http_with_valid_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf",
+                "SW_APM_SERVICE_KEY": "foo-token:bar-name"
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ[OTEL_TRACES_EXPORTER] == "otlp_proto_http"
+        assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_http"
+        assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_http"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "http/protobuf"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/traces"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) == "authorization=Bearer%20foo-token"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == "authorization=Bearer%20foo-token"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == "authorization=Bearer%20foo-token"
+
+    def test_configure_no_env_valid_protocol_grpc_missing_token(self, mocker):
         mocker.patch.dict(
             os.environ,
             {
@@ -506,10 +612,71 @@ class TestDistro:
         )
         distro.SolarWindsDistro()._configure()
         assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
         assert os.environ[OTEL_TRACES_EXPORTER] == "otlp_proto_grpc"
         assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_grpc"
         assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/traces"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        # Headers not set without API token
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+
+    def test_configure_no_env_valid_protocol_grpc_with_invalid_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                OTEL_EXPORTER_OTLP_PROTOCOL: "grpc",
+                "SW_APM_SERVICE_KEY": "not-valid",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
         assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ[OTEL_TRACES_EXPORTER] == "otlp_proto_grpc"
+        assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_grpc"
+        assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/traces"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        # Headers not set without API token
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+
+    def test_configure_no_env_valid_protocol_grpc_with_valid_token(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                OTEL_EXPORTER_OTLP_PROTOCOL: "grpc",
+                "SW_APM_SERVICE_KEY": "foo-token:bar-service",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+        assert os.environ[OTEL_TRACES_EXPORTER] == "otlp_proto_grpc"
+        assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_grpc"
+        assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) == "grpc"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/traces"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) == "authorization=Bearer%20foo-token"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == "authorization=Bearer%20foo-token"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == "authorization=Bearer%20foo-token"
 
     def test_configure_env_exporter_and_valid_protocol_http(self, mocker):
         mocker.patch.dict(

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -252,18 +252,8 @@ class TestDistro:
         )
         assert distro.SolarWindsDistro()._get_token_from_service_key() == "foo-token"
 
-    def test__configure_logs_export_env_defaults_invalid_protocol(self, mocker):
-        distro.SolarWindsDistro()._configure_logs_export_env_defaults(
-            "foo-token",
-            "not-valid-protocol",
-        )
-        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL) is None
-        assert os.environ.get(OTEL_LOGS_EXPORTER) is None
-        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) is None
-        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
-
     def test__configure_logs_export_env_defaults_valid_protocol_http(self, mocker):
-        distro.SolarWindsDistro()._configure_logs_export_env_defaults(
+        distro.SolarWindsDistro()._configure_logs_export_otlp_env_defaults(
             "foo-token",
             "http/protobuf",
         )
@@ -273,7 +263,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == "authorization=Bearer%20foo-token"
 
     def test__configure_logs_export_env_defaults_valid_protocol_grpc(self, mocker):
-        distro.SolarWindsDistro()._configure_logs_export_env_defaults(
+        distro.SolarWindsDistro()._configure_logs_export_otlp_env_defaults(
             "foo-token",
             "grpc",
         )
@@ -282,18 +272,8 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == "authorization=Bearer%20foo-token"
 
-    def test__configure_metrics_export_env_defaults_invalid_protocol(self, mocker):
-        distro.SolarWindsDistro()._configure_metrics_export_env_defaults(
-            "foo-token",
-            "not-valid-protocol",
-        )
-        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL) is None
-        assert os.environ.get(OTEL_METRICS_EXPORTER) is None
-        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) is None
-        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
-
     def test__configure_metrics_export_env_defaults_valid_protocol_http(self, mocker):
-        distro.SolarWindsDistro()._configure_metrics_export_env_defaults(
+        distro.SolarWindsDistro()._configure_metrics_export_otlp_env_defaults(
             "foo-token",
             "http/protobuf",
         )
@@ -303,7 +283,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == "authorization=Bearer%20foo-token"
 
     def test__configure_metrics_export_env_defaults_valid_protocol_grpc(self, mocker):
-        distro.SolarWindsDistro()._configure_metrics_export_env_defaults(
+        distro.SolarWindsDistro()._configure_metrics_export_otlp_env_defaults(
             "foo-token",
             "grpc",
         )
@@ -312,28 +292,8 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/metrics"
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == "authorization=Bearer%20foo-token"
 
-    def test__configure_traces_export_env_defaults_none_protocol(self, mocker):
-        distro.SolarWindsDistro()._configure_traces_export_env_defaults(
-            "foo-token",
-            None,
-        )
-        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
-        assert os.environ.get(OTEL_TRACES_EXPORTER) == "solarwinds_exporter"
-        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
-        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
-
-    def test__configure_traces_export_env_defaults_invalid_protocol(self, mocker):
-        distro.SolarWindsDistro()._configure_traces_export_env_defaults(
-            "foo-token",
-            "not-valid-protocol",
-        )
-        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL) is None
-        assert os.environ.get(OTEL_TRACES_EXPORTER) == "solarwinds_exporter"
-        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) is None
-        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
-
     def test__configure_traces_export_env_defaults_valid_protocol_http(self, mocker):
-        distro.SolarWindsDistro()._configure_traces_export_env_defaults(
+        distro.SolarWindsDistro()._configure_traces_export_otlp_env_defaults(
             "foo-token",
             "http/protobuf",
         )
@@ -343,7 +303,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) == "authorization=Bearer%20foo-token"
 
     def test__configure_traces_export_env_defaults_valid_protocol_grpc(self, mocker):
-        distro.SolarWindsDistro()._configure_traces_export_env_defaults(
+        distro.SolarWindsDistro()._configure_traces_export_otlp_env_defaults(
             "foo-token",
             "grpc",
         )
@@ -372,7 +332,7 @@ class TestDistro:
             }
         )
         distro.SolarWindsDistro()._configure()
-        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) == f"authorization=Bearer%20foo-token"
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
 
@@ -386,8 +346,8 @@ class TestDistro:
         )
         distro.SolarWindsDistro()._configure()
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
-        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
-        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
 
     def test_configure_set_otlp_header_defaults_not_lambda_valid_protocol(self, mocker):
         mocker.patch.dict(
@@ -428,8 +388,7 @@ class TestDistro:
             }
         )
         distro.SolarWindsDistro()._configure()
-        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
-        # Currently still get set for metrics and logs
+        assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) == f"authorization=Bearer%20not-required-but-here"
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20not-required-but-here"
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20not-required-but-here"
 
@@ -446,9 +405,8 @@ class TestDistro:
         )
         distro.SolarWindsDistro()._configure()
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
-        # Currently still get set for metrics and logs
-        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20not-required-but-here"
-        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20not-required-but-here"
+        assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
+        assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
 
     def test_configure_set_otlp_header_defaults_lambda_valid_protocol(self, mocker):
         mocker.patch.dict(
@@ -471,7 +429,7 @@ class TestDistro:
         mocker.patch.dict(os.environ, {})
         distro.SolarWindsDistro()._configure()
         assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
-        assert os.environ[OTEL_TRACES_EXPORTER] == "solarwinds_exporter"
+        assert os.environ[OTEL_TRACES_EXPORTER] == "otlp_proto_http"
         assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_http"
         assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_http"
         assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
@@ -492,7 +450,7 @@ class TestDistro:
         assert os.environ[OTEL_LOGS_EXPORTER] == "qux"
         assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
 
-    def test_configure_no_env_invalid_protocol(self, mocker):
+    def test_configure_no_env_invalid_protocol_not_legacy(self, mocker):
         mocker.patch.dict(
             os.environ,
             {
@@ -502,9 +460,25 @@ class TestDistro:
         )
         distro.SolarWindsDistro()._configure()
         assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
-        assert os.environ[OTEL_TRACES_EXPORTER] == "solarwinds_exporter"
-        assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_http"
-        assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_http"
+        assert os.environ.get(OTEL_TRACES_EXPORTER) is None
+        assert os.environ.get(OTEL_METRICS_EXPORTER) is None
+        assert os.environ.get(OTEL_LOGS_EXPORTER) is None
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
+
+    def test_configure_no_env_invalid_protocol_is_legacy(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                OTEL_EXPORTER_OTLP_PROTOCOL: "foo",
+                "SW_APM_LEGACY": "true",
+            },
+            clear=True
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ.get(OTEL_TRACES_EXPORTER) is None
+        assert os.environ.get(OTEL_METRICS_EXPORTER) is None
+        assert os.environ.get(OTEL_LOGS_EXPORTER) is None
         assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
 
     def test_configure_no_env_valid_protocol_http(self, mocker):
@@ -575,7 +549,6 @@ class TestDistro:
         mocker.patch.dict(os.environ, {"OTEL_PROPAGATORS": "tracecontext,solarwinds_propagator,foobar"})
         distro.SolarWindsDistro()._configure()
         assert os.environ[OTEL_PROPAGATORS] == "tracecontext,solarwinds_propagator,foobar"
-        assert os.environ[OTEL_TRACES_EXPORTER] == "solarwinds_exporter"
         assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
 
     def test_load_instrumentor_aws_lambda_not_lambda_env(self, mocker):


### PR DESCRIPTION
Note: This will merge into epic feature branch `NH-79205-otlp-by-default`.

This updates APM Python's `Distro` component, which is called first when [sitecustomize](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/748c92592d2f476199667629defce4a3bca9ecc9/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py#L37-L39) is used for auto-instrumentation, to more clearly prepare for OTLP-by-default. I'm changing the parts used to `setdefault` of exporter configurations. All values can still be configured (i.e. override defaults) by user via `OTEL_*` env vars. It is the `Configurator` component's responsibility to load and init the exporters later according to final config.

Key code changes:

(1)
For users, it used to be that setting an invalid protocol like `OTEL_EXPORTER_OTLP_PROTOCOL: "foo"` (not `http/protobuf` nor `grpc`) would be ignored and a safeguard defaults would be set: APM-proto exporter for traces + OTLP exporter for metrics and logs (a confusing mix!). This is not advertised. Now, if invalid protocol, all _default_ exporters will be `None` and a warning is logged. See also [this test case](https://github.com/solarwinds/apm-python/blob/dc3c7404579afd414e455fcb8c05d88b98ba6a57/tests/unit/test_distro.py#L475-L498).

(2)
For users, it used to be that invalid protocol OR not setting protocol at all would setdefault `OTEL_TRACES_EXPORTER` as APM-proto (also confusing!) Now, the new `calculate_is_legacy` method is used. If legacy, set APM-proto as default. If not, set OTLP by http/proto as default. However, if an invalid protocol was provided, exporter will be `None` -- see (1) above. See also [this test case](https://github.com/solarwinds/apm-python/blob/dc3c7404579afd414e455fcb8c05d88b98ba6a57/tests/unit/test_distro.py#L716-L741) vs [this other test case](https://github.com/solarwinds/apm-python/blob/dc3c7404579afd414e455fcb8c05d88b98ba6a57/tests/unit/test_distro.py#L743-L771).

(3)
Refactors and renames `_configure_(traces|metrics|logs)_export_env_defaults` to `_configure_(traces|metrics|logs)_export_otlp_env_defaults` to cut duplicate code and imports.

(4)
It used to be the responsibility of each `_configure_(traces|metrics|logs)` function to check if protocol was valid. Now the `_configure` entry function does it once.

Please let me know if any questions or criticisms! 😺 