### PR TITLE
NH-98561 Remove unnecessary Lambda-specific defaults

### DIFF
--- a/lambda/solarwinds-apm/wrapper
+++ b/lambda/solarwinds-apm/wrapper
@@ -27,16 +27,6 @@ export LAMBDA_LAYER_PKGS_DIR="/opt/python";
 export PYTHONPATH="$LAMBDA_LAYER_PKGS_DIR:$PYTHONPATH";
 export PYTHONPATH="$LAMBDA_RUNTIME_DIR:$PYTHONPATH";
 
-# Default opt into OTLP metrics export in lambda
-if [ -z "${SW_APM_EXPORT_METRICS_ENABLED}" ]; then
-    export SW_APM_EXPORT_METRICS_ENABLED=true
-fi
-
-# Default OTEL_EXPORTER_OTLP_PROTOCOL for APM Python in lambda
-# for all of logs/trace/metrics is HTTP through otelcollector
-if [ -z "${OTEL_EXPORTER_OTLP_PROTOCOL}" ]; then
-    export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-fi
 # Set default endpoints for traces, metrics, and logs else would use regular SWO defaults
 if [ -z "${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT}" ]; then
     export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://0.0.0.0:4318/v1/traces


### PR DESCRIPTION
Note: This will merge into epic feature branch `NH-79205-otlp-by-default`.

Removes default configs set by the wrapper for APM Python Lambda layers because no longer necessary, as these are now the defaults outside Lambda too (see https://github.com/solarwinds/apm-python/pull/499, https://github.com/solarwinds/apm-python/pull/508).