### PR TITLE
NH-102374 update scout scans

### DIFF
--- a/.github/workflows/build_publish_image_autoinstrumentation.yaml
+++ b/.github/workflows/build_publish_image_autoinstrumentation.yaml
@@ -58,12 +58,23 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push - amd64
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          load: true
+          context: image
+          platforms: linux/amd64
+          build-args: version=${{ env.VERSION }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push - arm64
         uses: docker/build-push-action@v6
         with:
           push: true
           context: image
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           build-args: version=${{ env.VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -74,16 +85,6 @@ jobs:
         with:
           username: ${{ vars.ENOPS5919_DOCKER_SCOUT_CI_USER }}
           password: ${{ secrets.ENOPS5919_DOCKER_SCOUT_CI_PAT }}
-
-      - name: Analyze for critical and high CVEs - local Dockerfile
-        id: docker-scout-cves
-        uses: docker/scout-action@v1
-        with:
-          command: cves
-          image: "fs://./"
-          platform: "linux/amd64"
-          ignore-base: true
-          only-package-types: pip
 
       - name: Analyze for critical and high CVEs - tagged image
         id: docker-scout-image-cves

--- a/.github/workflows/build_publish_image_autoinstrumentation.yaml
+++ b/.github/workflows/build_publish_image_autoinstrumentation.yaml
@@ -7,6 +7,9 @@
 name: "Publish APM Python Auto-Instrumentation"
 
 on:
+  push:
+    branches:
+      - NH-102374-update-scout-scans
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build_publish_image_autoinstrumentation.yaml
+++ b/.github/workflows/build_publish_image_autoinstrumentation.yaml
@@ -7,9 +7,6 @@
 name: "Publish APM Python Auto-Instrumentation"
 
 on:
-  push:
-    branches:
-      - NH-102374-update-scout-scans
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build_publish_image_autoinstrumentation.yaml
+++ b/.github/workflows/build_publish_image_autoinstrumentation.yaml
@@ -13,6 +13,7 @@ permissions:
   packages: write
   contents: write
   id-token: write
+  security-events: write
 
 jobs:
   docker_hub:
@@ -93,7 +94,12 @@ jobs:
           command: cves
           image: ${{ steps.meta.outputs.tags[0] }}
           platform: "linux/amd64"
-  
+          sarif-file: sarif.output.json
+
+      - name: Upload SARIF result
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: sarif.output.json
 
   ghcr_io:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Replaces https://github.com/solarwinds/apm-python/pull/530

Docker scout scan results more consistent like APM Java. Splits image build with first load=true, and removes fs scan. Adds upload of sarif results. See ticket comment for result.