### PR TITLE
NH-79205 Prep integration tests to run as legacy, plus small fix

### DIFF
--- a/tests/integration/test_base_sw_headers_attrs.py
+++ b/tests/integration/test_base_sw_headers_attrs.py
@@ -87,6 +87,9 @@ class TestBaseSwHeadersAndAttributes(TestBase):
         # Set APM service key - not valid, but we mock liboboe anyway
         os.environ["SW_APM_SERVICE_KEY"] = "foo:bar"
 
+        # Set APM to legacy mode
+        os.environ["SW_APM_LEGACY"] = "true"
+
         # Load Distro
         SolarWindsDistro().configure()
         assert os.environ["OTEL_PROPAGATORS"] == "tracecontext,baggage,solarwinds_propagator"
@@ -138,3 +141,5 @@ class TestBaseSwHeadersAndAttributes(TestBase):
     def tearDown(self):
         """Teardown called after each test scenario"""
         self.memory_exporter.clear()
+        del os.environ["SW_APM_SERVICE_KEY"]
+        del os.environ["SW_APM_LEGACY"]


### PR DESCRIPTION
Note: This will merge into epic feature branch NH-79205-otlp-by-default.

Preps the APM Python integration tests to all run in legacy mode, plus a small fix to restore empty `SW_APM_SERVICE_KEY` before the unit tests run. This currently isn't an issue but the bug is revealed as I write more updates and tests 😃 