### PR TITLE
NH-105440 Adjust APM Python OTLP logger component init

### DIFF
--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -6,6 +6,8 @@
 
 import pytest
 
+from solarwinds_apm.apm_config import SolarWindsApmConfig
+
 # ==================================================================
 # Configurator stdlib fixtures
 # ==================================================================
@@ -196,6 +198,7 @@ def get_apmconfig_mocks(
             "is_lambda": is_lambda,
             "extension": mock_ext,
             "oboe_api": mocker.Mock(),
+            "convert_to_bool": SolarWindsApmConfig.convert_to_bool,
         }
     )
     return mock_apmconfig
@@ -216,6 +219,16 @@ def mock_apmconfig_enabled(mocker):
         "solarwinds_apm.configurator.SolarWindsApmConfig",
         get_apmconfig_mocks(
             mocker,
+        )
+    )
+
+@pytest.fixture(name="mock_apmconfig_enabled_export_logs_false")
+def mock_apmconfig_enabled_export_logs_false(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsApmConfig",
+        get_apmconfig_mocks(
+            mocker,
+            export_logs_enabled=False
         )
     )
 
@@ -387,6 +400,12 @@ def mock_config_metrics_exp(mocker):
 def mock_config_logs_exp(mocker):
     return mocker.patch(
         "solarwinds_apm.configurator.SolarWindsConfigurator._configure_logs_exporter"
+    )
+
+@pytest.fixture(name="mock_config_logs_handler")
+def mock_config_logs_handler(mocker):
+    return mocker.patch(
+        "solarwinds_apm.configurator.SolarWindsConfigurator._configure_logs_handler"
     )
 
 @pytest.fixture(name="mock_config_propagator")

--- a/tests/unit/test_configurator/test_configurator_configure_otel.py
+++ b/tests/unit/test_configurator/test_configurator_configure_otel.py
@@ -4,9 +4,316 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
+import os
+
+from opentelemetry.sdk.environment_variables import (
+    _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
+)
+
 from solarwinds_apm import configurator
 
 class TestConfiguratorConfigureOtelComponents:
+    def helper_test_configure_otel_components_logs_enabled(
+        self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_enabled,
+        mock_oboe_api_obj,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_logs_handler,
+        mock_config_propagator,
+        mock_config_response_propagator,
+
+        logging_env,
+        logging_assert,
+    ):
+        mocker.patch.dict(
+            os.environ,
+            {
+                _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED: logging_env,
+            }
+        )
+        test_configurator = configurator.SolarWindsConfigurator()
+        test_configurator._configure_otel_components(
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_apmconfig_enabled,
+            mock_extension.Reporter,
+            mock_oboe_api_obj,
+        )
+
+        mock_config_serviceentryid_processor.assert_called_once()
+        mock_config_inbound_processor.assert_called_once()
+        mock_config_otlp_processors.assert_called_once_with(
+            mock_txn_name_manager,
+            mock_apmconfig_enabled, 
+            mock_oboe_api_obj,
+        )
+        mock_config_traces_exp.assert_called_once_with(
+            mock_extension.Reporter,
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_apmconfig_enabled,
+        )
+        mock_config_metrics_exp.assert_called_once_with(mock_apmconfig_enabled)
+        mock_config_logs_exp.assert_called_once_with(mock_apmconfig_enabled)
+        if logging_assert:
+            mock_config_logs_handler.assert_called_once()
+        else:
+            mock_config_logs_handler.assert_not_called()
+        mock_config_propagator.assert_called_once()
+        mock_config_response_propagator.assert_called_once()
+
+    def test_configure_otel_components_logs_enabled_true_by_otel_sw_default(
+        self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_enabled_export_logs_false,
+        mock_oboe_api_obj,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_logs_handler,
+        mock_config_propagator,
+        mock_config_response_propagator,
+    ):
+        self.helper_test_configure_otel_components_logs_enabled(
+            mocker,
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_meter_manager,
+            mock_extension,
+            mock_apmconfig_enabled_export_logs_false,
+            mock_oboe_api_obj,
+            mock_config_serviceentryid_processor,
+            mock_config_inbound_processor,
+            mock_config_otlp_processors,
+            mock_config_traces_exp,
+            mock_config_metrics_exp,
+            mock_config_logs_exp,
+            mock_config_logs_handler,
+            mock_config_propagator,
+            mock_config_response_propagator,
+            "true",
+            True,
+        )
+
+    def test_configure_otel_components_logs_enabled_otel_none_sw_default(self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_enabled_export_logs_false,
+        mock_oboe_api_obj,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_logs_handler,
+        mock_config_propagator,
+        mock_config_response_propagator,
+    ):
+        self.helper_test_configure_otel_components_logs_enabled(
+            mocker,
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_meter_manager,
+            mock_extension,
+            mock_apmconfig_enabled_export_logs_false,
+            mock_oboe_api_obj,
+            mock_config_serviceentryid_processor,
+            mock_config_inbound_processor,
+            mock_config_otlp_processors,
+            mock_config_traces_exp,
+            mock_config_metrics_exp,
+            mock_config_logs_exp,
+            mock_config_logs_handler,
+            mock_config_propagator,
+            mock_config_response_propagator,
+            "",
+            False,
+        )
+
+    def test_configure_otel_components_logs_enabled_otel_none_sw_true(self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_enabled,
+        mock_oboe_api_obj,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_logs_handler,
+        mock_config_propagator,
+        mock_config_response_propagator,
+    ):
+        self.helper_test_configure_otel_components_logs_enabled(
+            mocker,
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_meter_manager,
+            mock_extension,
+            mock_apmconfig_enabled,
+            mock_oboe_api_obj,
+            mock_config_serviceentryid_processor,
+            mock_config_inbound_processor,
+            mock_config_otlp_processors,
+            mock_config_traces_exp,
+            mock_config_metrics_exp,
+            mock_config_logs_exp,
+            mock_config_logs_handler,
+            mock_config_propagator,
+            mock_config_response_propagator,
+            "",
+            True,  # true because SW next in precedence
+        )
+
+    def test_configure_otel_components_logs_enabled_otel_false_sw_default(self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_enabled_export_logs_false,
+        mock_oboe_api_obj,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_logs_handler,
+        mock_config_propagator,
+        mock_config_response_propagator,
+    ):
+        self.helper_test_configure_otel_components_logs_enabled(
+            mocker,
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_meter_manager,
+            mock_extension,
+            mock_apmconfig_enabled_export_logs_false,
+            mock_oboe_api_obj,
+            mock_config_serviceentryid_processor,
+            mock_config_inbound_processor,
+            mock_config_otlp_processors,
+            mock_config_traces_exp,
+            mock_config_metrics_exp,
+            mock_config_logs_exp,
+            mock_config_logs_handler,
+            mock_config_propagator,
+            mock_config_response_propagator,
+            "false",
+            False,
+        )
+
+    def test_configure_otel_components_logs_enabled_otel_false_sw_true(self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_enabled,
+        mock_oboe_api_obj,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_logs_handler,
+        mock_config_propagator,
+        mock_config_response_propagator,
+    ):
+        self.helper_test_configure_otel_components_logs_enabled(
+            mocker,
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_meter_manager,
+            mock_extension,
+            mock_apmconfig_enabled,
+            mock_oboe_api_obj,
+            mock_config_serviceentryid_processor,
+            mock_config_inbound_processor,
+            mock_config_otlp_processors,
+            mock_config_traces_exp,
+            mock_config_metrics_exp,
+            mock_config_logs_exp,
+            mock_config_logs_handler,
+            mock_config_propagator,
+            mock_config_response_propagator,
+            "false",
+            False,  # should be false because OTEL explicitly false, even if SW true
+        )
+
+    def test_configure_otel_components_logs_enabled_otel_invalid(self,
+        mocker,
+        mock_txn_name_manager,
+        mock_fwkv_manager,
+        mock_meter_manager,
+        mock_extension,
+        mock_apmconfig_enabled_export_logs_false,
+        mock_oboe_api_obj,
+
+        mock_config_serviceentryid_processor,
+        mock_config_inbound_processor,
+        mock_config_otlp_processors,
+        mock_config_traces_exp,
+        mock_config_metrics_exp,
+        mock_config_logs_exp,
+        mock_config_logs_handler,
+        mock_config_propagator,
+        mock_config_response_propagator,
+    ):
+        self.helper_test_configure_otel_components_logs_enabled(
+            mocker,
+            mock_txn_name_manager,
+            mock_fwkv_manager,
+            mock_meter_manager,
+            mock_extension,
+            mock_apmconfig_enabled_export_logs_false,
+            mock_oboe_api_obj,
+            mock_config_serviceentryid_processor,
+            mock_config_inbound_processor,
+            mock_config_otlp_processors,
+            mock_config_traces_exp,
+            mock_config_metrics_exp,
+            mock_config_logs_exp,
+            mock_config_logs_handler,
+            mock_config_propagator,
+            mock_config_response_propagator,
+            "not-a-bool-string",
+            False,
+        )
+
     def test_configure_otel_components_agent_enabled(
         self,
         mocker,
@@ -23,6 +330,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_traces_exp,
         mock_config_metrics_exp,
         mock_config_logs_exp,
+        mock_config_logs_handler,
         mock_config_propagator,
         mock_config_response_propagator,
     ):
@@ -53,6 +361,7 @@ class TestConfiguratorConfigureOtelComponents:
         )
         mock_config_metrics_exp.assert_called_once_with(mock_apmconfig_enabled)
         mock_config_logs_exp.assert_called_once_with(mock_apmconfig_enabled)
+        mock_config_logs_handler.assert_called_once()
         mock_config_propagator.assert_called_once()
         mock_config_response_propagator.assert_called_once()
 
@@ -72,6 +381,7 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_traces_exp,
         mock_config_metrics_exp,
         mock_config_logs_exp,
+        mock_config_logs_handler,
         mock_config_propagator,
         mock_config_response_propagator,
     ):
@@ -90,5 +400,6 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_traces_exp.assert_not_called()
         mock_config_metrics_exp.assert_not_called()
         mock_config_logs_exp.assert_not_called()
+        mock_config_logs_handler.assert_not_called()
         mock_config_propagator.assert_not_called()
         mock_config_response_propagator.assert_not_called()

--- a/tests/unit/test_configurator/test_configurator_logs_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_logs_exporter.py
@@ -285,4 +285,4 @@ class TestConfiguratorLogsExporter:
         mock_loggerprovider.assert_called_once()
 
         mock_blprocessor.assert_called_once()
-        mock_logginghandler.assert_called_once()
+        mock_logginghandler.assert_not_called()


### PR DESCRIPTION
Replaces https://github.com/solarwinds/apm-python/pull/519

Adjusts APM Python's internal usage of upstream `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` and vendor-specific `SW_APM_EXPORT_LOGS_ENABLED`. The change is that logging provider and exporters are now _always_ set up when Agent Enabled.

The code is also cleaned up, but this is all the same:

1. `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` continues to have no default value (None) in APM Python.
2. `SW_APM_EXPORT_LOGS_ENABLED` continues to be False by default; it's an opt-in for users.
3. The OTEL config, only if set to True/False, continues to takes precedence over the SW_APM config.
4. The final config is still the condition for setting up the SDK log handler.
5. `OTEL_LOGS_EXPORTER` is still otlp http by default
6. Success of logging provider and exporter init and registration depends on correctness of `OTEL_LOGS_EXPORTER`.

EDIT: Should clarify that, from users PoV, `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` and `SW_APM_EXPORT_LOGS_ENABLED` do the same thing.