### PR TITLE
NH-100961 Fix ApmConfig unit test conditions

### DIFF
--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -27,7 +27,7 @@ def setup_caplog():
 
 class TestSolarWindsApmConfig:
     """
-    Note: _calculate_agent_enabled sets defaults for OTEL_PROPAGATORS
+    Note: mock_env_vars test fixture sets values for OTEL_PROPAGATORS
     and OTEL_TRACES_EXPORTER. SW_APM_SERVICE_KEY is required.
     SW_APM_AGENT_ENABLED is optional.
     """
@@ -129,7 +129,11 @@ class TestSolarWindsApmConfig:
         assert test_config.service_name == ""
         assert test_config.get("service_key") == "service_key_with:sw_service_name"
 
-    def test__init_valid_service_key_format_agent_enabled_true_default(self, mocker):
+    def test__init_valid_service_key_format_agent_enabled_true_default(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "service_key_with:sw_service_name",
         })
@@ -138,7 +142,11 @@ class TestSolarWindsApmConfig:
         assert test_config.service_name == "sw_service_name"
         assert test_config.get("service_key") == "service_key_with:sw_service_name"
 
-    def test__init_valid_service_key_format_agent_enabled_true_explicit(self, mocker):
+    def test__init_valid_service_key_format_agent_enabled_true_explicit(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "service_key_with:sw_service_name",
             "SW_APM_AGENT_ENABLED": "true",
@@ -148,7 +156,11 @@ class TestSolarWindsApmConfig:
         assert test_config.service_name == "sw_service_name"
         assert test_config.get("service_key") == "service_key_with:sw_service_name"
 
-    def test__init_valid_service_key_format_otel_service_name(self, mocker):
+    def test__init_valid_service_key_format_otel_service_name(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "service_key_with:sw_service_name",
             "OTEL_SERVICE_NAME": "from_otel_env"
@@ -159,7 +171,11 @@ class TestSolarWindsApmConfig:
         assert test_config.service_name == "from_otel_env"
         assert test_config.get("service_key") == "service_key_with:from_otel_env"
 
-    def test__init_valid_service_key_format_otel_service_name_and_resource_attrs(self, mocker):
+    def test__init_valid_service_key_format_otel_service_name_and_resource_attrs(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "service_key_with:sw_service_name",
             "OTEL_SERVICE_NAME": "from_otel_env",
@@ -171,7 +187,11 @@ class TestSolarWindsApmConfig:
         assert test_config.service_name == "from_otel_env"
         assert test_config.get("service_key") == "service_key_with:from_otel_env"
 
-    def test__init_valid_service_key_format_otel_resource_attrs(self, mocker):
+    def test__init_valid_service_key_format_otel_resource_attrs(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "service_key_with:sw_service_name",
             "OTEL_RESOURCE_ATTRIBUTES": "service.name=also_from_otel_env_used_this_time"
@@ -182,7 +202,11 @@ class TestSolarWindsApmConfig:
         assert test_config.service_name == "also_from_otel_env_used_this_time"
         assert test_config.get("service_key") == "service_key_with:also_from_otel_env_used_this_time"
 
-    def test__init_valid_service_key_format_empty_otel_service_name(self, mocker):
+    def test__init_valid_service_key_format_empty_otel_service_name(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "service_key_with:sw_service_name",
             "OTEL_SERVICE_NAME": "",
@@ -193,7 +217,11 @@ class TestSolarWindsApmConfig:
         assert test_config.service_name == "sw_service_name"
         assert test_config.get("service_key") == "service_key_with:sw_service_name"
 
-    def test__init_valid_service_key_format_empty_otel_service_name_and_resource_attrs(self, mocker):
+    def test__init_valid_service_key_format_empty_otel_service_name_and_resource_attrs(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "service_key_with:sw_service_name",
             "OTEL_SERVICE_NAME": "",
@@ -205,7 +233,11 @@ class TestSolarWindsApmConfig:
         assert test_config.service_name == "sw_service_name"
         assert test_config.get("service_key") == "service_key_with:sw_service_name"
 
-    def test__init_valid_service_key_format_otel_resource_attrs_without_name(self, mocker):
+    def test__init_valid_service_key_format_otel_resource_attrs_without_name(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "service_key_with:sw_service_name",
             "OTEL_RESOURCE_ATTRIBUTES": "foo=bar,telemetry.sdk.version=whatever-i-want-baby",
@@ -633,7 +665,11 @@ class TestSolarWindsApmConfig:
         self._mock_service_key(mocker, "CyUuit1W--8RVmUXX6_cVjTWemaUyBh1ruL0nMPiFdrPo1iiRnO31_pwiUCPzdzv9UMHK6I")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "CyUu...<invalid_format>"
 
-    def test_mask_service_key_less_than_9_char_token(self, mocker):
+    def test_mask_service_key_less_than_9_char_token(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         self._mock_service_key(mocker, ":foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == ":foo-bar"
         self._mock_service_key(mocker, "a:foo-bar")
@@ -653,7 +689,11 @@ class TestSolarWindsApmConfig:
         self._mock_service_key(mocker, "abcdefgh:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcdefgh:foo-bar"
 
-    def test_mask_service_key_9_or_more_char_token(self, mocker):
+    def test_mask_service_key_9_or_more_char_token(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         self._mock_service_key(mocker, "abcd1efgh:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcd...efgh:foo-bar"
         self._mock_service_key(mocker, "abcd12efgh:foo-bar")
@@ -665,11 +705,19 @@ class TestSolarWindsApmConfig:
         self._mock_service_key(mocker, "CyUuit1W--8RVmUXX6_cVjTWemaUyBh1ruL0nMPiFdrPo1iiRnO31_pwiUCPzdzv9UMHK6I:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "CyUu...HK6I:foo-bar"
 
-    def test_config_mask_service_key(self, mocker):
+    def test_config_mask_service_key(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         self._mock_service_key(mocker, "valid-and-long:key")
         assert apm_config.SolarWindsApmConfig()._config_mask_service_key().get("service_key") == "vali...long:key"
 
-    def test_str(self, mocker):
+    def test_str(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         self._mock_service_key(mocker, "valid-and-long:key")
         result = str(apm_config.SolarWindsApmConfig())
         assert "vali...long:key" in result

--- a/tests/unit/test_apm_config/test_apm_config_agent_enabled.py
+++ b/tests/unit/test_apm_config/test_apm_config_agent_enabled.py
@@ -15,6 +15,8 @@ from .fixtures.cnf_dict import (
     fixture_cnf_dict_enabled_false_mixed_case,
 )
 
+# pylint: disable=unused-import
+from .fixtures.env_vars import fixture_mock_env_vars
 
 class TestSolarWindsApmConfigAgentEnabled:
     def test_calculate_agent_enabled_service_key_missing(self, mocker):
@@ -58,6 +60,7 @@ class TestSolarWindsApmConfigAgentEnabled:
         self,
         mocker,
         fixture_cnf_dict,
+        mock_env_vars
     ):
         # Save any service key in os for later
         old_service_key = os.environ.get("SW_APM_SERVICE_KEY", None)
@@ -114,6 +117,7 @@ class TestSolarWindsApmConfigAgentEnabled:
         self,
         mocker,
         fixture_cnf_dict,
+        mock_env_vars,
     ):
         # Save any service key in os for later
         old_service_key = os.environ.get("SW_APM_SERVICE_KEY", None)
@@ -196,7 +200,11 @@ class TestSolarWindsApmConfigAgentEnabled:
         assert not resulting_config._calculate_agent_enabled()
         assert resulting_config.service_name == ""
 
-    def test_calculate_agent_enabled_service_key_ok(self, mocker):
+    def test_calculate_agent_enabled_service_key_ok(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "valid:key",
         })
@@ -225,7 +233,11 @@ class TestSolarWindsApmConfigAgentEnabled:
         assert resulting_config._calculate_agent_enabled()
         assert resulting_config.service_name == "key"
 
-    def test_calculate_agent_enabled_env_var_true(self, mocker):
+    def test_calculate_agent_enabled_env_var_true(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "valid:key",
             "SW_APM_AGENT_ENABLED": "true",
@@ -399,6 +411,7 @@ class TestSolarWindsApmConfigAgentEnabled:
         self,
         mocker,
         fixture_cnf_dict_enabled_false,
+        mock_env_vars,
     ):
         mock_entry_points = mocker.patch(
             "solarwinds_apm.apm_config.entry_points"
@@ -477,7 +490,11 @@ class TestSolarWindsApmConfigAgentEnabled:
         assert not resulting_config.agent_enabled
         assert resulting_config.service_name == ""
 
-    def test_calculate_agent_enabled_ok_all_env_vars(self, mocker):
+    def test_calculate_agent_enabled_ok_all_env_vars(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         mocker.patch.dict(os.environ, {
             "OTEL_PROPAGATORS": "foo,tracecontext,bar,solarwinds_propagator",
             "OTEL_TRACES_EXPORTER": "solarwinds_exporter,foo",
@@ -597,7 +614,11 @@ class TestSolarWindsApmConfigAgentEnabled:
         assert not resulting_config._calculate_agent_enabled()
         assert resulting_config.service_name == ""
 
-    def test_calculate_agent_enabled_sw_after_baggage_propagator(self, mocker):
+    def test_calculate_agent_enabled_sw_after_baggage_propagator(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         mocker.patch.dict(os.environ, {
             "OTEL_PROPAGATORS": "tracecontext,baggage,solarwinds_propagator",
             "SW_APM_SERVICE_KEY": "valid:key",
@@ -619,7 +640,11 @@ class TestSolarWindsApmConfigAgentEnabled:
         assert resulting_config._calculate_agent_enabled()
         assert resulting_config.service_name == "key"
 
-    def test_calculate_agent_enabled_sw_but_no_such_other_exporter(self, mocker):
+    def test_calculate_agent_enabled_sw_but_no_such_other_exporter(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         mocker.patch.dict(os.environ, {
             "OTEL_TRACES_EXPORTER": "solarwinds_exporter,not-valid",
             "SW_APM_SERVICE_KEY": "valid:key",
@@ -647,7 +672,11 @@ class TestSolarWindsApmConfigAgentEnabled:
         assert not resulting_config._calculate_agent_enabled()
         assert resulting_config.service_name == ""
 
-    def test_calculate_agent_enabled_sw_and_two_other_valid_exporters(self, mocker):
+    def test_calculate_agent_enabled_sw_and_two_other_valid_exporters(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
         mocker.patch.dict(os.environ, {
             "OTEL_TRACES_EXPORTER": "foo,solarwinds_exporter,bar",
             "SW_APM_SERVICE_KEY": "valid:key",

--- a/tests/unit/test_apm_config/test_apm_config_cnf_file.py
+++ b/tests/unit/test_apm_config/test_apm_config_cnf_file.py
@@ -34,6 +34,7 @@ class TestSolarWindsApmConfigCnfFile:
     def test_get_cnf_dict_custom_path_no_file(
         self,
         mocker,
+        mock_env_vars,
     ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "valid:key-service-name",
@@ -51,6 +52,7 @@ class TestSolarWindsApmConfigCnfFile:
         self,
         mocker,
         fixture_cnf_file_invalid_json,
+        mock_env_vars,
     ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "valid:key-service-name",
@@ -68,6 +70,7 @@ class TestSolarWindsApmConfigCnfFile:
         self,
         mocker,
         fixture_cnf_file,
+        mock_env_vars,
     ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "valid:key-service-name",
@@ -85,6 +88,7 @@ class TestSolarWindsApmConfigCnfFile:
         self,
         mocker,
         fixture_cnf_dict,
+        mock_env_vars,
     ):
         # Save any collector in os for later
         old_collector = os.environ.get("SW_APM_COLLECTOR", None)
@@ -154,6 +158,7 @@ class TestSolarWindsApmConfigCnfFile:
     def test_update_with_cnf_file_mostly_invalid(
         self,
         mocker,
+        mock_env_vars,
     ):
         # Save any collector in os for later
         old_collector = os.environ.get("SW_APM_COLLECTOR", None)

--- a/tests/unit/test_apm_config/test_apm_config_service_name.py
+++ b/tests/unit/test_apm_config/test_apm_config_service_name.py
@@ -10,6 +10,8 @@ from opentelemetry.sdk.resources import Resource
 
 from solarwinds_apm import apm_config
 
+# pylint: disable=unused-import
+from .fixtures.env_vars import fixture_mock_env_vars
 
 class TestSolarWindsApmConfigServiceName:
     def test__calculate_service_name_is_lambda(self, mocker):
@@ -75,6 +77,7 @@ class TestSolarWindsApmConfigServiceNameApmProto:
     def test__calculate_service_name_apm_proto_no_otel_service_name(
         self,
         mocker,
+        mock_env_vars,
     ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "service_key_with:sw_service_name",
@@ -89,6 +92,7 @@ class TestSolarWindsApmConfigServiceNameApmProto:
     def test__calculate_service_name_apm_proto_default_unknown_otel_service_name(
         self,
         mocker,
+        mock_env_vars,
     ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "service_key_with:sw_service_name",
@@ -104,6 +108,7 @@ class TestSolarWindsApmConfigServiceNameApmProto:
     def test__calculate_service_name_apm_proto_use_otel_service_name(
         self,
         mocker,
+        mock_env_vars,
     ):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": "service_key_with:sw_service_name",


### PR DESCRIPTION
If we run all tox tests at once, e.g. `make tox OPTIONS="-e py312-nh-staging"`, then all tests pass. But if we only run the ApmConfig unit tests, e.g.

`make tox OPTIONS="-e py312-nh-staging -- tests/unit/test_apm_config/*"`

Then there are 27 failures!! The ApmConfig tests themselves are not setting their conditions up properly. This fixes the `os.environ` mocking using an existing fixture.