### PR TITLE
NH-102114 Add support for SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE

### DIFF
--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -226,7 +226,9 @@ class SolarWindsDistro(BaseDistro):
         individual instrumentor by upstream sitecustomize.
 
         For enabling sqlcommenting, SW_APM_ENABLED_SQLCOMMENT enables
-        individual instrumentors if in _SQLCOMMENTERS (each is false by default)
+        individual instrumentors if in _SQLCOMMENTERS (each is false by default).
+        APM Python also sets enable_attribute_commenter=True by default;
+        can be opted out with SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE=false.
         """
         # If we're in Lambda environment, then we skip loading
         # AwsLambdaInstrumentor because we assume the wrapper
@@ -250,6 +252,17 @@ class SolarWindsDistro(BaseDistro):
                     kwargs["commenter_options"] = (
                         self.detect_commenter_options()
                     )
+
+                if (
+                    SolarWindsApmConfig.convert_to_bool(
+                        environ.get(
+                            "SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE", "true"
+                        )
+                    )
+                    is True
+                ):
+                    kwargs["enable_attribute_commenter"] = True
+
                 logger.debug(
                     "Enabling sqlcommenter for %s with %s",
                     entry_point.name,

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -228,7 +228,7 @@ class SolarWindsDistro(BaseDistro):
         For enabling sqlcommenting, SW_APM_ENABLED_SQLCOMMENT enables
         individual instrumentors if in _SQLCOMMENTERS (each is false by default).
         APM Python also sets enable_attribute_commenter=True by default;
-        can be opted out with SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE=false.
+        can be opted out for each instrumentor with SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE.
         """
         # If we're in Lambda environment, then we skip loading
         # AwsLambdaInstrumentor because we assume the wrapper
@@ -241,7 +241,7 @@ class SolarWindsDistro(BaseDistro):
             entry_point_setting = self.get_enable_commenter_env_map().get(
                 entry_point.name
             )
-            if entry_point_setting is True:
+            if entry_point_setting.get("enable_commenter") is True:
                 if entry_point.name == "django":
                     kwargs["is_sql_commentor_enabled"] = True
                 else:
@@ -252,22 +252,14 @@ class SolarWindsDistro(BaseDistro):
                     kwargs["commenter_options"] = (
                         self.detect_commenter_options()
                     )
+            if entry_point_setting.get("enable_attribute_commenter") is True:
+                kwargs["enable_attribute_commenter"] = True
 
-                if (
-                    SolarWindsApmConfig.convert_to_bool(
-                        environ.get(
-                            "SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE", "true"
-                        )
-                    )
-                    is True
-                ):
-                    kwargs["enable_attribute_commenter"] = True
-
-                logger.debug(
-                    "Enabling sqlcommenter for %s with %s",
-                    entry_point.name,
-                    kwargs,
-                )
+            logger.debug(
+                "Enabling sqlcommenter for %s with %s",
+                entry_point.name,
+                kwargs,
+            )
 
         try:
             instrumentor: BaseInstrumentor = entry_point.load()
@@ -281,33 +273,64 @@ class SolarWindsDistro(BaseDistro):
         instrumentor().instrument(**kwargs)
 
     def get_enable_commenter_env_map(self) -> dict:
-        """Return a map of which instrumentors will have sqlcomment enabled,
-        if implemented. Default is False for each instrumentor in _SQLCOMMENTERS.
+        """Return a map of which instrumentors will have sqlcomment and attribute
+        -in-attribute enabled, if implemented.
+        Reads env SW_APM_ENABLED_SQLCOMMENT and SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE
+        each as a comma-separated string of KVs paired by equals signs,
+        e.g. 'django=true,sqlalchemy=false'.
 
-        Reads env SW_APM_ENABLED_SQLCOMMENT as a comma-separated string of KVs
-        paired by equals signs, e.g. 'django=true,sqlalchemy=false'."""
-        env_commenter_items = environ.get("SW_APM_ENABLED_SQLCOMMENT", "")
-        env_commenter_map = {instr: False for instr in _SQLCOMMENTERS}
-        if env_commenter_items:
-            for item in env_commenter_items.split(","):
-                try:
-                    key, value = item.split("=", maxsplit=1)
-                except ValueError as exc:
-                    logger.warning(
-                        "Invalid sqlcommenter key value at pair %s: %s",
-                        item,
-                        exc,
-                    )
-                    continue
+        Partial example returned map:
+        {
+            "django": {
+                "enable_commenter": True,
+                "enable_attribute_commenter", False,
+            }
+            "psycopg2": {
+                "enable_commenter": False,
+                "enable_attribute_commenter", True,
+            }
+            ...
+        }
 
-                instrumentor_name = key.strip().lower()
-                if instrumentor_name in _SQLCOMMENTERS:
-                    env_v_bool = SolarWindsApmConfig.convert_to_bool(
-                        value.strip()
-                    )
-                    if env_v_bool is not None:
-                        env_commenter_map[instrumentor_name] = env_v_bool
+        Default for sqlcomment is False for each instrumentor in _SQLCOMMENTERS.
+        Default for adding sqlcomment to attribute is True. This has no effect
+        upstream if sqlcomment is False."""
+        env_commenter_map = {
+            instr: {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            }
+            for instr in _SQLCOMMENTERS
+        }
 
+        def parse_env_items(env_var, key_name):
+            env_items = environ.get(env_var, "")
+            if env_items:
+                for item in env_items.split(","):
+                    try:
+                        key, value = item.split("=", maxsplit=1)
+                    except ValueError as exc:
+                        logger.warning(
+                            "Invalid sqlcommenter key value at pair %s: %s",
+                            item,
+                            exc,
+                        )
+                        continue
+
+                    instrumentor_name = key.strip().lower()
+                    if instrumentor_name in _SQLCOMMENTERS:
+                        env_v_bool = SolarWindsApmConfig.convert_to_bool(
+                            value.strip()
+                        )
+                        if env_v_bool is not None:
+                            env_commenter_map[instrumentor_name][
+                                key_name
+                            ] = env_v_bool
+
+        parse_env_items("SW_APM_ENABLED_SQLCOMMENT", "enable_commenter")
+        parse_env_items(
+            "SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE", "enable_commenter_attribute"
+        )
         return env_commenter_map
 
     def detect_commenter_options(self):

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -329,7 +329,7 @@ class SolarWindsDistro(BaseDistro):
 
         parse_env_items("SW_APM_ENABLED_SQLCOMMENT", "enable_commenter")
         parse_env_items(
-            "SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE", "enable_commenter_attribute"
+            "SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE", "enable_attribute_commenter"
         )
         return env_commenter_map
 

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -923,7 +923,13 @@ class TestDistro:
         }
 
     def test_get_enable_commenter_env_map_invalid_just_a_comma(self, mocker):
-        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": ","})
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_ENABLED_SQLCOMMENT": ",",
+                "SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE": ",",
+            }
+        )
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": {
                 "enable_commenter": False,
@@ -948,7 +954,13 @@ class TestDistro:
         }
 
     def test_get_enable_commenter_env_map_invalid_missing_equals_sign_single_val(self, mocker):
-        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django"})
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_ENABLED_SQLCOMMENT": "django",
+                "SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE": "django",
+            }
+        )
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": {
                 "enable_commenter": False,
@@ -973,7 +985,13 @@ class TestDistro:
         }
 
     def test_get_enable_commenter_env_map_invalid_missing_equals_sign_multiple_first(self, mocker):
-        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django,flask=true"})
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_ENABLED_SQLCOMMENT": "django,flask=true",
+                "SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE": "django,flask=false",
+            }
+        )
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": {
                 "enable_commenter": False,
@@ -981,7 +999,7 @@ class TestDistro:
             },
             "flask": {
                 "enable_commenter": True,
-                "enable_attribute_commenter": True,
+                "enable_attribute_commenter": False,
             },
             "psycopg": {
                 "enable_commenter": False,
@@ -998,7 +1016,13 @@ class TestDistro:
         }
 
     def test_get_enable_commenter_env_map_invalid_missing_equals_sign_multiple_last(self, mocker):
-        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "flask=true,django"})
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_ENABLED_SQLCOMMENT": "flask=true,django",
+                "SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE": "flask=false,django",
+            }
+        )
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": {
                 "enable_commenter": False,
@@ -1006,7 +1030,7 @@ class TestDistro:
             },
             "flask": {
                 "enable_commenter": True,
-                "enable_attribute_commenter": True,
+                "enable_attribute_commenter": False,
             },
             "psycopg": {
                 "enable_commenter": False,
@@ -1023,11 +1047,17 @@ class TestDistro:
         }
 
     def test_get_enable_commenter_env_map_valid_ignored_values(self, mocker):
-        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django=true,flask=foobar,psycopg=123"})
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_ENABLED_SQLCOMMENT": "django=true,flask=foobar,psycopg=123",
+                "SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE": "django=false,flask=foobar,psycopg=123",
+            }
+        )
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": {
                 "enable_commenter": True,
-                "enable_attribute_commenter": True,
+                "enable_attribute_commenter": False,
             },
             "flask": {
                 "enable_commenter": False,
@@ -1048,15 +1078,21 @@ class TestDistro:
         }
 
     def test_get_enable_commenter_env_map_valid_mixed_case(self, mocker):
-        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "dJAnGO=tRuE,FlaSK=TrUe"})
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_ENABLED_SQLCOMMENT": "dJAnGO=tRuE,FlaSK=TrUe",
+                "SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE": "dJAnGO=fAlSe,FlaSK=FaLsE",
+            }
+        )
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": {
                 "enable_commenter": True,
-                "enable_attribute_commenter": True,
+                "enable_attribute_commenter": False,
             },
             "flask": {
                 "enable_commenter": True,
-                "enable_attribute_commenter": True,
+                "enable_attribute_commenter": False,
             },
             "psycopg": {
                 "enable_commenter": False,
@@ -1073,15 +1109,21 @@ class TestDistro:
         }
 
     def test_get_enable_commenter_env_map_valid_whitespace_stripped(self, mocker):
-        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django  =  true  ,  flask=  true  "})
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_ENABLED_SQLCOMMENT": "django  =  true  ,  flask=  true  ",
+                "SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE": "django  =  false  ,  flask=  false  ",
+            }
+        )
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": {
                 "enable_commenter": True,
-                "enable_attribute_commenter": True,
+                "enable_attribute_commenter": False,
             },
             "flask": {
                 "enable_commenter": True,
-                "enable_attribute_commenter": True,
+                "enable_attribute_commenter": False,
             },
             "psycopg": {
                 "enable_commenter": False,
@@ -1098,32 +1140,44 @@ class TestDistro:
         }
 
     def test_get_enable_commenter_env_map_valid_update_existing(self, mocker):
-        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django=true,flask=true,psycopg=true,psycopg2=true,sqlalchemy=true"})
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_ENABLED_SQLCOMMENT": "django=true,flask=true,psycopg=true,psycopg2=true,sqlalchemy=true",
+                "SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE": "django=false,flask=false,psycopg=false,psycopg2=false,sqlalchemy=false",
+            }
+        )
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": {
                 "enable_commenter": True,
-                "enable_attribute_commenter": True,
+                "enable_attribute_commenter": False,
             },
             "flask": {
                 "enable_commenter": True,
-                "enable_attribute_commenter": True,
+                "enable_attribute_commenter": False,
             },
             "psycopg": {
                 "enable_commenter": True,
-                "enable_attribute_commenter": True,
+                "enable_attribute_commenter": False,
             },
             "psycopg2": {
                 "enable_commenter": True,
-                "enable_attribute_commenter": True,
+                "enable_attribute_commenter": False,
             },
             "sqlalchemy": {
                 "enable_commenter": True,
-                "enable_attribute_commenter": True,
+                "enable_attribute_commenter": False,
             },
         }
 
     def test_get_enable_commenter_env_map_valid_ignores_if_not_on_list(self, mocker):
-        mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "flask=true,foobar=true"})
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_ENABLED_SQLCOMMENT": "flask=true,foobar=true",
+                "SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE": "flask=false,foobar=false",
+            }
+        )
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
             "django": {
                 "enable_commenter": False,
@@ -1131,7 +1185,7 @@ class TestDistro:
             },
             "flask": {
                 "enable_commenter": True,
-                "enable_attribute_commenter": True,
+                "enable_attribute_commenter": False,
             },
             "psycopg": {
                 "enable_commenter": False,

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -754,6 +754,7 @@ class TestDistro:
         distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
         mock_instrument.assert_called_once_with(
             foo="bar",
+            # If passed without enable_commenter=True, this does nothing
             enable_attribute_commenter=True,
         )
 

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -697,7 +697,10 @@ class TestDistro:
         mocker.patch(
             "solarwinds_apm.distro.SolarWindsDistro.get_enable_commenter_env_map",
             return_value={
-                "not-on-list": True,
+                "not-on-list": {
+                    "enable_commenter": True,
+                    "enable_attribute_commenter": True,
+                }
             }
         )
         mocker.patch(
@@ -738,7 +741,10 @@ class TestDistro:
         mocker.patch(
             "solarwinds_apm.distro.SolarWindsDistro.get_enable_commenter_env_map",
             return_value={
-                "foo-instrumentor": False,
+                "foo-instrumentor": {
+                    "enable_commenter": False,
+                    "enable_attribute_commenter": True,
+                }
             }
         )
         mocker.patch(
@@ -746,9 +752,9 @@ class TestDistro:
             return_value="foo-options"
         )
         distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
-        # Commenting still enabled for individual even if catch-all is False
         mock_instrument.assert_called_once_with(
             foo="bar",
+            enable_attribute_commenter=True,
         )
 
     def test_load_instrumentor_enable_commenting_true(self, mocker):
@@ -779,7 +785,10 @@ class TestDistro:
         mocker.patch(
             "solarwinds_apm.distro.SolarWindsDistro.get_enable_commenter_env_map",
             return_value={
-                "foo-instrumentor": True,
+                "foo-instrumentor": {
+                    "enable_commenter": True,
+                    "enable_attribute_commenter": True,
+                }
             }
         )
         mocker.patch(
@@ -823,7 +832,10 @@ class TestDistro:
         mocker.patch(
             "solarwinds_apm.distro.SolarWindsDistro.get_enable_commenter_env_map",
             return_value={
-                "foo-instrumentor": True,
+                "foo-instrumentor": {
+                    "enable_commenter": True,
+                    "enable_attribute_commenter": True,
+                }
             }
         )
         mocker.patch(
@@ -866,7 +878,10 @@ class TestDistro:
         mocker.patch(
             "solarwinds_apm.distro.SolarWindsDistro.get_enable_commenter_env_map",
             return_value={
-                "django": True,
+                "django": {
+                    "enable_commenter": True,
+                    "enable_attribute_commenter": True,
+                }
             }
         )
         mocker.patch(
@@ -884,101 +899,251 @@ class TestDistro:
     def test_get_enable_commenter_env_map_none(self, mocker):
         mocker.patch.dict(os.environ, {})
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
-            "django": False,
-            "flask": False,
-            "psycopg": False,
-            "psycopg2": False,
-            "sqlalchemy": False,
+            "django": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "flask": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg2": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "sqlalchemy": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
         }
 
     def test_get_enable_commenter_env_map_invalid_just_a_comma(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": ","})
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
-            "django": False,
-            "flask": False,
-            "psycopg": False,
-            "psycopg2": False,
-            "sqlalchemy": False,
+            "django": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "flask": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg2": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "sqlalchemy": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
         }
 
     def test_get_enable_commenter_env_map_invalid_missing_equals_sign_single_val(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django"})
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
-            "django": False,
-            "flask": False,
-            "psycopg": False,
-            "psycopg2": False,
-            "sqlalchemy": False,
+            "django": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "flask": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg2": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "sqlalchemy": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
         }
 
     def test_get_enable_commenter_env_map_invalid_missing_equals_sign_multiple_first(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django,flask=true"})
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
-            "django": False,
-            "flask": True,
-            "psycopg": False,
-            "psycopg2": False,
-            "sqlalchemy": False,
+            "django": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "flask": {
+                "enable_commenter": True,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg2": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "sqlalchemy": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
         }
 
     def test_get_enable_commenter_env_map_invalid_missing_equals_sign_multiple_last(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "flask=true,django"})
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
-            "django": False,
-            "flask": True,
-            "psycopg": False,
-            "psycopg2": False,
-            "sqlalchemy": False,
+            "django": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "flask": {
+                "enable_commenter": True,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg2": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "sqlalchemy": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
         }
 
     def test_get_enable_commenter_env_map_valid_ignored_values(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django=true,flask=foobar,psycopg=123"})
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
-            "django": True,
-            "flask": False,
-            "psycopg": False,
-            "psycopg2": False,
-            "sqlalchemy": False,
+            "django": {
+                "enable_commenter": True,
+                "enable_attribute_commenter": True,
+            },
+            "flask": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg2": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "sqlalchemy": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
         }
 
     def test_get_enable_commenter_env_map_valid_mixed_case(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "dJAnGO=tRuE,FlaSK=TrUe"})
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
-            "django": True,
-            "flask": True,
-            "psycopg": False,
-            "psycopg2": False,
-            "sqlalchemy": False,
+            "django": {
+                "enable_commenter": True,
+                "enable_attribute_commenter": True,
+            },
+            "flask": {
+                "enable_commenter": True,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg2": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "sqlalchemy": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
         }
 
     def test_get_enable_commenter_env_map_valid_whitespace_stripped(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django  =  true  ,  flask=  true  "})
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
-            "django": True,
-            "flask": True,
-            "psycopg": False,
-            "psycopg2": False,
-            "sqlalchemy": False,
+            "django": {
+                "enable_commenter": True,
+                "enable_attribute_commenter": True,
+            },
+            "flask": {
+                "enable_commenter": True,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg2": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "sqlalchemy": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
         }
 
     def test_get_enable_commenter_env_map_valid_update_existing(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "django=true,flask=true,psycopg=true,psycopg2=true,sqlalchemy=true"})
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
-            "django": True,
-            "flask": True,
-            "psycopg": True,
-            "psycopg2": True,
-            "sqlalchemy": True,
+            "django": {
+                "enable_commenter": True,
+                "enable_attribute_commenter": True,
+            },
+            "flask": {
+                "enable_commenter": True,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg": {
+                "enable_commenter": True,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg2": {
+                "enable_commenter": True,
+                "enable_attribute_commenter": True,
+            },
+            "sqlalchemy": {
+                "enable_commenter": True,
+                "enable_attribute_commenter": True,
+            },
         }
 
     def test_get_enable_commenter_env_map_valid_ignores_if_not_on_list(self, mocker):
         mocker.patch.dict(os.environ, {"SW_APM_ENABLED_SQLCOMMENT": "flask=true,foobar=true"})
         assert distro.SolarWindsDistro().get_enable_commenter_env_map() == {
-            "django": False,
-            "flask": True,
-            "psycopg": False,
-            "psycopg2": False,
-            "sqlalchemy": False,
+            "django": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "flask": {
+                "enable_commenter": True,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "psycopg2": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
+            "sqlalchemy": {
+                "enable_commenter": False,
+                "enable_attribute_commenter": True,
+            },
         }
 
     def test_detect_commenter_options_not_set(self, mocker):

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -699,7 +699,7 @@ class TestDistro:
             return_value={
                 "not-on-list": {
                     "enable_commenter": True,
-                    "enable_attribute_commenter": True,
+                    "enable_attribute_commenter": False,
                 }
             }
         )
@@ -788,7 +788,7 @@ class TestDistro:
             return_value={
                 "foo-instrumentor": {
                     "enable_commenter": True,
-                    "enable_attribute_commenter": True,
+                    "enable_attribute_commenter": False,
                 }
             }
         )
@@ -797,11 +797,9 @@ class TestDistro:
             return_value="foo-options"
         )
         distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
-        # Commenting still enabled for individual even if catch-all is False
         mock_instrument.assert_called_once_with(
             commenter_options="foo-options",
             enable_commenter=True,
-            enable_attribute_commenter=True,
             foo="bar",
         )
 
@@ -835,7 +833,7 @@ class TestDistro:
             return_value={
                 "foo-instrumentor": {
                     "enable_commenter": True,
-                    "enable_attribute_commenter": True,
+                    "enable_attribute_commenter": False,
                 }
             }
         )
@@ -847,7 +845,6 @@ class TestDistro:
         mock_instrument.assert_called_once_with(
             commenter_options="foo-options",
             enable_commenter=True,
-            enable_attribute_commenter=True,
             foo="bar",
         )
 
@@ -881,7 +878,7 @@ class TestDistro:
             return_value={
                 "django": {
                     "enable_commenter": True,
-                    "enable_attribute_commenter": True,
+                    "enable_attribute_commenter": False,
                 }
             }
         )
@@ -893,7 +890,6 @@ class TestDistro:
         # No commenter_options because Django reads settings.py instead
         mock_instrument.assert_called_once_with(
             is_sql_commentor_enabled=True,
-            enable_attribute_commenter=True,
             foo="bar",
         )
 

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -791,6 +791,7 @@ class TestDistro:
         mock_instrument.assert_called_once_with(
             commenter_options="foo-options",
             enable_commenter=True,
+            enable_attribute_commenter=True,
             foo="bar",
         )
 
@@ -833,6 +834,7 @@ class TestDistro:
         mock_instrument.assert_called_once_with(
             commenter_options="foo-options",
             enable_commenter=True,
+            enable_attribute_commenter=True,
             foo="bar",
         )
 
@@ -875,6 +877,7 @@ class TestDistro:
         # No commenter_options because Django reads settings.py instead
         mock_instrument.assert_called_once_with(
             is_sql_commentor_enabled=True,
+            enable_attribute_commenter=True,
             foo="bar",
         )
 


### PR DESCRIPTION
Add support for new config `SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE`. It is "true" by default for APM Python for all instrumentors. It can be set to "false" for each to opt out. When true _and_ `SW_APM_ENABLED_SQLCOMMENT` is true for that instrumentor, then it will add sqlcomment to `db.statement` attribute.

It accepts a string representing a list of instrumentor keys and their values, delimited by commas. Accepted instrumentor names are: sqlalchemy, django, flask, psycopg2, and psycopg2. Other keys will be ignored.

Example:
```
export SW_APM_ENABLED_SQLCOMMENT_ATTRIBUTE="psycopg2=true,sqlalchemy=false"
```