### PR TITLE
NH-98561 Sampler uses Context if legacy, else OboeAPI

### DIFF
--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -208,8 +208,7 @@ class _SwSampler(Sampler):
             timestamp,
         )
 
-        if self.apm_config.is_lambda:
-            logger.debug("Sampling in lambda mode.")
+        if self.apm_config.get("legacy") is False:
             (
                 do_metrics,
                 do_sample,
@@ -235,6 +234,7 @@ class _SwSampler(Sampler):
             )
 
         else:
+            logger.debug("Sampling in legacy mode.")
             (
                 do_metrics,
                 do_sample,

--- a/tests/unit/test_sampler/fixtures/sampler.py
+++ b/tests/unit/test_sampler/fixtures/sampler.py
@@ -14,6 +14,8 @@ def config_get(param) -> Any:
         return []
     elif param == "transaction_name":
         return "foo-txn"
+    elif param == "legacy":
+        return False
     else:
         return None
 


### PR DESCRIPTION
Note: This will merge into epic feature branch `NH-79205-otlp-by-default`.

Updates Sampler to use Context for decision-making if legacy, else use OboeAPI.