### PR TITLE
NH-103629 Propagator custom `inject` checks for when baggage, tracestate set as dict

### DIFF
--- a/solarwinds_apm/propagator.py
+++ b/solarwinds_apm/propagator.py
@@ -136,8 +136,10 @@ class SolarWindsPropagator(textmap.TextMapPropagator):
 
         # Remove any baggage stored for custom transaction naming
         if baggage_header:
-            # Note: OTel instrumentors of messaging systems (e.g. boto3) may set
+            # Note: OTel instrumentors of messaging systems (e.g. boto3) may inject
             # baggage header value as a dictionary, not a string.
+            # APM Python SDK always sets baggage header as a string because the same
+            # instrumentors' getters extract with expectation of string.
             if isinstance(baggage_header, dict):
                 baggage_stringvalue = baggage_header.get("StringValue")
                 handle_baggage_header(baggage_stringvalue)

--- a/solarwinds_apm/propagator.py
+++ b/solarwinds_apm/propagator.py
@@ -125,7 +125,7 @@ class SolarWindsPropagator(textmap.TextMapPropagator):
             carrier, self._TRACESTATE_HEADER_NAME, trace_state.to_header()
         )
 
-        def handle_baggage_header(baggage_header):
+        def _handle_baggage_header(baggage_header):
             sanitized_baggage = self.remove_custom_naming_baggage_header(
                 baggage_header
             )
@@ -144,9 +144,9 @@ class SolarWindsPropagator(textmap.TextMapPropagator):
             # inject header values as dictionary, not a string.
             if isinstance(baggage_header, dict):
                 baggage_stringvalue = baggage_header.get("StringValue")
-                handle_baggage_header(baggage_stringvalue)
+                _handle_baggage_header(baggage_stringvalue)
             elif isinstance(baggage_header, str):
-                handle_baggage_header(baggage_header)
+                _handle_baggage_header(baggage_header)
             # Else: leave baggage header as is in carrier
 
     def remove_custom_naming_baggage_header(

--- a/solarwinds_apm/propagator.py
+++ b/solarwinds_apm/propagator.py
@@ -83,6 +83,10 @@ class SolarWindsPropagator(textmap.TextMapPropagator):
 
         # Prepare carrier with carrier's or new tracestate
         trace_state = None
+        # Note: OTel Propagation API callers (OTel instrumentors) may
+        # inject header values as dictionary, not a string.
+        if isinstance(trace_state_header, dict):
+            trace_state_header = trace_state_header.get("StringValue")
         if not trace_state_header:
             # Only create new trace state if valid span_id
             if span_context.span_id == self._INVALID_SPAN_ID:
@@ -136,10 +140,8 @@ class SolarWindsPropagator(textmap.TextMapPropagator):
 
         # Remove any baggage stored for custom transaction naming
         if baggage_header:
-            # Note: OTel instrumentors of messaging systems (e.g. boto3) may inject
-            # baggage header value as a dictionary, not a string.
-            # APM Python SDK always sets baggage header as a string because the same
-            # instrumentors' getters extract with expectation of string.
+            # Note: OTel Propagation API callers (OTel instrumentors) may
+            # inject header values as dictionary, not a string.
             if isinstance(baggage_header, dict):
                 baggage_stringvalue = baggage_header.get("StringValue")
                 handle_baggage_header(baggage_stringvalue)


### PR DESCRIPTION
Addresses https://github.com/solarwinds/apm-python/issues/538

Updates APM Python custom propagator to handle `baggage` and `tracestate` if injected by some upstream OTel instrumentors as dict instead of str:

* [opentelemetry-instrumentation-boto3sqs](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/d5dce5de996efcf2c2f85eed787c13f831095377/instrumentation/opentelemetry-instrumentation-boto3sqs/src/opentelemetry/instrumentation/boto3sqs/__init__.py#L77-L89)
* [opentelemetry-instrumentation-botocore](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/d5dce5de996efcf2c2f85eed787c13f831095377/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/_messaging.py#L26-L31)

APM-sanitized, non-empty baggage is still always re-injected as string.
