### PR TITLE
NH-98561 Breaking: Update metrics/logs-from-OTel opt-in and existing config

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -279,19 +279,14 @@ class SolarWindsApmConfig:
     @classmethod
     def calculate_logs_enabled(
         cls,
-        is_legacy: bool = False,
         cnf_dict: dict = None,
     ) -> bool:
         """Return if export of instrumentor logs telemetry enabled.
         Invalid boolean values are ignored.
-        Order of precedence: Environment Variable > config file > default.
-        Default is True is not legacy, False if legacy.
+        Order of precedence: Environment Variable > config file > default (False).
         Optional cnf_dict is presumably already from a config file, else a call
         to get_cnf_dict() is made for a fresh read."""
-        if is_legacy:
-            logs_enabled = False
-        else:
-            logs_enabled = True
+        logs_enabled = False
         if cnf_dict is None:
             cnf_dict = cls.get_cnf_dict()
         if cnf_dict:

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -244,7 +244,6 @@ class SolarWindsApmConfig:
             noop_extension.OboeAPIOptions,
         )
 
-    # TODO Make cnf_dict required
     @classmethod
     def calculate_is_legacy(
         cls,
@@ -277,7 +276,6 @@ class SolarWindsApmConfig:
             return True
         return False
 
-    # TODO Make cnf_dict required
     @classmethod
     def calculate_logs_enabled(
         cls,
@@ -308,7 +306,6 @@ class SolarWindsApmConfig:
         )
         return env_enabled if env_enabled is not None else logs_enabled
 
-    # TODO Make cnf_dict required
     @classmethod
     def calculate_metrics_enabled(
         cls,

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -335,7 +335,7 @@ class SolarWindsApmConfig:
                 cnf_enabled if cnf_enabled is not None else metrics_enabled
             )
         env_enabled = cls.convert_to_bool(
-            os.environ.get("SW_APM_EXPORT_metrics_ENABLED")
+            os.environ.get("SW_APM_EXPORT_METRICS_ENABLED")
         )
         return env_enabled if env_enabled is not None else metrics_enabled
 

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -281,14 +281,19 @@ class SolarWindsApmConfig:
     @classmethod
     def calculate_logs_enabled(
         cls,
+        is_legacy: bool = False,
         cnf_dict: dict = None,
     ) -> bool:
         """Return if export of instrumentor logs telemetry enabled.
         Invalid boolean values are ignored.
-        Order of precedence: Environment Variable > config file > default True.
+        Order of precedence: Environment Variable > config file > default.
+        Default is True is not legacy, False if legacy.
         Optional cnf_dict is presumably already from a config file, else a call
         to get_cnf_dict() is made for a fresh read."""
-        logs_enabled = True
+        if is_legacy:
+            logs_enabled = False
+        else:
+            logs_enabled = True
         if cnf_dict is None:
             cnf_dict = cls.get_cnf_dict()
         if cnf_dict:
@@ -307,14 +312,19 @@ class SolarWindsApmConfig:
     @classmethod
     def calculate_metrics_enabled(
         cls,
+        is_legacy: bool = False,
         cnf_dict: dict = None,
     ) -> bool:
         """Return if export of instrumentor metrics telemetry enabled.
         Invalid boolean values are ignored.
-        Order of precedence: Environment Variable > config file > default True.
+        Order of precedence: Environment Variable > config file > default.
+        Default is True is not legacy, False if legacy.
         Optional cnf_dict is presumably already from a config file, else a call
         to get_cnf_dict() is made for a fresh read."""
-        metrics_enabled = True
+        if is_legacy:
+            metrics_enabled = False
+        else:
+            metrics_enabled = True
         if cnf_dict is None:
             cnf_dict = cls.get_cnf_dict()
         if cnf_dict:

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -246,14 +246,21 @@ class SolarWindsApmConfig:
             noop_extension.OboeAPIOptions,
         )
 
+    # TODO Make cnf_dict required
     @classmethod
-    def calculate_is_legacy(cls) -> bool:
+    def calculate_is_legacy(
+        cls,
+        cnf_dict: dict = None,
+    ) -> bool:
         """Checks if agent is running in a legacy environment.
         Invalid boolean values are ignored.
-        Order of precedence: Environment Variable > config file > default False
+        Order of precedence: Environment Variable > config file > default False.
+        Optional cnf_dict is presumably already from a config file, else a call
+        to get_cnf_dict() is made for a fresh read.
         """
         is_legacy = False
-        cnf_dict = cls.get_cnf_dict()
+        if cnf_dict is None:
+            cnf_dict = cls.get_cnf_dict()
         if cnf_dict:
             cnf_legacy = cls.convert_to_bool(cnf_dict.get("legacy"))
             is_legacy = cnf_legacy if cnf_legacy is not None else is_legacy

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -409,15 +409,8 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         self,
         apm_config: SolarWindsApmConfig,
     ) -> None:
-        """Configure OTel OTLP metrics exporters if enabled.
-        Settings precedence: OTEL_* > SW_APM_EXPORT_METRICS_ENABLED.
-        Links to new metric readers and global MeterProvider."""
-        if not apm_config.get("export_metrics_enabled"):
-            logger.debug(
-                "APM OTLP metrics export disabled. Skipping init of metrics exporters"
-            )
-            return
-
+        """Configures OTel OTLP metrics exporter(s). Links to new metric
+        readers and global MeterProvider."""
         # SolarWindsDistro._configure does setdefault before this is called
         environ_exporter = os.environ.get(
             OTEL_METRICS_EXPORTER,
@@ -492,26 +485,14 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         self,
         apm_config: SolarWindsApmConfig,
     ) -> None:
-        """Configure OTel OTLP logs exporters if enabled.
-        Settings precedence: OTEL_* > SW_APM_EXPORT_LOGS_ENABLED.
-        Links to new global LoggerProvider."""
-        otel_ev = os.environ.get(
-            _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
-        )
-        otlp_log_enabled = SolarWindsApmConfig.convert_to_bool(otel_ev)
-        sw_enabled = apm_config.get("export_logs_enabled")
-        if otlp_log_enabled is False:
+        """Configures OTel OTLP logs exporter(s), unless OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
+        is set to false i.e. by user. Links to new global LoggerProvider."""
+        if (
+            os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED)
+            is False
+        ):
             logger.debug(
                 "OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED false. Skipping init of logs exporters"
-            )
-            return
-
-        # If otel_ev is True, ignore sw_enabled.
-        # If otel_ev is None (unset or could not convert to bool)
-        # then sw_enabled determines logs export setup.
-        if not otlp_log_enabled and sw_enabled is False:
-            logger.debug(
-                "APM OTLP logs export disabled. Skipping init of logs exporters"
             )
             return
 

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -491,6 +491,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED)
             is False
         ):
+            # TODO (NH-101363): Change to configure stdlib handler not exporter
             logger.debug(
                 "OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED false. Skipping init of logs exporters"
             )

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -308,19 +308,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         apm_config: SolarWindsApmConfig,
         oboe_api: "OboeAPI",
     ) -> None:
-        """Configure SolarWindsOTLPMetricsSpanProcessor (including OTLP meters)
-        if metrics exporters are configured and set up i.e. by _configure_metrics_exporter
-        """
-        # SolarWindsDistro._configure does setdefault before this is called
-        environ_exporter = os.environ.get(
-            OTEL_METRICS_EXPORTER,
-        )
-        if not environ_exporter:
-            logger.debug(
-                "No OTEL_METRICS_EXPORTER set, skipping init of metrics processors"
-            )
-            return
-
+        """Configure SolarWindsOTLPMetricsSpanProcessor with APM OTLP meters"""
         trace.get_tracer_provider().add_span_processor(
             SolarWindsOTLPMetricsSpanProcessor(
                 apm_txname_manager,

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -162,15 +162,10 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                 # Default values are set by SolarWindsDistro; user can customize.
                 if apm_config.get("export_metrics_enabled") is True:
                     self._configure_metrics_exporter(apm_config)
-                    self._configure_otlp_metrics_span_processors(
-                        apm_txname_manager,
-                        apm_config,
-                        oboe_api,
-                    )
                 if apm_config.get("export_logs_enabled") is True:
                     self._configure_logs_exporter(apm_config)
             else:
-                # Export APM metrics, logs by OTLP.
+                # Export APM and Otel instrumentor metrics, logs by OTLP.
                 # Default values are set by SolarWindsDistro; user can customize.
                 self._configure_metrics_exporter(apm_config)
                 self._configure_otlp_metrics_span_processors(

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -157,6 +157,18 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                     apm_txname_manager,
                     apm_config,
                 )
+                # While in legacy mode, user can also opt into exporting
+                # metrics and logs by OTLP.
+                # Default values are set by SolarWindsDistro; user can customize.
+                if apm_config.get("export_metrics_enabled") is True:
+                    self._configure_metrics_exporter(apm_config)
+                    self._configure_otlp_metrics_span_processors(
+                        apm_txname_manager,
+                        apm_config,
+                        oboe_api,
+                    )
+                if apm_config.get("export_logs_enabled") is True:
+                    self._configure_logs_exporter(apm_config)
             else:
                 # Export APM metrics, logs by OTLP.
                 # Default values are set by SolarWindsDistro; user can customize.

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -158,7 +158,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                     apm_config,
                 )
                 # While in legacy mode, user can also opt into exporting
-                # metrics and logs by OTLP.
+                # Otel instrumentor metrics and logs by OTLP.
                 # Default values are set by SolarWindsDistro; user can customize.
                 if apm_config.get("export_metrics_enabled") is True:
                     self._configure_metrics_exporter(apm_config)

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -24,10 +24,7 @@ from opentelemetry.instrumentation.logging.environment_variables import (
 )
 from opentelemetry.instrumentation.version import __version__ as inst_version
 from opentelemetry.metrics import NoOpMeterProvider
-from opentelemetry.sdk.environment_variables import (
-    _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
-    OTEL_EXPORTER_OTLP_PROTOCOL,
-)
+from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_PROTOCOL
 from opentelemetry.sdk.version import __version__ as sdk_version
 from opentelemetry.util._importlib_metadata import EntryPoint
 
@@ -213,11 +210,12 @@ class SolarWindsDistro(BaseDistro):
                     header_token, otlp_protocol
                 )
 
-                # APM Python enables logging auto-instrumentation by default
-                environ.setdefault(
-                    _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
-                    "true",
-                )
+                # TODO (NH-101363): APM Python enables logging auto-instrumentation
+                # by default to configure logging stdlib handler
+                # environ.setdefault(
+                #     _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
+                #     "true",
+                # )
 
             else:
                 logger.warning(

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -22,7 +22,10 @@ from opentelemetry.instrumentation.logging.environment_variables import (
     OTEL_PYTHON_LOG_FORMAT,
 )
 from opentelemetry.instrumentation.version import __version__ as inst_version
-from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_PROTOCOL
+from opentelemetry.sdk.environment_variables import (
+    _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
+    OTEL_EXPORTER_OTLP_PROTOCOL,
+)
 from opentelemetry.sdk.version import __version__ as sdk_version
 from opentelemetry.util._importlib_metadata import EntryPoint
 
@@ -191,13 +194,19 @@ class SolarWindsDistro(BaseDistro):
                         header_token, otlp_protocol
                     )
 
-                # We do OTLP export setdefault if legacy or not
-                # in case SW_APM_EXPORT_METRICS_ENABLED
+                # We do OTLP export setdefault if legacy too
+                # in case SW_APM_EXPORT_(METRICS|LOGS)_ENABLED
                 self._configure_logs_export_otlp_env_defaults(
                     header_token, otlp_protocol
                 )
                 self._configure_metrics_export_otlp_env_defaults(
                     header_token, otlp_protocol
+                )
+
+                # APM Python enables logging auto-instrumentation by default
+                environ.setdefault(
+                    _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
+                    "true",
                 )
 
             else:

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -57,6 +57,14 @@ logger = logging.getLogger(__name__)
 class SolarWindsDistro(BaseDistro):
     """OpenTelemetry Distro for SolarWinds reporting environment"""
 
+    _cnf_dict = None
+
+    def __new__(cls, *args, **kwargs):
+        # Maintain singleton pattern and cache config dict
+        if cls._cnf_dict is None:
+            cls._cnf_dict = SolarWindsApmConfig.get_cnf_dict()
+        return super().__new__(cls, *args, **kwargs)
+
     def _log_python_runtime(self):
         """Logs Python runtime info, with any warnings"""
         python_vers = platform.python_version()
@@ -175,7 +183,7 @@ class SolarWindsDistro(BaseDistro):
         # Protocol is the above default or what user has set
         otlp_protocol = environ.get(OTEL_EXPORTER_OTLP_PROTOCOL)
 
-        is_legacy = SolarWindsApmConfig.calculate_is_legacy()
+        is_legacy = SolarWindsApmConfig.calculate_is_legacy(self._cnf_dict)
 
         if otlp_protocol:
             if otlp_protocol in _EXPORTER_BY_OTLP_PROTOCOL:

--- a/solarwinds_apm/trace/otlp_metrics_processor.py
+++ b/solarwinds_apm/trace/otlp_metrics_processor.py
@@ -72,7 +72,7 @@ class SolarWindsOTLPMetricsSpanProcessor(_SwBaseMetricsProcessor):
         return "unknown"
 
     def on_end(self, span: "ReadableSpan") -> None:
-        """Calculates and reports OTLP trace metrics"""
+        """Calculates and reports APM OTLP trace metrics"""
         # Only calculate OTLP metrics for service entry spans
         parent_span_context = span.parent
         if (

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -379,14 +379,9 @@ class TestSolarWindsApmConfig:
         mock_certs = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig._calculate_certificates"
         )
-        mock_logs_enabled = mocker.patch(
-            "solarwinds_apm.apm_config.SolarWindsApmConfig._calculate_logs_enabled"
-        )
-
         apm_config.SolarWindsApmConfig()
         mock_metric_format.assert_called_once()
         mock_certs.assert_called_once()
-        mock_logs_enabled.assert_called_once()
 
     def test_calculate_metric_format_no_collector(self, mocker):
         assert apm_config.SolarWindsApmConfig()._calculate_metric_format() == 2
@@ -538,104 +533,6 @@ class TestSolarWindsApmConfig:
         )
         mock_get_public_cert.configure_mock(return_value="foo")
         assert apm_config.SolarWindsApmConfig()._calculate_certificates() == "bar"
-
-    def test_calculate_logs_enabled_no_collector_enabled(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_COLLECTOR": "",
-            "SW_APM_EXPORT_LOGS_ENABLED": "true",
-        })
-        assert apm_config.SolarWindsApmConfig()._calculate_logs_enabled() == True
-
-    def test_calculate_logs_enabled_no_collector_disabled(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_COLLECTOR": "",
-            "SW_APM_EXPORT_LOGS_ENABLED": "false",
-        })
-        assert apm_config.SolarWindsApmConfig()._calculate_logs_enabled() == False
-
-    def test_calculate_logs_enabled_not_ao_enabled(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_COLLECTOR": "some-other-collector",
-            "SW_APM_EXPORT_LOGS_ENABLED": "true",
-        })
-        assert apm_config.SolarWindsApmConfig()._calculate_logs_enabled() == True
-
-    def test_calculate_logs_enabled_not_ao_disabled(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_COLLECTOR": "some-other-collector",
-            "SW_APM_EXPORT_LOGS_ENABLED": "false",
-        })
-        assert apm_config.SolarWindsApmConfig()._calculate_logs_enabled() == False
-
-    def test_calculate_logs_enabled_ao_prod(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_COLLECTOR": INTL_SWO_AO_COLLECTOR,
-            "SW_APM_EXPORT_LOGS_ENABLED": "true",
-        })
-        assert apm_config.SolarWindsApmConfig()._calculate_logs_enabled() == False
-
-    def test_calculate_logs_enabled_ao_staging(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_COLLECTOR": INTL_SWO_AO_STG_COLLECTOR,
-            "SW_APM_EXPORT_LOGS_ENABLED": "true",
-        })
-        assert apm_config.SolarWindsApmConfig()._calculate_logs_enabled() == False
-
-    def test_calculate_logs_enabled_ao_prod_with_port(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_COLLECTOR": "{}:123".format(INTL_SWO_AO_COLLECTOR),
-            "SW_APM_EXPORT_LOGS_ENABLED": "true",
-        })
-        assert apm_config.SolarWindsApmConfig()._calculate_logs_enabled() == False
-
-    def test_calculate_metrics_enabled_no_collector_enabled(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_COLLECTOR": "",
-            "SW_APM_EXPORT_METRICS_ENABLED": "true",
-        })
-        assert apm_config.SolarWindsApmConfig()._calculate_metrics_enabled() == True
-
-    def test_calculate_metrics_enabled_no_collector_disabled(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_COLLECTOR": "",
-            "SW_APM_EXPORT_METRICS_ENABLED": "false",
-        })
-        assert apm_config.SolarWindsApmConfig()._calculate_metrics_enabled() == False
-
-    def test_calculate_metrics_enabled_not_ao_enabled(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_COLLECTOR": "some-other-collector",
-            "SW_APM_EXPORT_METRICS_ENABLED": "true",
-        })
-        assert apm_config.SolarWindsApmConfig()._calculate_metrics_enabled() == True
-
-    def test_calculate_metrics_enabled_not_ao_disabled(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_COLLECTOR": "some-other-collector",
-            "SW_APM_EXPORT_METRICS_ENABLED": "false",
-        })
-        assert apm_config.SolarWindsApmConfig()._calculate_metrics_enabled() == False
-
-    def test_calculate_metrics_enabled_ao_prod(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_COLLECTOR": INTL_SWO_AO_COLLECTOR,
-            "SW_APM_EXPORT_METRICS_ENABLED": "true",
-        })
-        assert apm_config.SolarWindsApmConfig()._calculate_metrics_enabled() == False
-
-    def test_calculate_metrics_enabled_ao_staging(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_COLLECTOR": INTL_SWO_AO_STG_COLLECTOR,
-            "SW_APM_EXPORT_METRICS_ENABLED": "true",
-        })
-        assert apm_config.SolarWindsApmConfig()._calculate_metrics_enabled() == False
-
-    def test_calculate_metrics_enabled_ao_prod_with_port(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_COLLECTOR": "{}:123".format(INTL_SWO_AO_COLLECTOR),
-            "SW_APM_EXPORT_METRICS_ENABLED": "true",
-        })
-        assert apm_config.SolarWindsApmConfig()._calculate_metrics_enabled() == False
 
     def test_mask_service_key_no_key_empty_default(self, mocker):
         mock_entry_points = mocker.patch(

--- a/tests/unit/test_apm_config/test_apm_config_calculate_logs_enabled.py
+++ b/tests/unit/test_apm_config/test_apm_config_calculate_logs_enabled.py
@@ -14,37 +14,32 @@ class TestSolarWindsApmConfigCalculateLogsEnabled:
         # Clear environment variables before each test
         os.environ.clear()
 
-    def test_calculate_logs_enabled_default_non_legacy(self, mocker):
+    def test_calculate_logs_enabled_default(self, mocker):
         mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={})
-        assert SolarWindsApmConfig.calculate_logs_enabled() is True
-
-    def test_calculate_logs_enabled_default_legacy(self, mocker):
-        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={})
-        assert SolarWindsApmConfig.calculate_logs_enabled(is_legacy=True) is False
+        assert SolarWindsApmConfig.calculate_logs_enabled() is False
 
     def test_calculate_logs_enabled_with_env_var_true(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_EXPORT_LOGS_ENABLED": "true"})
-        assert SolarWindsApmConfig.calculate_logs_enabled(is_legacy=False) is True
+        assert SolarWindsApmConfig.calculate_logs_enabled() is True
 
     def test_calculate_logs_enabled_with_env_var_false(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_EXPORT_LOGS_ENABLED": "false"})
-        assert SolarWindsApmConfig.calculate_logs_enabled(is_legacy=True) is False
+        assert SolarWindsApmConfig.calculate_logs_enabled() is False
 
     def test_calculate_logs_enabled_with_config_not_provided_true(self, mocker):
         mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"export_logs_enabled": "true"})
         mocker.patch.object(SolarWindsApmConfig, 'convert_to_bool', return_value=True)
-        assert SolarWindsApmConfig.calculate_logs_enabled(is_legacy=True) is True
+        assert SolarWindsApmConfig.calculate_logs_enabled() is True
 
     def test_calculate_logs_enabled_with_config_not_provided_false(self, mocker):
         mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"export_logs_enabled": "false"})
         mocker.patch.object(SolarWindsApmConfig, 'convert_to_bool', return_value=False)
-        assert SolarWindsApmConfig.calculate_logs_enabled(is_legacy=False) is False
+        assert SolarWindsApmConfig.calculate_logs_enabled() is False
 
     def test_calculate_logs_enabled_with_config_not_boolean(self, mocker):
         assert SolarWindsApmConfig.calculate_logs_enabled(
-            is_legacy=False,
             cnf_dict={"export_logs_enabled": "foo-bar"}
-        ) is True
+        ) is False
 
     def test_calculate_logs_enabled_with_config_not_provided_and_env_var(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_EXPORT_LOGS_ENABLED": "true"})

--- a/tests/unit/test_apm_config/test_apm_config_calculate_logs_enabled.py
+++ b/tests/unit/test_apm_config/test_apm_config_calculate_logs_enabled.py
@@ -1,0 +1,57 @@
+# © 2025 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+import os
+import pytest
+from solarwinds_apm.apm_config import SolarWindsApmConfig
+
+class TestSolarWindsApmConfigCalculateLogsEnabled:
+    @pytest.fixture(autouse=True)
+    def clear_env_vars(self):
+        # Clear environment variables before each test
+        os.environ.clear()
+
+    def test_calculate_logs_enabled_default_non_legacy(self, mocker):
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={})
+        assert SolarWindsApmConfig.calculate_logs_enabled() is True
+
+    def test_calculate_logs_enabled_default_legacy(self, mocker):
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={})
+        assert SolarWindsApmConfig.calculate_logs_enabled(is_legacy=True) is False
+
+    def test_calculate_logs_enabled_with_env_var_true(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_EXPORT_LOGS_ENABLED": "true"})
+        assert SolarWindsApmConfig.calculate_logs_enabled(is_legacy=False) is True
+
+    def test_calculate_logs_enabled_with_env_var_false(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_EXPORT_LOGS_ENABLED": "false"})
+        assert SolarWindsApmConfig.calculate_logs_enabled(is_legacy=True) is False
+
+    def test_calculate_logs_enabled_with_config_not_provided_true(self, mocker):
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"export_logs_enabled": "true"})
+        mocker.patch.object(SolarWindsApmConfig, 'convert_to_bool', return_value=True)
+        assert SolarWindsApmConfig.calculate_logs_enabled(is_legacy=True) is True
+
+    def test_calculate_logs_enabled_with_config_not_provided_false(self, mocker):
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"export_logs_enabled": "false"})
+        mocker.patch.object(SolarWindsApmConfig, 'convert_to_bool', return_value=False)
+        assert SolarWindsApmConfig.calculate_logs_enabled(is_legacy=False) is False
+
+    def test_calculate_logs_enabled_with_config_not_boolean(self, mocker):
+        assert SolarWindsApmConfig.calculate_logs_enabled(
+            is_legacy=False,
+            cnf_dict={"export_logs_enabled": "foo-bar"}
+        ) is True
+
+    def test_calculate_logs_enabled_with_config_not_provided_and_env_var(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_EXPORT_LOGS_ENABLED": "true"})
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"export_logs_enabled": "false"})
+        assert SolarWindsApmConfig.calculate_logs_enabled() is True
+
+    def test_calculate_logs_enabled_with_provided_cnf_dict(self, mocker):
+        mock_get_cnf_dict = mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict')
+        assert SolarWindsApmConfig.calculate_logs_enabled(cnf_dict={"export_logs_enabled": True}) is True
+        mock_get_cnf_dict.assert_not_called()

--- a/tests/unit/test_apm_config/test_apm_config_calculate_metrics_enabled.py
+++ b/tests/unit/test_apm_config/test_apm_config_calculate_metrics_enabled.py
@@ -1,0 +1,57 @@
+# © 2025 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+import os
+import pytest
+from solarwinds_apm.apm_config import SolarWindsApmConfig
+
+class TestSolarWindsApmConfigCalculateMetricsEnabled:
+    @pytest.fixture(autouse=True)
+    def clear_env_vars(self):
+        # Clear environment variables before each test
+        os.environ.clear()
+
+    def test_calculate_metrics_enabled_default_non_legacy(self, mocker):
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={})
+        assert SolarWindsApmConfig.calculate_metrics_enabled() is True
+
+    def test_calculate_metrics_enabled_default_legacy(self, mocker):
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={})
+        assert SolarWindsApmConfig.calculate_metrics_enabled(is_legacy=True) is False
+
+    def test_calculate_metrics_enabled_with_env_var_true(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_EXPORT_METRICS_ENABLED": "true"})
+        assert SolarWindsApmConfig.calculate_metrics_enabled(is_legacy=False) is True
+
+    def test_calculate_metrics_enabled_with_env_var_false(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_EXPORT_METRICS_ENABLED": "false"})
+        assert SolarWindsApmConfig.calculate_metrics_enabled(is_legacy=True) is False
+
+    def test_calculate_metrics_enabled_with_config_not_provided_true(self, mocker):
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"export_metrics_enabled": "true"})
+        mocker.patch.object(SolarWindsApmConfig, 'convert_to_bool', return_value=True)
+        assert SolarWindsApmConfig.calculate_metrics_enabled(is_legacy=True) is True
+
+    def test_calculate_metrics_enabled_with_config_not_provided_false(self, mocker):
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"export_metrics_enabled": "false"})
+        mocker.patch.object(SolarWindsApmConfig, 'convert_to_bool', return_value=False)
+        assert SolarWindsApmConfig.calculate_metrics_enabled(is_legacy=False) is False
+
+    def test_calculate_metrics_enabled_with_config_not_boolean(self, mocker):
+        assert SolarWindsApmConfig.calculate_metrics_enabled(
+            is_legacy=False,
+            cnf_dict={"export_metrics_enabled": "foo-bar"}
+        ) is True
+
+    def test_calculate_metrics_enabled_with_config_not_provided_and_env_var(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_EXPORT_METRICS_ENABLED": "true"})
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"export_metrics_enabled": "false"})
+        assert SolarWindsApmConfig.calculate_metrics_enabled() is True
+
+    def test_calculate_metrics_enabled_with_provided_cnf_dict(self, mocker):
+        mock_get_cnf_dict = mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict')
+        assert SolarWindsApmConfig.calculate_metrics_enabled(cnf_dict={"export_metrics_enabled": True}) is True
+        mock_get_cnf_dict.assert_not_called()

--- a/tests/unit/test_apm_config/test_apm_config_is_legacy.py
+++ b/tests/unit/test_apm_config/test_apm_config_is_legacy.py
@@ -29,79 +29,156 @@ class TestSolarWindsApmConfigIsLegacy:
         mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "true"})
         assert SolarWindsApmConfig.calculate_is_legacy() is True
 
-    def test_calculate_is_legacy_with_config_not_boolean(self, mocker):
+    def test_calculate_is_legacy_with_unread_config_not_boolean(self, mocker):
         mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
             return_value={"legacy": "foo-bar"},
         )
         assert SolarWindsApmConfig.calculate_is_legacy() is False
 
-    def test_calculate_is_legacy_with_config_false(self, mocker):
+    def test_calculate_is_legacy_with_unread_config_false(self, mocker):
         mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
             return_value={"legacy": "false"},
         )
         assert SolarWindsApmConfig.calculate_is_legacy() is False
 
-    def test_calculate_is_legacy_with_config_true(self, mocker):
+    def test_calculate_is_legacy_with_unread_config_true(self, mocker):
         mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
             return_value={"legacy": "true"},
         )
         assert SolarWindsApmConfig.calculate_is_legacy() is True
+
+    def test_calculate_is_legacy_with_unread_config_not_bool_env_var_not_bool(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "foo-bar"})
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "foo-bar"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is False
+
+    def test_calculate_is_legacy_with_unread_config_false_env_var_false(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "false"})
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "false"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is False
+
+    def test_calculate_is_legacy_with_unread_config_false_env_var_true(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "true"})
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "false"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is True
+
+    def test_calculate_is_legacy_with_unread_config_not_bool_env_var_true(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "true"})
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "foo-bar"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is True
+
+    def test_calculate_is_legacy_with_unread_config_true_env_var_false(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "false"})
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "true"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is False
+
+    def test_calculate_is_legacy_with_unread_config_true_env_var_not_bool(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "foo-bar"})
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "true"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is True
+
+    def test_calculate_is_legacy_with_unread_config_true_env_var_true(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "true"})
+        mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"legacy": "true"},
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy() is True
+
+    def test_calculate_is_legacy_with_config_not_boolean(self, mocker):
+        mock_get_cnf = mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy({"legacy": "foo-bar"}) is False
+        mock_get_cnf.assert_not_called()
+
+    def test_calculate_is_legacy_with_config_false(self, mocker):
+        mock_get_cnf = mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy({"legacy": "false"}) is False
+        mock_get_cnf.assert_not_called()
+
+    def test_calculate_is_legacy_with_config_true(self, mocker):
+        mock_get_cnf = mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
+        )
+        assert SolarWindsApmConfig.calculate_is_legacy({"legacy": "true"}) is True
+        mock_get_cnf.assert_not_called()
 
     def test_calculate_is_legacy_with_config_not_bool_env_var_not_bool(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "foo-bar"})
-        mocker.patch(
+        mock_get_cnf = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
-            return_value={"legacy": "foo-bar"},
         )
-        assert SolarWindsApmConfig.calculate_is_legacy() is False
+        assert SolarWindsApmConfig.calculate_is_legacy({"legacy": "foo-bar"}) is False
+        mock_get_cnf.assert_not_called()
 
     def test_calculate_is_legacy_with_config_false_env_var_false(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "false"})
-        mocker.patch(
+        mock_get_cnf =  mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
-            return_value={"legacy": "false"},
         )
-        assert SolarWindsApmConfig.calculate_is_legacy() is False
+        assert SolarWindsApmConfig.calculate_is_legacy({"legacy": "false"}) is False
+        mock_get_cnf.assert_not_called()
 
     def test_calculate_is_legacy_with_config_false_env_var_true(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "true"})
-        mocker.patch(
+        mock_get_cnf = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
-            return_value={"legacy": "false"},
         )
-        assert SolarWindsApmConfig.calculate_is_legacy() is True
+        assert SolarWindsApmConfig.calculate_is_legacy({"legacy": "false"}) is True
+        mock_get_cnf.assert_not_called()
 
     def test_calculate_is_legacy_with_config_not_bool_env_var_true(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "true"})
-        mocker.patch(
+        mock_get_cnf = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
-            return_value={"legacy": "foo-bar"},
         )
-        assert SolarWindsApmConfig.calculate_is_legacy() is True
+        assert SolarWindsApmConfig.calculate_is_legacy({"legacy": "foo-bar"}) is True
+        mock_get_cnf.assert_not_called()
 
     def test_calculate_is_legacy_with_config_true_env_var_false(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "false"})
-        mocker.patch(
+        mock_get_cnf = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
-            return_value={"legacy": "true"},
         )
-        assert SolarWindsApmConfig.calculate_is_legacy() is False
+        assert SolarWindsApmConfig.calculate_is_legacy({"legacy": "true"}) is False
+        mock_get_cnf.assert_not_called()
 
     def test_calculate_is_legacy_with_config_true_env_var_not_bool(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "foo-bar"})
-        mocker.patch(
+        mock_get_cnf = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
-            return_value={"legacy": "true"},
         )
-        assert SolarWindsApmConfig.calculate_is_legacy() is True
+        assert SolarWindsApmConfig.calculate_is_legacy({"legacy": "true"}) is True
+        mock_get_cnf.assert_not_called()
 
     def test_calculate_is_legacy_with_config_true_env_var_true(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_LEGACY": "true"})
-        mocker.patch(
+        mock_get_cnf = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict",
-            return_value={"legacy": "true"},
         )
-        assert SolarWindsApmConfig.calculate_is_legacy() is True
+        assert SolarWindsApmConfig.calculate_is_legacy({"legacy": "true"}) is True
+        mock_get_cnf.assert_not_called()

--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -228,6 +228,20 @@ def mock_apmconfig_enabled_legacy(mocker):
         "solarwinds_apm.configurator.SolarWindsApmConfig",
         get_apmconfig_mocks(
             mocker,
+            export_logs_enabled=False,
+            export_metrics_enabled=False,
+            legacy=True,
+        )
+    )
+
+@pytest.fixture(name="mock_apmconfig_enabled_legacy_opt_in_metrics_logs")
+def mock_apmconfig_enabled_legacy_opt_in_metrics_logs(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsApmConfig",
+        get_apmconfig_mocks(
+            mocker,
+            export_logs_enabled=True,
+            export_metrics_enabled=True,
             legacy=True,
         )
     )

--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -222,6 +222,17 @@ def mock_apmconfig_enabled(mocker):
         )
     )
 
+@pytest.fixture(name="mock_apmconfig_enabled_metrics_logs_false")
+def mock_apmconfig_enabled_metrics_logs_false(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsApmConfig",
+        get_apmconfig_mocks(
+            mocker,
+            export_logs_enabled=False,
+            export_metrics_enabled=False,
+        )
+    )
+
 @pytest.fixture(name="mock_apmconfig_enabled_legacy")
 def mock_apmconfig_enabled_legacy(mocker):
     return mocker.patch(

--- a/tests/unit/test_configurator/test_configurator_configure_otel.py
+++ b/tests/unit/test_configurator/test_configurator_configure_otel.py
@@ -183,11 +183,7 @@ class TestConfiguratorConfigureOtelComponents:
             mock_txn_name_manager,
             mock_apmconfig_enabled_legacy_opt_in_metrics_logs,
         )
-        mock_config_otlp_processors.assert_called_once_with(
-            mock_txn_name_manager,
-            mock_apmconfig_enabled_legacy_opt_in_metrics_logs,
-            mock_oboe_api_obj_legacy, 
-        )
+        mock_config_otlp_processors.assert_not_called()
         mock_config_traces_exp.assert_called_once_with(
             mock_extension.Reporter,
             mock_txn_name_manager,

--- a/tests/unit/test_configurator/test_configurator_configure_otel.py
+++ b/tests/unit/test_configurator/test_configurator_configure_otel.py
@@ -53,6 +53,58 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_propagator.assert_called_once()
         mock_config_response_propagator.assert_called_once()
 
+    def test_configure_otel_components_agent_enabled_non_legacy_metrics_logs_false(
+        self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_enabled_metrics_logs_false,
+        mock_oboe_api_obj_non_legacy,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_propagator,
+        mock_config_response_propagator,
+    ):
+        test_configurator = configurator.SolarWindsConfigurator()
+        test_configurator._configure_otel_components(
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_apmconfig_enabled_metrics_logs_false,
+            mock_extension.Reporter,
+            mock_oboe_api_obj_non_legacy,
+        )
+
+        mock_config_serviceentryid_processor.assert_called_once()
+        mock_config_inbound_processor.assert_not_called()
+        mock_config_otlp_processors.assert_called_once_with(
+            mock_txn_name_manager,
+            mock_apmconfig_enabled_metrics_logs_false, 
+            mock_oboe_api_obj_non_legacy,
+        )
+        mock_config_traces_exp.assert_called_once_with(
+            mock_extension.Reporter,
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_apmconfig_enabled_metrics_logs_false,
+        )
+        # If SW_APM_EXPORT_(METRICS|LOGS) is False while non-legacy,
+        # metrics/logs exporters are still configured for APM telemetry
+        mock_config_metrics_exp.assert_called_once_with(
+            mock_apmconfig_enabled_metrics_logs_false
+        )
+        mock_config_logs_exp.assert_called_once_with(
+            mock_apmconfig_enabled_metrics_logs_false
+        )
+        mock_config_propagator.assert_called_once()
+        mock_config_response_propagator.assert_called_once()
+
     def test_configure_otel_components_agent_enabled_legacy(
         self,
         mocker,

--- a/tests/unit/test_configurator/test_configurator_configure_otel.py
+++ b/tests/unit/test_configurator/test_configurator_configure_otel.py
@@ -98,6 +98,59 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_propagator.assert_called_once()
         mock_config_response_propagator.assert_called_once()
 
+    def test_configure_otel_components_agent_enabled_legacy_opt_in_metrics_logs(
+        self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_enabled_legacy_opt_in_metrics_logs,
+        mock_oboe_api_obj_legacy,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_propagator,
+        mock_config_response_propagator,
+    ):
+        test_configurator = configurator.SolarWindsConfigurator()
+        test_configurator._configure_otel_components(
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_apmconfig_enabled_legacy_opt_in_metrics_logs,
+            mock_extension.Reporter,
+            mock_oboe_api_obj_legacy,
+        )
+
+        mock_config_serviceentryid_processor.assert_called_once()
+        mock_config_inbound_processor.assert_called_once_with(
+            mock_txn_name_manager,
+            mock_apmconfig_enabled_legacy_opt_in_metrics_logs,
+        )
+        mock_config_otlp_processors.assert_called_once_with(
+            mock_txn_name_manager,
+            mock_apmconfig_enabled_legacy_opt_in_metrics_logs,
+            mock_oboe_api_obj_legacy, 
+        )
+        mock_config_traces_exp.assert_called_once_with(
+            mock_extension.Reporter,
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_apmconfig_enabled_legacy_opt_in_metrics_logs,
+        )
+        mock_config_metrics_exp.assert_called_once_with(
+            mock_apmconfig_enabled_legacy_opt_in_metrics_logs
+        )
+        mock_config_logs_exp.assert_called_once_with(
+            mock_apmconfig_enabled_legacy_opt_in_metrics_logs
+        )
+        mock_config_propagator.assert_called_once()
+        mock_config_response_propagator.assert_called_once()
+
     def test_configure_otel_components_agent_disabled_non_legacy(
         self,
         mocker,

--- a/tests/unit/test_configurator/test_configurator_logs_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_logs_exporter.py
@@ -61,7 +61,7 @@ class TestConfiguratorLogsExporter:
         mock_blprocessor.assert_not_called()
         mock_logginghandler.assert_not_called()
 
-    def test_configure_logs_exporter_otel_false_sw_any(
+    def test_configure_logs_exporter_otel_false(
         self,
         mocker,
         mock_apmconfig_enabled,
@@ -88,7 +88,7 @@ class TestConfiguratorLogsExporter:
         mock_blprocessor.assert_not_called()
         mock_logginghandler.assert_not_called()
 
-    def test_configure_logs_exporter_otel_none_sw_false(
+    def test_configure_logs_exporter_otel_none(
         self,
         mocker,
         mock_apmconfig_logs_enabled_false,
@@ -115,61 +115,7 @@ class TestConfiguratorLogsExporter:
         mock_blprocessor.assert_not_called()
         mock_logginghandler.assert_not_called()
 
-    def test_configure_logs_exporter_otel_true_sw_false(
-        self,
-        mocker,
-        mock_apmconfig_logs_enabled_false,
-        mock_blprocessor,
-        mock_loggerprovider,
-        mock_logginghandler,
-    ):
-        mocker.patch.dict(
-            os.environ,
-            {
-                _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED: "true"
-            }
-        )
-        trace_mocks = get_trace_mocks(mocker)
-
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_logs_exporter(
-            mock_apmconfig_logs_enabled_false,
-        )
-
-        trace_mocks.get_tracer_provider.assert_not_called()
-        trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
-        mock_loggerprovider.assert_not_called()
-        mock_blprocessor.assert_not_called()
-        mock_logginghandler.assert_not_called()
-
-    def test_configure_logs_exporter_otel_true_sw_none(
-        self,
-        mocker,
-        mock_apmconfig_logs_enabled_none,
-        mock_blprocessor,
-        mock_loggerprovider,
-        mock_logginghandler,
-    ):
-        mocker.patch.dict(
-            os.environ,
-            {
-                _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED: "true"
-            }
-        )
-        trace_mocks = get_trace_mocks(mocker)
-
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_logs_exporter(
-            mock_apmconfig_logs_enabled_none,
-        )
-
-        trace_mocks.get_tracer_provider.assert_not_called()
-        trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
-        mock_loggerprovider.assert_not_called()
-        mock_blprocessor.assert_not_called()
-        mock_logginghandler.assert_not_called()
-
-    def test_configure_logs_exporter_otel_true_sw_true_no_exporter(
+    def test_configure_logs_exporter_otel_true_no_exporter(
         self,
         mocker,
         mock_apmconfig_enabled,
@@ -197,7 +143,7 @@ class TestConfiguratorLogsExporter:
         mock_blprocessor.assert_not_called()
         mock_logginghandler.assert_not_called()
 
-    def test_configure_logs_exporter_otel_true_sw_true_invalid_exporter(
+    def test_configure_logs_exporter_otel_true_invalid_exporter(
         self,
         mocker,
         mock_apmconfig_enabled,
@@ -236,7 +182,7 @@ class TestConfiguratorLogsExporter:
         mock_blprocessor.assert_not_called()
         mock_logginghandler.assert_not_called()
 
-    def test_configure_logs_exporter_otel_true_sw_true_not_lambda(
+    def test_configure_logs_exporter_otel_true_valid_exporter(
         self,
         mocker,
         mock_apmconfig_enabled,

--- a/tests/unit/test_configurator/test_configurator_metrics_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_metrics_exporter.py
@@ -16,46 +16,6 @@ from .fixtures.trace import get_trace_mocks
 
 
 class TestConfiguratorMetricsExporter:
-    def test_configure_metrics_exporter_sw_enabled_false(
-        self,
-        mocker,
-        mock_apmconfig_metrics_enabled_false,
-        mock_pemreader,
-        mock_meterprovider,
-    ):
-        # Mock Otel
-        trace_mocks = get_trace_mocks(mocker)
-
-        # Test!
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_metrics_exporter(
-            mock_apmconfig_metrics_enabled_false,
-        )
-        mock_pemreader.assert_not_called()
-        trace_mocks.get_tracer_provider.assert_not_called()
-        trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
-        mock_meterprovider.assert_not_called()
-
-    def test_configure_metrics_exporter_sw_enabled_none(
-        self,
-        mocker,
-        mock_apmconfig_metrics_enabled_none,
-        mock_pemreader,
-        mock_meterprovider,
-    ):
-        # Mock Otel
-        trace_mocks = get_trace_mocks(mocker)
-
-        # Test!
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_metrics_exporter(
-            mock_apmconfig_metrics_enabled_none,
-        )
-        mock_pemreader.assert_not_called()
-        trace_mocks.get_tracer_provider.assert_not_called()
-        trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
-        mock_meterprovider.assert_not_called()
-
     def test_configure_metrics_exporter_none(
         self,
         mocker,

--- a/tests/unit/test_configurator/test_configurator_span_processors.py
+++ b/tests/unit/test_configurator/test_configurator_span_processors.py
@@ -121,57 +121,13 @@ class TestConfiguratorSpanProcessors:
         if old_exporter:
             os.environ["OTEL_TRACES_EXPORTER"] = old_exporter
 
-    def test_configure_otlp_metrics_span_processors_exporters_not_set(
+    def test_configure_otlp_metrics_span_processors(
         self,
         mocker,
         mock_apmconfig_enabled,
         mock_txn_name_manager,
         mock_meter_manager,
     ):
-        # Save any exporters in os for later
-        old_exporter = os.environ.get("OTEL_METRICS_EXPORTER", None)
-        if old_exporter:
-            del os.environ["OTEL_METRICS_EXPORTER"]
-        mocker.patch.dict(os.environ, {
-            "OTEL_METRICS_EXPORTER": "",
-        })
-
-        trace_mocks = get_trace_mocks(mocker)
-        mock_processor_instance = mocker.Mock()
-        mock_otlp_processor = mocker.patch(
-            "solarwinds_apm.configurator.SolarWindsOTLPMetricsSpanProcessor",
-            return_value=mock_processor_instance,
-        )
-
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_otlp_metrics_span_processors(
-            mock_txn_name_manager,
-            mock_apmconfig_enabled,
-            mock_meter_manager,
-        )
-        trace_mocks.get_tracer_provider.assert_not_called()
-        trace_mocks.get_tracer_provider().add_span_processor.assert_not_called()
-        mock_otlp_processor.assert_not_called()
-
-        # Restore the os exporters
-        if old_exporter:
-            os.environ["OTEL_METRICS_EXPORTER"] = old_exporter
-
-    def test_configure_otlp_metrics_span_processors_exporters_set(
-        self,
-        mocker,
-        mock_apmconfig_enabled,
-        mock_txn_name_manager,
-        mock_meter_manager,
-    ):
-        # Save any exporters in os for later
-        old_exporter = os.environ.get("OTEL_METRICS_EXPORTER", None)
-        if old_exporter:
-            del os.environ["OTEL_METRICS_EXPORTER"]
-        mocker.patch.dict(os.environ, {
-            "OTEL_METRICS_EXPORTER": "foo_exporter",
-        })
-
         trace_mocks = get_trace_mocks(mocker)
         mock_processor_instance = mocker.Mock()
         mock_otlp_processor = mocker.patch(
@@ -200,7 +156,3 @@ class TestConfiguratorSpanProcessors:
             mock_apmconfig_enabled,
             mock_meter_manager,
         )
-
-        # Restore the os exporters
-        if old_exporter:
-            os.environ["OTEL_METRICS_EXPORTER"] = old_exporter

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -1085,6 +1085,14 @@ class TestDistro:
         mock_instrument.assert_not_called()
 
     def test_load_instrumentor_no_commenting_configured(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_metrics_enabled",
+            return_value=True,
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_logs_enabled",
+            return_value=True,
+        )
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -1110,6 +1118,14 @@ class TestDistro:
         )  
 
     def test_load_instrumentor_enable_commenting_all_only(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_metrics_enabled",
+            return_value=True,
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_logs_enabled",
+            return_value=True,
+        )
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -1144,6 +1160,14 @@ class TestDistro:
         )
 
     def test_load_instrumentor_enable_commenting_individual_only_not_on_list(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_metrics_enabled",
+            return_value=True,
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_logs_enabled",
+            return_value=True,
+        )
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -1185,6 +1209,14 @@ class TestDistro:
         )
 
     def test_load_instrumentor_enable_commenting_all_false_and_individual_false(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_metrics_enabled",
+            return_value=True,
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_logs_enabled",
+            return_value=True,
+        )
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -1230,6 +1262,14 @@ class TestDistro:
         )
 
     def test_load_instrumentor_enable_commenting_all_false_and_individual_true(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_metrics_enabled",
+            return_value=True,
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_logs_enabled",
+            return_value=True,
+        )
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -1277,6 +1317,14 @@ class TestDistro:
         )
 
     def test_load_instrumentor_enable_commenting_all_true_and_individual_false(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_metrics_enabled",
+            return_value=True,
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_logs_enabled",
+            return_value=True,
+        )
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -1325,6 +1373,14 @@ class TestDistro:
         )
 
     def test_load_instrumentor_enable_commenting_individual_only_not_django(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_metrics_enabled",
+            return_value=True,
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_logs_enabled",
+            return_value=True,
+        )
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -1367,6 +1423,14 @@ class TestDistro:
         )
 
     def test_load_instrumentor_enable_commenting_individual_only_django(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_metrics_enabled",
+            return_value=True,
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_logs_enabled",
+            return_value=True,
+        )
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -1406,6 +1470,82 @@ class TestDistro:
         mock_instrument.assert_called_once_with(
             is_sql_commentor_enabled=True,
             foo="bar",
+        )
+
+    def test_load_instrumentor_metrics_logs_enabled(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_metrics_enabled",
+            return_value=True,
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_logs_enabled",
+            return_value=True,
+        )
+        mock_instrument = mocker.Mock()
+        mock_instrumentor = mocker.Mock()
+        mock_instrumentor.configure_mock(
+            return_value=mocker.Mock(
+                **{
+                    "instrument": mock_instrument
+                }
+            )
+        )
+        mock_load = mocker.Mock()
+        mock_load.configure_mock(return_value=mock_instrumentor)
+        mock_entry_point = mocker.Mock()
+        mock_entry_point.configure_mock(
+            **{
+                "name": "foo-instrumentor",
+                "load": mock_load,
+            }
+        )
+        distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
+        # No meter_provider, log_provider set
+        mock_instrument.assert_called_once_with(
+            foo="bar",
+        )
+
+    def test_load_instrumentor_metrics_logs_disabled(self, mocker):
+        mock_nmp = mocker.patch(
+            "solarwinds_apm.distro.NoOpMeterProvider",
+            return_value="noop"
+        )
+        mock_nlp = mocker.patch(
+            "solarwinds_apm.distro.NoOpLoggerProvider",
+            return_value="noop"
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_metrics_enabled",
+            return_value=False,
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_logs_enabled",
+            return_value=False,
+        )
+        mock_instrument = mocker.Mock()
+        mock_instrumentor = mocker.Mock()
+        mock_instrumentor.configure_mock(
+            return_value=mocker.Mock(
+                **{
+                    "instrument": mock_instrument
+                }
+            )
+        )
+        mock_load = mocker.Mock()
+        mock_load.configure_mock(return_value=mock_instrumentor)
+        mock_entry_point = mocker.Mock()
+        mock_entry_point.configure_mock(
+            **{
+                "name": "foo-instrumentor",
+                "load": mock_load,
+            }
+        )
+        distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
+        # meter_provider, log_provider set as no-op
+        mock_instrument.assert_called_once_with(
+            foo="bar",
+            meter_provider="noop",
+            logger_provider="noop",
         )
 
     def test_enable_commenter_none(self, mocker):

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -112,6 +112,31 @@ class TestDistro:
             os.environ["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = old_otel_ev_le
 
 
+    def test_new_initializes_class_variables(self, mocker):
+        mock_get_cnf_dict = mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"foo": "bar"},
+        )
+        mock_calculate_is_legacy = mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_is_legacy", return_value="baz",
+        )
+        mock_calculate_metrics_enabled = mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_metrics_enabled", return_value="qux",
+        )
+        mock_calculate_logs_enabled = mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_logs_enabled", return_value="quxx",
+        )
+
+        instance = distro.SolarWindsDistro()
+        assert instance._cnf_dict == {"foo": "bar"}
+        assert instance._is_legacy is "baz"
+        assert instance._instrumentor_metrics_enabled is "qux"
+        assert instance._instrumentor_logs_enabled is "quxx"
+        mock_get_cnf_dict.assert_called_once()
+        mock_calculate_is_legacy.assert_called_once_with({"foo": "bar"})
+        mock_calculate_metrics_enabled.assert_called_once_with({"foo": "bar"})
+        mock_calculate_logs_enabled.assert_called_once_with({"foo": "bar"})
+
     def test__log_python_runtime(self, mocker):
         mock_plat = mocker.patch(
             "solarwinds_apm.distro.platform"


### PR DESCRIPTION
Note: This will merge into epic feature branch `NH-79205-otlp-by-default`.

### Before this PR

Before these changes, `SW_APM_EXPORT_(METRICS|LOGS)_ENABLED` was a convenience config for enabling/disabling all metrics and logs export by OTLP unless AO collector set. But now we can and will support both an AO collector and an OTLP collector.

### After this PR - main changes

This PR changes the role of `SW_APM_EXPORT_(METRICS|LOGS)_ENABLED` (breaking!) to support these cases:
	
If `SW_APM_LEGACY=true` and `SW_APM_EXPORT_(METRICS|LOGS)_ENABLED=true`, then library still exports SWO metrics by APM-proto. In addition, Otel Python instrumentor metrics and logs will export by OTLP. If `ENABLED=false` (default), then only do SWO metrics by APM-proto.
	
If not legacy and `SW_APM_EXPORT_(METRICS|LOGS)_ENABLED=false`, then library still exports SWO metrics and logs by OTLP. But Otel Python instrumentor metrics and logs won't be exported (if implemented) by passing NoOp providers at `load_instrumentor`. If `ENABLED=true` (default for metrics only), both sets are exported.

Note: `SW_APM_EXPORT_METRICS_ENABLED` is now True by default. `SW_APM_EXPORT_LOGS_ENABLED` is still False by default.

### Some more info

The Distro class now caches `_cnf_dict` as contents read from a valid JSON config file once at singleton creation. This is so the distro only reads the file once to calculate (1) if legacy during `_configure`, (2) if Otel Python metrics/log enabled for each call to `load_instrumentor`. Auto-instrumentation still reads the file twice (another time by the Configurator to get all other settings); Distro and Configurator can't share one ApmConfig due to lifecycles when [sitecustomize](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/748c92592d2f476199667629defce4a3bca9ecc9/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py#L37-L39) is used.

All configs like `OTEL_METRICS_EXPORTER`, `PROTOCOL`, `ENDPOINT`, etc are still supported.

APM Python still respects `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` if configured by user as before. This behaviour will be updated later (added todos).



