### PR TITLE
NH-100958 Prevent AttributeError if OTEL_PROPAGATORS is None

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -326,6 +326,7 @@ class SolarWindsApmConfig:
             # SolarWindsDistro._configure does setdefault before this is called
             environ_propagators = os.environ.get(
                 OTEL_PROPAGATORS,
+                "",
             ).split(",")
             # If not using the default propagators,
             # can any arbitrary list BUT


### PR DESCRIPTION
Prevent AttributeError if OTEL_PROPAGATORS is None, which could happen if if user sets `OTEL_PYTHON_DISTRO` to something that is not `solarwinds_distro` while using `OTEL_PYTHON_CONFIGURATOR=solarwinds_configurator`.

This will still log and agent_enabled will be False a few lines down, so this change doesn't silence anything:

```
logger.error(
    "Must include tracecontext and solarwinds_propagator in OTEL_PROPAGATORS to use SolarWinds APM. Tracing disabled."
)
return False
```
