### PR TITLE
NH-102271 Add image APM version bump to 'Create Release PR' action

### DIFF
--- a/.github/scripts/release_pr.sh
+++ b/.github/scripts/release_pr.sh
@@ -20,10 +20,8 @@ gh api -X POST /repos/solarwinds/apm-python/git/refs \
 # Get SHA of current version.py at main
 SHA=$(gh api /repos/solarwinds/apm-python/contents/solarwinds_apm/version.py?ref="main" --jq '.sha')
 
-newline=$'\n'
-content=$(base64 <<< "__version__ = \"$version_number\"$newline")
-
 # Commit version.py with updated agent version
+content=$(base64 <<< "__version__ = \"$version_number\"")
 echo "Pushing new version.py to branch '$branch_name'"
 gh api --method PUT /repos/solarwinds/apm-python/contents/solarwinds_apm/version.py \
     --field message="Update agent version to $version_number" \

--- a/.github/scripts/release_pr.sh
+++ b/.github/scripts/release_pr.sh
@@ -18,27 +18,30 @@ gh api -X POST /repos/solarwinds/apm-python/git/refs \
     --field sha="$(git rev-parse "origin/main")"
 
 # Get SHA of current version.py at main
-SHA=$(gh api /repos/solarwinds/apm-python/contents/solarwinds_apm/version.py?ref="main" --jq '.sha')
+SHA_VERS=$(gh api /repos/solarwinds/apm-python/contents/solarwinds_apm/version.py?ref="main" --jq '.sha')
 
 # Commit version.py with updated agent version
-content=$(base64 <<< "__version__ = \"$version_number\"")
+version_str=$(base64 <<< "__version__ = \"$version_number\"")
 echo "Pushing new version.py to branch '$branch_name'"
 gh api --method PUT /repos/solarwinds/apm-python/contents/solarwinds_apm/version.py \
     --field message="Update agent version to $version_number" \
-    --field content="$content" \
+    --field content="$version_str" \
     --field encoding="base64" \
     --field branch="$branch_name" \
-    --field sha="$SHA"
+    --field sha="$SHA_VERS"
+
+# Get SHA of current requirements-nodeps.py at main
+SHA_REQ=$(gh api /repos/solarwinds/apm-python/contents/image/requirements-nodeps.txt?ref="main" --jq '.sha')
 
 # Commit image requirements with updated agent version
-requirement=$(base64 <<< "solarwinds_apm==$version_number")
+requirement_str=$(base64 <<< "solarwinds_apm==$version_number")
 echo "Pushing new image/requirements to branch '$branch_name'"
 gh api --method PUT /repos/solarwinds/apm-python/contents/image/requirements-nodeps.txt \
     --field message="Update image's agent version to $version_number" \
-    --field content="$requirement" \
+    --field content="$requirement_str" \
     --field encoding="base64" \
     --field branch="$branch_name" \
-    --field sha="$SHA"
+    --field sha="$SHA_REQ"
 
 # Open draft Pull Request for version bump
 echo "Creating draft pull request"

--- a/.github/scripts/release_pr.sh
+++ b/.github/scripts/release_pr.sh
@@ -32,6 +32,16 @@ gh api --method PUT /repos/solarwinds/apm-python/contents/solarwinds_apm/version
     --field branch="$branch_name" \
     --field sha="$SHA"
 
+# Commit image requirements with updated agent version
+requirement=$(base64 <<< "solarwinds_apm==$version_number")
+echo "Pushing new image/requirements to branch '$branch_name'"
+gh api --method PUT /repos/solarwinds/apm-python/contents/image/requirements-nodeps.txt \
+    --field message="Update image's agent version to $version_number" \
+    --field content="$requirement" \
+    --field encoding="base64" \
+    --field branch="$branch_name" \
+    --field sha="$SHA"
+
 # Open draft Pull Request for version bump
 echo "Creating draft pull request"
 gh pr create --draft --base "main" --head "$branch_name" \


### PR DESCRIPTION
Updates the "Create Release PR" workflow to also bump the APM Python version in [image/requirements-nodeps.txt](https://github.com/solarwinds/apm-python/blob/main/image/requirements-nodeps.txt#L1). This is so "Publish APM Python Auto-Instrumentation" can be run, manually and minutes after PyPI updates are picked up by GH, after PyPI publish is complete but with less to remember.

This also fixes the existing [version.py](https://github.com/solarwinds/apm-python/blob/main/solarwinds_apm/version.py#L1) update logic that was unnecessarily adding newlines.

Example test PR: https://github.com/solarwinds/apm-python/pull/533