### PR TITLE
NH-100646 _get_extension now based on if Legacy, not if Lambda

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -709,11 +709,12 @@ class SolarWindsApmConfig:
 
     def __str__(self) -> str:
         """String representation of ApmConfig is config with masked service key,
-        plus agent_enabled and context"""
+        plus agent_enabled and context and OboeAPI"""
         apm_config = {
             "__config": self._config_mask_service_key(),
             "agent_enabled": self.agent_enabled,
             "context": str(self.context),
+            "oboe_api": str(self.oboe_api),
             "service_name": self.service_name,
         }
         return json.dumps(apm_config)

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -718,7 +718,7 @@ class TestSolarWindsApmConfig:
         self._mock_service_key(mocker, "valid-and-long:key")
         assert apm_config.SolarWindsApmConfig()._config_mask_service_key().get("service_key") == "vali...long:key"
 
-    def test_str(
+    def test_str_non_legacy(
         self,
         mocker,
         mock_env_vars,
@@ -727,7 +727,23 @@ class TestSolarWindsApmConfig:
         result = str(apm_config.SolarWindsApmConfig())
         assert "vali...long:key" in result
         assert "agent_enabled" in result
+        assert "solarwinds_apm.apm_noop.Context" in result
+        assert "solarwinds_apm.extension.oboe.OboeAPI" in result
+
+    def test_str_legacy(
+        self,
+        mocker,
+        mock_env_vars,
+    ):
+        self._mock_service_key(mocker, "valid-and-long:key")
+        mocker.patch.dict(os.environ, {
+            "SW_APM_LEGACY": "true",
+        })
+        result = str(apm_config.SolarWindsApmConfig())
+        assert "vali...long:key" in result
+        assert "agent_enabled" in result
         assert "solarwinds_apm.extension.oboe.Context" in result
+        assert "solarwinds_apm.apm_noop.OboeAPI" in result
 
     # pylint:disable=unused-argument
     def test_set_config_value_invalid_key(self, caplog, setup_caplog, mock_env_vars):

--- a/tests/unit/test_apm_config/test_apm_config_agent_enabled.py
+++ b/tests/unit/test_apm_config/test_apm_config_agent_enabled.py
@@ -229,6 +229,15 @@ class TestSolarWindsApmConfigAgentEnabled:
                 "ApmLoggingLevel.default_level": mocker.Mock(return_value=2)
             }
         )
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig._get_extension_components",
+            return_value=(
+                mocker.Mock(),
+                mocker.Mock(),
+                mocker.Mock(),
+                mocker.Mock(),
+            )
+        )
         resulting_config = apm_config.SolarWindsApmConfig()
         assert resulting_config._calculate_agent_enabled()
         assert resulting_config.service_name == "key"
@@ -262,6 +271,15 @@ class TestSolarWindsApmConfigAgentEnabled:
                 "set_sw_log_level": mocker.Mock(),
                 "ApmLoggingLevel.default_level": mocker.Mock(return_value=2)
             }
+        )
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig._get_extension_components",
+            return_value=(
+                mocker.Mock(),
+                mocker.Mock(),
+                mocker.Mock(),
+                mocker.Mock(),
+            )
         )
         resulting_config = apm_config.SolarWindsApmConfig()
         assert resulting_config._calculate_agent_enabled()
@@ -444,6 +462,15 @@ class TestSolarWindsApmConfigAgentEnabled:
                 "ApmLoggingLevel.default_level": mocker.Mock(return_value=2)
             }
         )
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig._get_extension_components",
+            return_value=(
+                mocker.Mock(),
+                mocker.Mock(),
+                mocker.Mock(),
+                mocker.Mock(),
+            )
+        )
         resulting_config = apm_config.SolarWindsApmConfig()
         assert resulting_config.agent_enabled
         assert resulting_config.service_name == "key"
@@ -521,6 +548,15 @@ class TestSolarWindsApmConfigAgentEnabled:
                 "set_sw_log_level": mocker.Mock(),
                 "ApmLoggingLevel.default_level": mocker.Mock(return_value=2)
             }
+        )
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig._get_extension_components",
+            return_value=(
+                mocker.Mock(),
+                mocker.Mock(),
+                mocker.Mock(),
+                mocker.Mock(),
+            )
         )
         resulting_config = apm_config.SolarWindsApmConfig()
         assert resulting_config._calculate_agent_enabled()
@@ -636,6 +672,15 @@ class TestSolarWindsApmConfigAgentEnabled:
                 "ApmLoggingLevel.default_level": mocker.Mock(return_value=2)
             }
         )
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig._get_extension_components",
+            return_value=(
+                mocker.Mock(),
+                mocker.Mock(),
+                mocker.Mock(),
+                mocker.Mock(),
+            )
+        )
         resulting_config = apm_config.SolarWindsApmConfig()
         assert resulting_config._calculate_agent_enabled()
         assert resulting_config.service_name == "key"
@@ -701,6 +746,15 @@ class TestSolarWindsApmConfigAgentEnabled:
                 "set_sw_log_level": mocker.Mock(),
                 "ApmLoggingLevel.default_level": mocker.Mock(return_value=2)
             }
+        )
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig._get_extension_components",
+            return_value=(
+                mocker.Mock(),
+                mocker.Mock(),
+                mocker.Mock(),
+                mocker.Mock(),
+            )
         )
         resulting_config = apm_config.SolarWindsApmConfig()
         assert resulting_config._calculate_agent_enabled()

--- a/tests/unit/test_apm_config/test_apm_config_cnf_file.py
+++ b/tests/unit/test_apm_config/test_apm_config_cnf_file.py
@@ -207,6 +207,15 @@ class TestSolarWindsApmConfigCnfFile:
         mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.update_log_settings"
         )
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig._get_extension_components",
+            return_value=(
+                mocker.Mock(),
+                mocker.Mock(),
+                mocker.Mock(),
+                mocker.Mock(),
+            )
+        )
         mock_apm_logging = mocker.patch(
             "solarwinds_apm.apm_config.apm_logging"
         )

--- a/tests/unit/test_apm_config/test_apm_config_get_extension.py
+++ b/tests/unit/test_apm_config/test_apm_config_get_extension.py
@@ -44,7 +44,7 @@ class TestApmConfigGetExtensionComponents:
         assert res3 == NoopOboeApi
         assert res4 == NoopOboeApiOptions
 
-    def test__get_extension_components_cannot_import(
+    def test__get_extension_components_non_legacy_cannot_import(
         self,
         mock_env_vars,
         monkeypatch,
@@ -57,7 +57,7 @@ class TestApmConfigGetExtensionComponents:
         assert res3 == NoopOboeApi
         assert res4 == NoopOboeApiOptions
 
-    def test__get_extension_components_is_lambda_cannot_import(
+    def test__get_extension_components_legacy_cannot_import(
         self,
         mock_env_vars,
         monkeypatch,
@@ -70,21 +70,21 @@ class TestApmConfigGetExtensionComponents:
         assert res3 == NoopOboeApi
         assert res4 == NoopOboeApiOptions
 
-    def test__get_extension_components_is_lambda(
+    def test__get_extension_components_enabled_non_legacy(
         self,
         mock_env_vars,
     ):
-        res1, res2, res3, res4 = apm_config.SolarWindsApmConfig()._get_extension_components(True, True)
+        res1, res2, res3, res4 = apm_config.SolarWindsApmConfig()._get_extension_components(True, False)
         assert res1 == NoopExtension
         assert res2 == NoopContext
         assert res3 == OboeAPI
         assert res4 == OboeAPIOptions
 
-    def test__get_extension_components_enabled(
+    def test__get_extension_components_legacy(
         self,
         mock_env_vars,
     ):
-        res1, res2, res3, res4 = apm_config.SolarWindsApmConfig()._get_extension_components(True, False)
+        res1, res2, res3, res4 = apm_config.SolarWindsApmConfig()._get_extension_components(True, True)
         assert res1 == Extension
         assert res2 == Context
         assert res3 == NoopOboeApi


### PR DESCRIPTION
Note: This will merge into epic feature branch `NH-79205-otlp-by-default`

`_get_extension_components` is now based on `SW_APM_LEGACY` false/true, instead of "is lambda". I'm keeping two separate try-except for now around import of `solarwinds_apm.extension.oboe` then import of OboeAPI and options, in case of upcoming updated extension builds. Also updates `str(ApmConfig)` debug helper to include OboeAPI.