### PR TITLE
NH-103629 Update APM exporter's lookup of boto3

### DIFF
--- a/solarwinds_apm/exporter.py
+++ b/solarwinds_apm/exporter.py
@@ -198,6 +198,8 @@ class SolarWindsSpanExporter(SpanExporter):
                 framework = "psutil"
             elif framework == "tortoiseorm":
                 framework = "tortoise"
+            elif framework == "boto3sqs":
+                framework = "boto3"
             # asgi is implemented over multiple frameworks
             # https://asgi.readthedocs.io/en/latest/implementations.html
             # Use the first best guess framework for name and version

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -1298,6 +1298,33 @@ class Test_SolarWindsSpanExporter():
             "4.5.6",
         )
 
+    def test__add_info_instrumented_framework_boto3(
+        self,
+        mocker,
+        mock_event,
+        mock_create_event,
+    ):
+        # mock module and sys.modules
+        mock_module = mocker.Mock()
+        mock_module.configure_mock(
+            **{
+                "__version__": "4.5.6"
+            }
+        )
+        mock_sys_modules = {
+            "boto3": mock_module
+        }
+
+        self.mock_and_assert_addinfo_for_instrumented_framework(
+            mocker,
+            mock_event,
+            mock_create_event,
+            mock_sys_modules,
+            "opentelemetry.instrumentation.boto3sqs",
+            "Python.boto3.Version",
+            "4.5.6",
+        )
+
     def test__add_info_instrumented_framework_mysql(
         self,
         mocker,


### PR DESCRIPTION
This is to stop the warning reported in https://github.com/solarwinds/apm-python/issues/538: `2025-03-03 10:53:22,630 [ solarwinds_apm.exporter WARNING p#2669645.138014233724608] Version lookup of boto3sqs failed, so skipping: No module named 'boto3sqs'`

APM Python custom exporter does lookups of instrumentation frameworks to enrich exported spans. The instrumentation package `opentelemetry.instrumentation.boto3sqs` is for [entrypoint boto3](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/d5dce5de996efcf2c2f85eed787c13f831095377/instrumentation/opentelemetry-instrumentation-boto3sqs/pyproject.toml#L41), the latter being the actual name of the module. 