### PR TITLE
NH-98561 Update configure_otel_components conditions

### DIFF
--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -159,6 +159,8 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                     apm_config,
                     oboe_api,
                 )
+
+                self._configure_logs_exporter(apm_config)
             else:
                 # Export APM metrics by APM-proto
                 self._configure_inbound_metrics_span_processor(
@@ -178,7 +180,6 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                 apm_fwkv_manager,
                 apm_config,
             )
-            self._configure_logs_exporter(apm_config)
 
         else:
             # Warning: This may still set OTEL_PROPAGATORS if set because OTel API defaults

--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -131,6 +131,7 @@ def get_apmconfig_mocks(
     md_is_valid=True,
     export_logs_enabled=True,
     export_metrics_enabled=True,
+    legacy=False,
 ):
     # mock the extension that is linked to ApmConfig
     mock_ext_config = mocker.Mock()
@@ -184,6 +185,8 @@ def get_apmconfig_mocks(
             return export_metrics_enabled
         elif param == "export_logs_enabled":
             return export_logs_enabled
+        elif param == "legacy":
+            return legacy
         else:
             return "foo"
 
@@ -216,6 +219,16 @@ def mock_apmconfig_enabled(mocker):
         "solarwinds_apm.configurator.SolarWindsApmConfig",
         get_apmconfig_mocks(
             mocker,
+        )
+    )
+
+@pytest.fixture(name="mock_apmconfig_enabled_legacy")
+def mock_apmconfig_enabled_legacy(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsApmConfig",
+        get_apmconfig_mocks(
+            mocker,
+            legacy=True,
         )
     )
 
@@ -445,9 +458,37 @@ def mock_fwkv_manager_init(mocker):
         "solarwinds_apm.configurator.SolarWindsFrameworkKvManager"
     )
 
-@pytest.fixture(name="mock_oboe_api_obj")
-def mock_oboe_api_obj(mocker):
-    return mocker.Mock()
+@pytest.fixture(name="mock_oboe_api_obj_non_legacy")
+def mock_oboe_api_obj_non_legacy(mocker):
+    def get_side_effect(param):
+        if param == "legacy":
+            return False
+        else:
+            return "not mocked"
+
+    mock_apmconfig = mocker.Mock()
+    mock_apmconfig.configure_mock(
+        **{
+            "get": mocker.Mock(side_effect=get_side_effect),
+        }
+    )
+    return mock_apmconfig
+
+@pytest.fixture(name="mock_oboe_api_obj_legacy")
+def mock_oboe_api_obj_legacy(mocker):
+    def get_side_effect(param):
+        if param == "legacy":
+            return True
+        else:
+            return "not mocked"
+
+    mock_apmconfig = mocker.Mock()
+    mock_apmconfig.configure_mock(
+        **{
+            "get": mocker.Mock(side_effect=get_side_effect),
+        }
+    )
+    return mock_apmconfig
 
 
 # ==================================================================

--- a/tests/unit/test_configurator/test_configurator_configure_otel.py
+++ b/tests/unit/test_configurator/test_configurator_configure_otel.py
@@ -94,7 +94,7 @@ class TestConfiguratorConfigureOtelComponents:
             mock_apmconfig_enabled_legacy,
         )
         mock_config_metrics_exp.assert_not_called()
-        mock_config_logs_exp.assert_called_once_with(mock_apmconfig_enabled_legacy)
+        mock_config_logs_exp.assert_not_called()
         mock_config_propagator.assert_called_once()
         mock_config_response_propagator.assert_called_once()
 

--- a/tests/unit/test_configurator/test_configurator_configure_otel.py
+++ b/tests/unit/test_configurator/test_configurator_configure_otel.py
@@ -7,7 +7,7 @@
 from solarwinds_apm import configurator
 
 class TestConfiguratorConfigureOtelComponents:
-    def test_configure_otel_components_agent_enabled(
+    def test_configure_otel_components_agent_enabled_non_legacy(
         self,
         mocker,
         mock_txn_name_manager,
@@ -15,7 +15,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_meter_manager,
         mock_extension,
         mock_apmconfig_enabled,
-        mock_oboe_api_obj,
+        mock_oboe_api_obj_non_legacy,
 
         mock_config_serviceentryid_processor,
         mock_config_inbound_processor,
@@ -32,18 +32,15 @@ class TestConfiguratorConfigureOtelComponents:
             mock_fwkv_manager,
             mock_apmconfig_enabled,
             mock_extension.Reporter,
-            mock_oboe_api_obj,
+            mock_oboe_api_obj_non_legacy,
         )
 
         mock_config_serviceentryid_processor.assert_called_once()
-        mock_config_inbound_processor.assert_called_once_with(
-            mock_txn_name_manager,
-            mock_apmconfig_enabled,
-        )
+        mock_config_inbound_processor.assert_not_called()
         mock_config_otlp_processors.assert_called_once_with(
             mock_txn_name_manager,
             mock_apmconfig_enabled, 
-            mock_oboe_api_obj,
+            mock_oboe_api_obj_non_legacy,
         )
         mock_config_traces_exp.assert_called_once_with(
             mock_extension.Reporter,
@@ -56,7 +53,52 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_propagator.assert_called_once()
         mock_config_response_propagator.assert_called_once()
 
-    def test_configure_otel_components_agent_disabled(
+    def test_configure_otel_components_agent_enabled_legacy(
+        self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_enabled_legacy,
+        mock_oboe_api_obj_legacy,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_propagator,
+        mock_config_response_propagator,
+    ):
+        test_configurator = configurator.SolarWindsConfigurator()
+        test_configurator._configure_otel_components(
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_apmconfig_enabled_legacy,
+            mock_extension.Reporter,
+            mock_oboe_api_obj_legacy,
+        )
+
+        mock_config_serviceentryid_processor.assert_called_once()
+        mock_config_inbound_processor.assert_called_once_with(
+            mock_txn_name_manager,
+            mock_apmconfig_enabled_legacy,
+        )
+        mock_config_otlp_processors.assert_not_called()
+        mock_config_traces_exp.assert_called_once_with(
+            mock_extension.Reporter,
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_apmconfig_enabled_legacy,
+        )
+        mock_config_metrics_exp.assert_not_called()
+        mock_config_logs_exp.assert_called_once_with(mock_apmconfig_enabled_legacy)
+        mock_config_propagator.assert_called_once()
+        mock_config_response_propagator.assert_called_once()
+
+    def test_configure_otel_components_agent_disabled_non_legacy(
         self,
         mocker,
         mock_txn_name_manager,
@@ -64,7 +106,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_meter_manager,
         mock_extension,
         mock_apmconfig_disabled,
-        mock_oboe_api_obj,
+        mock_oboe_api_obj_non_legacy,
 
         mock_config_serviceentryid_processor,
         mock_config_inbound_processor,
@@ -81,7 +123,44 @@ class TestConfiguratorConfigureOtelComponents:
             mock_fwkv_manager,
             mock_apmconfig_disabled,
             mock_extension.Reporter,
-            mock_oboe_api_obj,
+            mock_oboe_api_obj_non_legacy,
+        )
+
+        mock_config_serviceentryid_processor.assert_not_called()
+        mock_config_inbound_processor.assert_not_called()
+        mock_config_otlp_processors.assert_not_called()
+        mock_config_traces_exp.assert_not_called()
+        mock_config_metrics_exp.assert_not_called()
+        mock_config_logs_exp.assert_not_called()
+        mock_config_propagator.assert_not_called()
+        mock_config_response_propagator.assert_not_called()
+
+    def test_configure_otel_components_agent_disabled_legacy(
+        self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_disabled,
+        mock_oboe_api_obj_legacy,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_propagator,
+        mock_config_response_propagator,
+    ):
+        test_configurator = configurator.SolarWindsConfigurator()
+        test_configurator._configure_otel_components(
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_apmconfig_disabled,
+            mock_extension.Reporter,
+            mock_oboe_api_obj_legacy,
         )
 
         mock_config_serviceentryid_processor.assert_not_called()

--- a/tests/unit/test_configurator/test_configurator_metrics_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_metrics_exporter.py
@@ -16,26 +16,6 @@ from .fixtures.trace import get_trace_mocks
 
 
 class TestConfiguratorMetricsExporter:
-    def test_configure_metrics_exporter_disabled(
-        self,
-        mocker,
-        mock_apmconfig_disabled,
-        mock_pemreader,
-        mock_meterprovider,
-    ):
-        # Mock Otel
-        trace_mocks = get_trace_mocks(mocker)
-
-        # Test!
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_metrics_exporter(
-            mock_apmconfig_disabled,
-        )
-        mock_pemreader.assert_not_called()
-        trace_mocks.get_tracer_provider.assert_not_called()
-        trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
-        mock_meterprovider.assert_not_called()
-
     def test_configure_metrics_exporter_sw_enabled_false(
         self,
         mocker,

--- a/tests/unit/test_configurator/test_configurator_sampler.py
+++ b/tests/unit/test_configurator/test_configurator_sampler.py
@@ -15,37 +15,11 @@ from .fixtures.resource import get_resource_mocks
 from .fixtures.trace import get_trace_mocks
 
 class TestConfiguratorSampler:
-    def test_configure_sampler_disabled(
-        self,
-        mocker,
-        mock_apmconfig_disabled,
-        mock_oboe_api_obj,
-        mock_tracerprovider,
-    ):
-        # Mock Otel
-        resource_mocks = get_resource_mocks(mocker)
-        trace_mocks = get_trace_mocks(mocker)
-
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_sampler(
-            mock_apmconfig_disabled,
-            mocker.Mock(),
-            mock_oboe_api_obj,
-        )
-
-        # sets tracer_provider with noop
-        trace_mocks.NoOpTracerProvider.assert_called_once()
-        trace_mocks.set_tracer_provider.assert_called_once()
-        
-        # resource and real provider not used
-        resource_mocks.create.assert_not_called()
-        mock_tracerprovider.assert_not_called()  
-
     def test_configure_sampler_error(
         self,
         mocker,
         mock_apmconfig_enabled,
-        mock_oboe_api_obj,
+        mock_oboe_api_obj_legacy,
         mock_tracerprovider,
     ):
         # Mock entry points
@@ -66,7 +40,7 @@ class TestConfiguratorSampler:
             test_configurator._configure_sampler(
                 mock_apmconfig_enabled,
                 mocker.Mock(),
-                mock_oboe_api_obj,
+                mock_oboe_api_obj_legacy,
             )
 
         # no tracer_provider is set
@@ -79,7 +53,7 @@ class TestConfiguratorSampler:
         self,
         mocker,
         mock_apmconfig_enabled,
-        mock_oboe_api_obj,
+        mock_oboe_api_obj_legacy,
         mock_tracerprovider,
     ):
         # Mock entry points
@@ -111,7 +85,7 @@ class TestConfiguratorSampler:
         test_configurator._configure_sampler(
             mock_apmconfig_enabled,
             mocker.Mock(),
-            mock_oboe_api_obj,
+            mock_oboe_api_obj_legacy,
         )
 
         # tracer_provider set with new resource using configured service_name
@@ -137,7 +111,7 @@ class TestConfiguratorSampler:
         self,
         mocker,
         mock_apmconfig_enabled,
-        mock_oboe_api_obj,
+        mock_oboe_api_obj_legacy,
         mock_tracerprovider,
     ):
         # Save any SAMPLER env var for later
@@ -186,7 +160,7 @@ class TestConfiguratorSampler:
         test_configurator._configure_sampler(
             mock_apmconfig_enabled,
             mocker.Mock(),
-            mock_oboe_api_obj,
+            mock_oboe_api_obj_legacy,
         )
 
         # sampler loaded was solarwinds_sampler, not configured foo_sampler


### PR DESCRIPTION
Note: This will merge into epic feature branch `NH-79205-otlp-by-default`

This makes initialization of custom OTel components explicitly dependent on Legacy Mode (`SW_APM_LEGACY`) within `_configure_otel_components`. The implicit dependency on supported env vars like `OTEL_METRICS_EXPORTER` still exists in the helper functions to keep supporting upstream config options. But now there is a clear line at 'top level' for internal component setup. Traces exporter is always configured with either default values set by SolarWindsDistro or user-set `OTEL_TRACES_EXPORTER`.

This also centralizes agent enabled vs disabled behaviour into `_configure_otel_components`, rather than having some but not all of the helpers doing it (probably some code smell).