### PR TITLE
NH-92496 Remove deprecated config support

### DIFF
--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -225,11 +225,8 @@ class SolarWindsDistro(BaseDistro):
         arguments to each entry point. This function is called for every
         individual instrumentor by upstream sitecustomize.
 
-        For enabling sqlcommenting:
-        - OTEL_SQLCOMMENTER_ENABLED is deprecated
-        - All instrumentors enabled if OTEL_SQLCOMMENTER_ENABLED=true
-        - If OTEL_SQLCOMMENTER_ENABLED=false, SW_APM_ENABLED_SQLCOMMENT enables
-          individual instrumentors if in _SQLCOMMENTERS (each is false by default)
+        For enabling sqlcommenting, SW_APM_ENABLED_SQLCOMMENT enables
+        individual instrumentors if in _SQLCOMMENTERS (each is false by default)
         """
         # If we're in Lambda environment, then we skip loading
         # AwsLambdaInstrumentor because we assume the wrapper
@@ -238,27 +235,7 @@ class SolarWindsDistro(BaseDistro):
             if SolarWindsApmConfig.calculate_is_lambda():
                 return
 
-        # If OTEL_SQLCOMMENTER_ENABLED=true, set `enable` for all instrumentors.
-        # Assumes sqlcommenting kwargs are ignored if sqlcommenting is not implemented
-        # for the current instrumentation library.
-        if self.enable_commenter():
-            # For Flask ORM, sqlalchemy, psycopg2
-            kwargs["enable_commenter"] = True
-            # For Django ORM
-            kwargs["is_sql_commentor_enabled"] = True
-
-            # Assumes this value can be empty
-            # Note: Django ORM reads options in settings.py instead
-            # https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/django/django.html
-            kwargs["commenter_options"] = self.detect_commenter_options()
-
-            logger.debug(
-                "(Deprecated) Enabling sqlcommenter for %s with %s",
-                entry_point.name,
-                kwargs,
-            )
-
-        elif entry_point.name in _SQLCOMMENTERS:
+        if entry_point.name in _SQLCOMMENTERS:
             entry_point_setting = self.get_enable_commenter_env_map().get(
                 entry_point.name
             )
@@ -289,16 +266,6 @@ class SolarWindsDistro(BaseDistro):
             )
             return
         instrumentor().instrument(**kwargs)
-
-    def enable_commenter(self) -> bool:
-        """Enable sqlcommenter feature, if implemented"""
-        enable_commenter = environ.get("OTEL_SQLCOMMENTER_ENABLED", "")
-        if enable_commenter.lower() == "true":
-            logger.warning(
-                "Deprecated: OTEL_SQLCOMMENTER_ENABLED support will be removed in a future release. Please use SW_APM_ENABLED_SQLCOMMENT instead."
-            )
-            return True
-        return False
 
     def get_enable_commenter_env_map(self) -> dict:
         """Return a map of which instrumentors will have sqlcomment enabled,
@@ -331,21 +298,12 @@ class SolarWindsDistro(BaseDistro):
         return env_commenter_map
 
     def detect_commenter_options(self):
-        """Returns commenter options dict parsed from environment, if any
-
-        OTEL_SQLCOMMENTER_OPTIONS is deprecated (along with OTEL_SQLCOMMENTER_ENABLED).
-        Users should update to use SW_APM_OPTIONS_SQLCOMMENT instead"""
+        """Returns commenter options dict parsed from environment, if any"""
         commenter_opts = {}
-        commenter_opts_env_depr = environ.get("OTEL_SQLCOMMENTER_OPTIONS")
         commenter_opts_env = environ.get("SW_APM_OPTIONS_SQLCOMMENT")
 
         opt_items = []
-        if commenter_opts_env_depr:
-            logger.warning(
-                "Deprecated: OTEL_SQLCOMMENTER_OPTIONS support will be removed in a future release. Please use SW_APM_OPTIONS_SQLCOMMENT instead."
-            )
-            opt_items = commenter_opts_env_depr.split(",")
-        elif commenter_opts_env:
+        if commenter_opts_env:
             opt_items = commenter_opts_env.split(",")
         else:
             return commenter_opts

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -669,41 +669,7 @@ class TestDistro:
             }
         )  
 
-    def test_load_instrumentor_enable_commenting_all_only(self, mocker):
-        mock_instrument = mocker.Mock()
-        mock_instrumentor = mocker.Mock()
-        mock_instrumentor.configure_mock(
-            return_value=mocker.Mock(
-                **{
-                    "instrument": mock_instrument
-                }
-            )
-        )
-        mock_load = mocker.Mock()
-        mock_load.configure_mock(return_value=mock_instrumentor)
-        mock_entry_point = mocker.Mock()
-        mock_entry_point.configure_mock(
-            **{
-                "load": mock_load
-            }
-        )
-        mocker.patch(
-            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter",
-            return_value=True
-        )
-        mocker.patch(
-            "solarwinds_apm.distro.SolarWindsDistro.detect_commenter_options",
-            return_value="foo-options"
-        )
-        distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
-        mock_instrument.assert_called_once_with(
-            commenter_options="foo-options",
-            enable_commenter=True,
-            foo="bar",
-            is_sql_commentor_enabled=True,
-        )
-
-    def test_load_instrumentor_enable_commenting_individual_only_not_on_list(self, mocker):
+    def test_load_instrumentor_enable_commenting_not_on_list(self, mocker):
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -744,7 +710,7 @@ class TestDistro:
             foo="bar",
         )
 
-    def test_load_instrumentor_enable_commenting_all_false_and_individual_false(self, mocker):
+    def test_load_instrumentor_enable_commenting_false(self, mocker):
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -769,10 +735,6 @@ class TestDistro:
                 "foo-instrumentor"
             ]
         )   
-        mocker.patch(
-            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter",
-            return_value=False
-        )
         mocker.patch(
             "solarwinds_apm.distro.SolarWindsDistro.get_enable_commenter_env_map",
             return_value={
@@ -789,7 +751,7 @@ class TestDistro:
             foo="bar",
         )
 
-    def test_load_instrumentor_enable_commenting_all_false_and_individual_true(self, mocker):
+    def test_load_instrumentor_enable_commenting_true(self, mocker):
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -814,10 +776,6 @@ class TestDistro:
                 "foo-instrumentor"
             ]
         )   
-        mocker.patch(
-            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter",
-            return_value=False
-        )
         mocker.patch(
             "solarwinds_apm.distro.SolarWindsDistro.get_enable_commenter_env_map",
             return_value={
@@ -836,55 +794,7 @@ class TestDistro:
             foo="bar",
         )
 
-    def test_load_instrumentor_enable_commenting_all_true_and_individual_false(self, mocker):
-        mock_instrument = mocker.Mock()
-        mock_instrumentor = mocker.Mock()
-        mock_instrumentor.configure_mock(
-            return_value=mocker.Mock(
-                **{
-                    "instrument": mock_instrument
-                }
-            )
-        )
-        mock_load = mocker.Mock()
-        mock_load.configure_mock(return_value=mock_instrumentor)
-        mock_entry_point = mocker.Mock()
-        mock_entry_point.configure_mock(
-            **{
-                "name": "foo-instrumentor",
-                "load": mock_load,
-            }
-        )
-        mocker.patch(
-            "solarwinds_apm.distro._SQLCOMMENTERS",
-            [
-                "foo-instrumentor"
-            ]
-        )   
-        mocker.patch(
-            "solarwinds_apm.distro.SolarWindsDistro.enable_commenter",
-            return_value=True
-        )
-        mocker.patch(
-            "solarwinds_apm.distro.SolarWindsDistro.get_enable_commenter_env_map",
-            return_value={
-                "foo-instrumentor": False,
-            }
-        )
-        mocker.patch(
-            "solarwinds_apm.distro.SolarWindsDistro.detect_commenter_options",
-            return_value="foo-options"
-        )
-        distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
-        # Commenting enabled with all kwargs because catch-all true
-        mock_instrument.assert_called_once_with(
-            commenter_options="foo-options",
-            enable_commenter=True,
-            is_sql_commentor_enabled=True,
-            foo="bar",
-        )
-
-    def test_load_instrumentor_enable_commenting_individual_only_not_django(self, mocker):
+    def test_load_instrumentor_enable_commenting_not_django(self, mocker):
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -926,7 +836,7 @@ class TestDistro:
             foo="bar",
         )
 
-    def test_load_instrumentor_enable_commenting_individual_only_django(self, mocker):
+    def test_load_instrumentor_enable_commenting_django(self, mocker):
         mock_instrument = mocker.Mock()
         mock_instrumentor = mocker.Mock()
         mock_instrumentor.configure_mock(
@@ -967,30 +877,6 @@ class TestDistro:
             is_sql_commentor_enabled=True,
             foo="bar",
         )
-
-    def test_enable_commenter_none(self, mocker):
-        mocker.patch.dict(os.environ, {})
-        assert distro.SolarWindsDistro().enable_commenter() == False
-
-    def test_enable_commenter_non_bool_value(self, mocker):
-        mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_ENABLED": "foo"})
-        assert distro.SolarWindsDistro().enable_commenter() == False
-
-    def test_enable_commenter_false(self, mocker):
-        mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_ENABLED": "false"})
-        assert distro.SolarWindsDistro().enable_commenter() == False
-        mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_ENABLED": "False"})
-        assert distro.SolarWindsDistro().enable_commenter() == False
-        mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_ENABLED": "faLsE"})
-        assert distro.SolarWindsDistro().enable_commenter() == False
-
-    def test_enable_commenter_true(self, mocker):
-        mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_ENABLED": "true"})
-        assert distro.SolarWindsDistro().enable_commenter() == True
-        mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_ENABLED": "True"})
-        assert distro.SolarWindsDistro().enable_commenter() == True
-        mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_ENABLED": "tRuE"})
-        assert distro.SolarWindsDistro().enable_commenter() == True
 
     def test_get_enable_commenter_env_map_none(self, mocker):
         mocker.patch.dict(os.environ, {})
@@ -1097,47 +983,11 @@ class TestDistro:
         result = distro.SolarWindsDistro().detect_commenter_options()
         assert result == {}
 
-    def test_detect_commenter_options_invalid_kv_ignored_deprecated(self, mocker):
-        mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_OPTIONS": "invalid-kv,foo=bar"})
-        result = distro.SolarWindsDistro().detect_commenter_options()
-        assert result == {}
-
-    def test_detect_commenter_options_valid_kvs_deprecated(self, mocker):
-        mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_OPTIONS": "foo=true,bar=FaLSe"})
-        result = distro.SolarWindsDistro().detect_commenter_options()
-        assert result == {
-            "foo": True,
-            "bar": False,
-        }
-
-    def test_detect_commenter_options_strip_whitespace_ok_deprecated(self, mocker):
-        mocker.patch.dict(
-            os.environ,
-            {
-                "OTEL_SQLCOMMENTER_OPTIONS": "   foo   =   tRUe   , bar = falsE "
-            }
-        )
-        result = distro.SolarWindsDistro().detect_commenter_options()
-        assert result.get("foo") == True
-        assert result.get("bar") == False
-
-    def test_detect_commenter_options_strip_mix_deprecated(self, mocker):
-        mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_OPTIONS": "invalid-kv,   foo=TrUe   ,bar  =  faLSE,   baz=qux  "})
-        result = distro.SolarWindsDistro().detect_commenter_options()
-        assert result.get("foo") == True
-        assert result.get("bar") == False
-        assert result.get("baz") is None
-
-    def test_detect_commenter_options_strip_mix_deprecated_and_new(self, mocker):
-        mocker.patch.dict(os.environ, {"OTEL_SQLCOMMENTER_OPTIONS": "invalid-kv,   foo=TrUe   ,bar  =  faLSE,   baz=qux  "})
+    def test_detect_commenter_options_strip_mixed(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_OPTIONS_SQLCOMMENT": "invalid-kv,   foofoo=TrUe   ,barbar  =  faLSE,   bazbaz=qux  "})
         result = distro.SolarWindsDistro().detect_commenter_options()
-        assert result.get("foo") == True
-        assert result.get("bar") == False
-        assert result.get("baz") is None
-        # SW_APM_OPTIONS_SQLCOMMENT is not used
-        assert result.get("foofoo") is None
-        assert result.get("barbar") is None
+        assert result.get("foofoo") == True
+        assert result.get("barbar") == False
         assert result.get("bazbaz") is None
 
     def test_detect_commenter_options_invalid_kv_ignored(self, mocker):


### PR DESCRIPTION
Removes last support of proprietary `OTEL_SQLCOMMENTER_ENABLED` and `OTEL_SQLCOMMENTER_OPTIONS`. They have been deprecated since APM Python 3.1.0 (October 1, 2024) and a warning was being logged.