### PR TITLE
NH-101919 Add upper limit to urllib3 for operator builds

### DIFF
--- a/image/requirements.txt
+++ b/image/requirements.txt
@@ -3,6 +3,10 @@ opentelemetry-api==1.28.2
 opentelemetry-sdk==1.28.2
 opentelemetry-instrumentation==0.49b2
 
+# We add a cap to urllib3 version else Python 3.8 support is dropped.
+# TODO: Update autoinstrumentation image builds to support all supported Python versions
+#       https://github.com/open-telemetry/opentelemetry-operator/issues/3712
+urllib3 < 2.3.0
 # We don't use the otlp_proto_grpc option since gRPC is not appropriate for
 # injected auto-instrumentation, where it has a strict dependency on the OS / Python version the artifact is built for.
 opentelemetry-exporter-otlp-proto-http==1.28.2


### PR DESCRIPTION
Adds upper limit to `urllib3` for operator autoinstrumentation image builds to maintain Python 3.8 support. [Python OTLP HTTP exporter](https://github.com/open-telemetry/opentelemetry-operator/blob/main/autoinstrumentation/python/requirements.txt#L4) depends on [requests ~= 2.7](https://github.com/open-telemetry/opentelemetry-python/blob/main/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml#L37) and that depends on ["urllib3>=1.21.1,<3"](https://github.com/psf/requests/blob/main/setup.py#L39). [urllib 2.3.0](https://github.com/urllib3/urllib3/releases/tag/2.3.0) is the latest and drops support of Python 3.8.