### PR TITLE
NH-98561 Update logging auto-instrumentation support

### DIFF
--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -16,10 +16,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from opentelemetry import trace
-from opentelemetry._logs import (
-    get_logger_provider,
-    set_logger_provider,
-)
+from opentelemetry._logs import get_logger_provider, set_logger_provider
 from opentelemetry.environment_variables import (
     OTEL_LOGS_EXPORTER,
     OTEL_METRICS_EXPORTER,

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -23,7 +23,10 @@ from opentelemetry.instrumentation.logging.environment_variables import (
 )
 from opentelemetry.instrumentation.version import __version__ as inst_version
 from opentelemetry.metrics import NoOpMeterProvider
-from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_PROTOCOL
+from opentelemetry.sdk.environment_variables import (
+    _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
+    OTEL_EXPORTER_OTLP_PROTOCOL,
+)
 from opentelemetry.sdk.version import __version__ as sdk_version
 from opentelemetry.util._importlib_metadata import EntryPoint
 
@@ -220,12 +223,11 @@ class SolarWindsDistro(BaseDistro):
                     header_token, otlp_protocol
                 )
 
-                # TODO (NH-101363): APM Python enables logging auto-instrumentation
-                # by default to configure logging stdlib handler
-                # environ.setdefault(
-                #     _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
-                #     "true",
-                # )
+                # Logging auto-instrumentation with APM Python is opt-in
+                environ.setdefault(
+                    _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
+                    "false",
+                )
 
             else:
                 logger.warning(

--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -6,6 +6,8 @@
 
 import pytest
 
+from solarwinds_apm.apm_config import SolarWindsApmConfig
+
 # ==================================================================
 # Configurator stdlib fixtures
 # ==================================================================
@@ -196,6 +198,7 @@ def get_apmconfig_mocks(
             "is_lambda": is_lambda,
             "extension": mock_ext,
             "oboe_api": mocker.Mock(),
+            "convert_to_bool": SolarWindsApmConfig.convert_to_bool,
         }
     )
     return mock_apmconfig
@@ -400,6 +403,12 @@ def mock_config_metrics_exp(mocker):
 def mock_config_logs_exp(mocker):
     return mocker.patch(
         "solarwinds_apm.configurator.SolarWindsConfigurator._configure_logs_exporter"
+    )
+
+@pytest.fixture(name="mock_config_logs_handler")
+def mock_config_logs_handler(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsConfigurator._configure_logs_handler"
     )
 
 @pytest.fixture(name="mock_config_propagator")

--- a/tests/unit/test_configurator/test_configurator_configure_otel.py
+++ b/tests/unit/test_configurator/test_configurator_configure_otel.py
@@ -4,9 +4,197 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
+import os
+
+from opentelemetry.sdk.environment_variables import (
+    _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
+)
+
 from solarwinds_apm import configurator
 
 class TestConfiguratorConfigureOtelComponents:
+    def helper_test_configure_otel_components_logs_enabled(
+        self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_enabled,
+        mock_oboe_api_obj_non_legacy,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_logs_handler,
+        mock_config_propagator,
+        mock_config_response_propagator,
+
+        logging_env,
+        logging_assert,
+    ):
+        mocker.patch.dict(
+            os.environ,
+            {
+                _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED: logging_env,
+            }
+        )
+        test_configurator = configurator.SolarWindsConfigurator()
+        test_configurator._configure_otel_components(
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_apmconfig_enabled,
+            mock_extension.Reporter,
+            mock_oboe_api_obj_non_legacy,
+        )
+
+        mock_config_serviceentryid_processor.assert_called_once()
+        mock_config_inbound_processor.assert_not_called()
+        mock_config_otlp_processors.assert_called_once_with(
+            mock_txn_name_manager,
+            mock_apmconfig_enabled, 
+            mock_oboe_api_obj_non_legacy,
+        )
+        mock_config_traces_exp.assert_called_once_with(
+            mock_extension.Reporter,
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_apmconfig_enabled,
+        )
+        mock_config_metrics_exp.assert_called_once_with(mock_apmconfig_enabled)
+        mock_config_logs_exp.assert_called_once_with(mock_apmconfig_enabled)
+        if logging_assert:
+            mock_config_logs_handler.assert_called_once()
+        else:
+            mock_config_logs_handler.assert_not_called()
+        mock_config_propagator.assert_called_once()
+        mock_config_response_propagator.assert_called_once()
+
+    def test_configure_otel_components_logs_enabled_true(
+        self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_enabled,
+        mock_oboe_api_obj_non_legacy,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_logs_handler,
+        mock_config_propagator,
+        mock_config_response_propagator,
+    ):
+        self.helper_test_configure_otel_components_logs_enabled(
+            mocker,
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_meter_manager,
+            mock_extension,
+            mock_apmconfig_enabled,
+            mock_oboe_api_obj_non_legacy,
+            mock_config_serviceentryid_processor,
+            mock_config_inbound_processor,
+            mock_config_otlp_processors,
+            mock_config_traces_exp,
+            mock_config_metrics_exp,
+            mock_config_logs_exp,
+            mock_config_logs_handler,
+            mock_config_propagator,
+            mock_config_response_propagator,
+            "true",
+            True,
+        )
+
+    def test_configure_otel_components_logs_enabled_false(self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_enabled,
+        mock_oboe_api_obj_non_legacy,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_logs_handler,
+        mock_config_propagator,
+        mock_config_response_propagator,
+    ):
+        self.helper_test_configure_otel_components_logs_enabled(
+            mocker,
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_meter_manager,
+            mock_extension,
+            mock_apmconfig_enabled,
+            mock_oboe_api_obj_non_legacy,
+            mock_config_serviceentryid_processor,
+            mock_config_inbound_processor,
+            mock_config_otlp_processors,
+            mock_config_traces_exp,
+            mock_config_metrics_exp,
+            mock_config_logs_exp,
+            mock_config_logs_handler,
+            mock_config_propagator,
+            mock_config_response_propagator,
+            "false",
+            False,
+        )
+
+    def test_configure_otel_components_logs_enabled_invalid_ie_none(self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_enabled,
+        mock_oboe_api_obj_non_legacy,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_logs_handler,
+        mock_config_propagator,
+        mock_config_response_propagator,
+    ):
+        self.helper_test_configure_otel_components_logs_enabled(
+            mocker,
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_meter_manager,
+            mock_extension,
+            mock_apmconfig_enabled,
+            mock_oboe_api_obj_non_legacy,
+            mock_config_serviceentryid_processor,
+            mock_config_inbound_processor,
+            mock_config_otlp_processors,
+            mock_config_traces_exp,
+            mock_config_metrics_exp,
+            mock_config_logs_exp,
+            mock_config_logs_handler,
+            mock_config_propagator,
+            mock_config_response_propagator,
+            "not-a-bool-string",
+            False,
+        )
+        pass
+
     def test_configure_otel_components_agent_enabled_non_legacy(
         self,
         mocker,
@@ -23,6 +211,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_traces_exp,
         mock_config_metrics_exp,
         mock_config_logs_exp,
+        mock_config_logs_handler,
         mock_config_propagator,
         mock_config_response_propagator,
     ):
@@ -50,6 +239,7 @@ class TestConfiguratorConfigureOtelComponents:
         )
         mock_config_metrics_exp.assert_called_once_with(mock_apmconfig_enabled)
         mock_config_logs_exp.assert_called_once_with(mock_apmconfig_enabled)
+        mock_config_logs_handler.assert_not_called()
         mock_config_propagator.assert_called_once()
         mock_config_response_propagator.assert_called_once()
 
@@ -69,6 +259,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_traces_exp,
         mock_config_metrics_exp,
         mock_config_logs_exp,
+        mock_config_logs_handler,
         mock_config_propagator,
         mock_config_response_propagator,
     ):
@@ -103,6 +294,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_logs_exp.assert_called_once_with(
             mock_apmconfig_enabled_metrics_logs_false
         )
+        mock_config_logs_handler.assert_not_called()
         mock_config_propagator.assert_called_once()
         mock_config_response_propagator.assert_called_once()
 
@@ -122,6 +314,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_traces_exp,
         mock_config_metrics_exp,
         mock_config_logs_exp,
+        mock_config_logs_handler,
         mock_config_propagator,
         mock_config_response_propagator,
     ):
@@ -150,6 +343,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_logs_exp.assert_called_once_with(
             mock_apmconfig_enabled_legacy
         )
+        mock_config_logs_handler.assert_not_called()
         mock_config_propagator.assert_called_once()
         mock_config_response_propagator.assert_called_once()
 
@@ -169,6 +363,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_traces_exp,
         mock_config_metrics_exp,
         mock_config_logs_exp,
+        mock_config_logs_handler,
         mock_config_propagator,
         mock_config_response_propagator,
     ):
@@ -199,6 +394,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_logs_exp.assert_called_once_with(
             mock_apmconfig_enabled_legacy_opt_in_metrics_logs
         )
+        mock_config_logs_handler.assert_not_called()
         mock_config_propagator.assert_called_once()
         mock_config_response_propagator.assert_called_once()
 
@@ -218,6 +414,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_traces_exp,
         mock_config_metrics_exp,
         mock_config_logs_exp,
+        mock_config_logs_handler,
         mock_config_propagator,
         mock_config_response_propagator,
     ):
@@ -236,6 +433,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_traces_exp.assert_not_called()
         mock_config_metrics_exp.assert_not_called()
         mock_config_logs_exp.assert_not_called()
+        mock_config_logs_handler.assert_not_called()
         mock_config_propagator.assert_not_called()
         mock_config_response_propagator.assert_not_called()
 
@@ -255,6 +453,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_traces_exp,
         mock_config_metrics_exp,
         mock_config_logs_exp,
+        mock_config_logs_handler,
         mock_config_propagator,
         mock_config_response_propagator,
     ):
@@ -273,5 +472,6 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_traces_exp.assert_not_called()
         mock_config_metrics_exp.assert_not_called()
         mock_config_logs_exp.assert_not_called()
+        mock_config_logs_handler.assert_not_called()
         mock_config_propagator.assert_not_called()
         mock_config_response_propagator.assert_not_called()

--- a/tests/unit/test_configurator/test_configurator_logs_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_logs_exporter.py
@@ -46,7 +46,6 @@ class TestConfiguratorLogsExporter:
         mock_apmconfig_disabled,
         mock_blprocessor,
         mock_loggerprovider,
-        mock_logginghandler,
     ):
         trace_mocks = get_trace_mocks(mocker)
 
@@ -59,7 +58,6 @@ class TestConfiguratorLogsExporter:
         trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
         mock_loggerprovider.assert_not_called()
         mock_blprocessor.assert_not_called()
-        mock_logginghandler.assert_not_called()
 
     def test_configure_logs_exporter_otel_false(
         self,
@@ -67,7 +65,6 @@ class TestConfiguratorLogsExporter:
         mock_apmconfig_enabled,
         mock_blprocessor,
         mock_loggerprovider,
-        mock_logginghandler,
     ):
         mocker.patch.dict(
             os.environ,
@@ -86,7 +83,6 @@ class TestConfiguratorLogsExporter:
         trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
         mock_loggerprovider.assert_not_called()
         mock_blprocessor.assert_not_called()
-        mock_logginghandler.assert_not_called()
 
     def test_configure_logs_exporter_otel_none(
         self,
@@ -94,7 +90,6 @@ class TestConfiguratorLogsExporter:
         mock_apmconfig_enabled,
         mock_blprocessor,
         mock_loggerprovider,
-        mock_logginghandler,
     ):
         mocker.patch.dict(
             os.environ,
@@ -113,7 +108,6 @@ class TestConfiguratorLogsExporter:
         trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
         mock_loggerprovider.assert_not_called()
         mock_blprocessor.assert_not_called()
-        mock_logginghandler.assert_not_called()
 
     def test_configure_logs_exporter_otel_true_no_exporter(
         self,
@@ -121,7 +115,6 @@ class TestConfiguratorLogsExporter:
         mock_apmconfig_enabled,
         mock_blprocessor,
         mock_loggerprovider,
-        mock_logginghandler,
     ):
         mocker.patch.dict(
             os.environ,
@@ -141,7 +134,6 @@ class TestConfiguratorLogsExporter:
         trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
         mock_loggerprovider.assert_not_called()
         mock_blprocessor.assert_not_called()
-        mock_logginghandler.assert_not_called()
 
     def test_configure_logs_exporter_otel_true_invalid_exporter(
         self,
@@ -149,7 +141,6 @@ class TestConfiguratorLogsExporter:
         mock_apmconfig_enabled,
         mock_blprocessor,
         mock_loggerprovider,
-        mock_logginghandler,
     ):
         # Mock entry points
         mock_entry_points = mocker.patch(
@@ -180,7 +171,6 @@ class TestConfiguratorLogsExporter:
         mock_loggerprovider.assert_called_once()
 
         mock_blprocessor.assert_not_called()
-        mock_logginghandler.assert_not_called()
 
     def test_configure_logs_exporter_otel_true_valid_exporter(
         self,
@@ -188,7 +178,6 @@ class TestConfiguratorLogsExporter:
         mock_apmconfig_enabled,
         mock_blprocessor,
         mock_loggerprovider,
-        mock_logginghandler,
     ):
         # Mock entry points
         mock_exporter = mocker.Mock()
@@ -231,4 +220,3 @@ class TestConfiguratorLogsExporter:
         mock_loggerprovider.assert_called_once()
 
         mock_blprocessor.assert_called_once()
-        mock_logginghandler.assert_called_once()

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -15,6 +15,7 @@ from opentelemetry.environment_variables import (
     OTEL_TRACES_EXPORTER
 )
 from opentelemetry.sdk.environment_variables import (
+    _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
     OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
     OTEL_EXPORTER_OTLP_LOGS_HEADERS,
     OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
@@ -83,6 +84,9 @@ class TestDistro:
         old_otel_ev_th = os.environ.get("OTEL_EXPORTER_OTLP_TRACES_HEADERS", None)
         if old_otel_ev_th:
             del os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"]
+        old_otel_log = os.environ.get("OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED")
+        if old_otel_log:
+            del os.environ["OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED"]
 
         # Wait for test
         yield
@@ -116,6 +120,8 @@ class TestDistro:
             os.environ["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] = old_otel_ev_me
         if old_otel_ev_le:
             os.environ["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = old_otel_ev_le
+        if old_otel_log:
+            os.environ["OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED"] = old_otel_log
 
 
     def test_new_initializes_class_variables(self, mocker):
@@ -518,6 +524,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_env_exporter(self, mocker):
         mocker.patch.dict(
@@ -546,6 +553,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_invalid_protocol_not_legacy(self, mocker):
         mocker.patch.dict(
@@ -571,6 +579,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) is None
 
     def test_configure_no_env_no_protocol_is_legacy_no_token(self, mocker):
         mocker.patch.dict(
@@ -596,6 +605,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_invalid_protocol_is_legacy_no_token(self, mocker):
         mocker.patch.dict(
@@ -625,6 +635,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) is None
 
     def test_configure_no_env_valid_protocol_http_is_legacy_no_token(self, mocker):
         mocker.patch.dict(
@@ -651,6 +662,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_valid_protocol_grpc_is_legacy_no_token(self, mocker):
         mocker.patch.dict(
@@ -677,6 +689,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_no_protocol_is_legacy_invalid_token(self, mocker):
         mocker.patch.dict(
@@ -703,6 +716,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_invalid_protocol_is_legacy_invalid_token(self, mocker):
         mocker.patch.dict(
@@ -733,6 +747,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) is None
 
     def test_configure_no_env_valid_protocol_http_is_legacy_invalid_token(self, mocker):
         mocker.patch.dict(
@@ -760,6 +775,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_valid_protocol_grpc_is_legacy_invalid_token(self, mocker):
         mocker.patch.dict(
@@ -787,6 +803,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_no_protocol_is_legacy_valid_token(self, mocker):
         mocker.patch.dict(
@@ -814,6 +831,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_invalid_protocol_is_legacy_valid_token(self, mocker):
         mocker.patch.dict(
@@ -844,6 +862,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) is None
 
     def test_configure_no_env_valid_protocol_http_is_legacy_valid_token(self, mocker):
         mocker.patch.dict(
@@ -872,6 +891,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_valid_protocol_grpc_is_legacy_valid_token(self, mocker):
         mocker.patch.dict(
@@ -900,6 +920,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) == "https://otel.collector.na-01.cloud.solarwinds.com:443/v1/logs"
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == f"authorization=Bearer%20foo-token"
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == f"authorization=Bearer%20foo-token"
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_valid_protocol_http_missing_token(self, mocker):
         mocker.patch.dict(
@@ -925,6 +946,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_valid_protocol_http_with_invalid_token(self, mocker):
         mocker.patch.dict(
@@ -951,6 +973,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_valid_protocol_http_with_valid_token(self, mocker):
         mocker.patch.dict(
@@ -976,6 +999,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) == "authorization=Bearer%20foo-token"
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == "authorization=Bearer%20foo-token"
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == "authorization=Bearer%20foo-token"
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_valid_protocol_grpc_missing_token(self, mocker):
         mocker.patch.dict(
@@ -1001,6 +1025,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_valid_protocol_grpc_with_invalid_token(self, mocker):
         mocker.patch.dict(
@@ -1027,6 +1052,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) is None
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) is None
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_no_env_valid_protocol_grpc_with_valid_token(self, mocker):
         mocker.patch.dict(
@@ -1052,6 +1078,7 @@ class TestDistro:
         assert os.environ.get(OTEL_EXPORTER_OTLP_TRACES_HEADERS) == "authorization=Bearer%20foo-token"
         assert os.environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS) == "authorization=Bearer%20foo-token"
         assert os.environ.get(OTEL_EXPORTER_OTLP_LOGS_HEADERS) == "authorization=Bearer%20foo-token"
+        assert os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED) == "false"
 
     def test_configure_env_exporter_and_valid_protocol_http(self, mocker):
         mocker.patch.dict(


### PR DESCRIPTION
Note: this will merge into feature branch `NH-79205-otlp-by-default`.

Updates APM Python support of `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED`:

1. `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` is False by default; it's an opt-in for users.
2. If True, then logs SDK handler is created and added.
3. Logging provider and exporters are always set up, with latter depending on `OTEL_LOGS_EXPORTER` (otlp http by default).

