### PR TITLE
NH-105445 Breaking: update OTLP metrics export defaults and configs

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -112,7 +112,7 @@ class SolarWindsApmConfig:
             "transaction_filters": [],
             "transaction_name": None,
             "export_logs_enabled": False,
-            "export_metrics_enabled": False,
+            "export_metrics_enabled": True,
         }
         self.is_lambda = self.calculate_is_lambda()
         self.lambda_function_name = os.environ.get("AWS_LAMBDA_FUNCTION_NAME")

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -396,21 +396,8 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         self,
         apm_config: SolarWindsApmConfig,
     ) -> None:
-        """Configure OTel OTLP metrics exporters if enabled and agent enabled.
-        Settings precedence: OTEL_* > SW_APM_EXPORT_METRICS_ENABLED.
+        """Configure OTel OTLP metrics exporters.
         Links to new metric readers and global MeterProvider."""
-        if not apm_config.agent_enabled:
-            logger.error(
-                "APM Python library disabled. Cannot set metrics exporters."
-            )
-            return
-
-        if not apm_config.get("export_metrics_enabled"):
-            logger.debug(
-                "APM OTLP metrics export disabled. Skipping init of metrics exporters"
-            )
-            return
-
         # SolarWindsDistro._configure does setdefault before this is called
         environ_exporter = os.environ.get(
             OTEL_METRICS_EXPORTER,

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -847,7 +847,7 @@ class TestSolarWindsApmConfig:
         self,
     ):
         test_config = apm_config.SolarWindsApmConfig()
-        assert test_config.get("export_metrics_enabled") == False
+        assert test_config.get("export_metrics_enabled") == True
 
     def test_set_config_value_ignore_export_metrics_enabled(
         self,
@@ -857,7 +857,7 @@ class TestSolarWindsApmConfig:
     ):
         test_config = apm_config.SolarWindsApmConfig()
         test_config._set_config_value("export_metrics_enabled", "not-valid")
-        assert test_config.get("export_metrics_enabled") == False
+        assert test_config.get("export_metrics_enabled") == True
         assert "Ignore config option" in caplog.text
     def test_set_config_value_set_export_metrics_enabled_false(
         self,

--- a/tests/unit/test_apm_config/test_apm_config_calculate_metrics_enabled.py
+++ b/tests/unit/test_apm_config/test_apm_config_calculate_metrics_enabled.py
@@ -1,0 +1,48 @@
+# © 2025 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+import os
+import pytest
+from solarwinds_apm.apm_config import SolarWindsApmConfig
+
+class TestSolarWindsApmConfigCalculateMetricsEnabled:
+    @pytest.fixture(autouse=True)
+    def clear_env_vars(self):
+        # Clear environment variables before each test
+        os.environ.clear()
+
+    def test_calculate_metrics_enabled_with_env_var_true(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_EXPORT_METRICS_ENABLED": "true"})
+        assert SolarWindsApmConfig.calculate_metrics_enabled() is True
+
+    def test_calculate_metrics_enabled_with_env_var_false(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_EXPORT_METRICS_ENABLED": "false"})
+        assert SolarWindsApmConfig.calculate_metrics_enabled() is False
+
+    def test_calculate_metrics_enabled_with_config_not_provided_true(self, mocker):
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"export_metrics_enabled": "true"})
+        mocker.patch.object(SolarWindsApmConfig, 'convert_to_bool', return_value=True)
+        assert SolarWindsApmConfig.calculate_metrics_enabled() is True
+
+    def test_calculate_metrics_enabled_with_config_not_provided_false(self, mocker):
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"export_metrics_enabled": "false"})
+        mocker.patch.object(SolarWindsApmConfig, 'convert_to_bool', return_value=False)
+        assert SolarWindsApmConfig.calculate_metrics_enabled() is False
+
+    def test_calculate_metrics_enabled_with_config_not_boolean(self, mocker):
+        assert SolarWindsApmConfig.calculate_metrics_enabled(
+            cnf_dict={"export_metrics_enabled": "foo-bar"}
+        ) is True
+
+    def test_calculate_metrics_enabled_with_config_not_provided_and_env_var(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_EXPORT_METRICS_ENABLED": "true"})
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"export_metrics_enabled": "false"})
+        assert SolarWindsApmConfig.calculate_metrics_enabled() is True
+
+    def test_calculate_metrics_enabled_with_provided_cnf_dict(self, mocker):
+        mock_get_cnf_dict = mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict')
+        assert SolarWindsApmConfig.calculate_metrics_enabled(cnf_dict={"export_metrics_enabled": True}) is True
+        mock_get_cnf_dict.assert_not_called()

--- a/tests/unit/test_configurator/test_configurator_metrics_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_metrics_exporter.py
@@ -16,66 +16,6 @@ from .fixtures.trace import get_trace_mocks
 
 
 class TestConfiguratorMetricsExporter:
-    def test_configure_metrics_exporter_disabled(
-        self,
-        mocker,
-        mock_apmconfig_disabled,
-        mock_pemreader,
-        mock_meterprovider,
-    ):
-        # Mock Otel
-        trace_mocks = get_trace_mocks(mocker)
-
-        # Test!
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_metrics_exporter(
-            mock_apmconfig_disabled,
-        )
-        mock_pemreader.assert_not_called()
-        trace_mocks.get_tracer_provider.assert_not_called()
-        trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
-        mock_meterprovider.assert_not_called()
-
-    def test_configure_metrics_exporter_sw_enabled_false(
-        self,
-        mocker,
-        mock_apmconfig_metrics_enabled_false,
-        mock_pemreader,
-        mock_meterprovider,
-    ):
-        # Mock Otel
-        trace_mocks = get_trace_mocks(mocker)
-
-        # Test!
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_metrics_exporter(
-            mock_apmconfig_metrics_enabled_false,
-        )
-        mock_pemreader.assert_not_called()
-        trace_mocks.get_tracer_provider.assert_not_called()
-        trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
-        mock_meterprovider.assert_not_called()
-
-    def test_configure_metrics_exporter_sw_enabled_none(
-        self,
-        mocker,
-        mock_apmconfig_metrics_enabled_none,
-        mock_pemreader,
-        mock_meterprovider,
-    ):
-        # Mock Otel
-        trace_mocks = get_trace_mocks(mocker)
-
-        # Test!
-        test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_metrics_exporter(
-            mock_apmconfig_metrics_enabled_none,
-        )
-        mock_pemreader.assert_not_called()
-        trace_mocks.get_tracer_provider.assert_not_called()
-        trace_mocks.get_tracer_provider().get_tracer.assert_not_called()
-        mock_meterprovider.assert_not_called()
-
     def test_configure_metrics_exporter_none(
         self,
         mocker,

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -111,6 +111,20 @@ class TestDistro:
         if old_otel_ev_le:
             os.environ["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = old_otel_ev_le
 
+    def test_new_initializes_class_variables(self, mocker):
+        mock_get_cnf_dict = mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.get_cnf_dict",
+            return_value={"foo": "bar"},
+        )
+        mock_calculate_metrics_enabled = mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_metrics_enabled", return_value="qux",
+        )
+
+        instance = distro.SolarWindsDistro()
+        assert instance._cnf_dict == {"foo": "bar"}
+        assert instance._instrumentor_metrics_enabled is "qux"
+        mock_get_cnf_dict.assert_called_once()
+        mock_calculate_metrics_enabled.assert_called_once_with({"foo": "bar"})
 
     def test__log_python_runtime(self, mocker):
         mock_plat = mocker.patch(
@@ -891,6 +905,69 @@ class TestDistro:
         mock_instrument.assert_called_once_with(
             is_sql_commentor_enabled=True,
             foo="bar",
+        )
+
+    def test_load_instrumentor_metrics_enabled(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_metrics_enabled",
+            return_value=True,
+        )
+        mock_instrument = mocker.Mock()
+        mock_instrumentor = mocker.Mock()
+        mock_instrumentor.configure_mock(
+            return_value=mocker.Mock(
+                **{
+                    "instrument": mock_instrument
+                }
+            )
+        )
+        mock_load = mocker.Mock()
+        mock_load.configure_mock(return_value=mock_instrumentor)
+        mock_entry_point = mocker.Mock()
+        mock_entry_point.configure_mock(
+            **{
+                "name": "foo-instrumentor",
+                "load": mock_load,
+            }
+        )
+        distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
+        # No custom meter_provider set
+        mock_instrument.assert_called_once_with(
+            foo="bar",
+        )
+
+    def test_load_instrumentor_metrics_disabled(self, mocker):
+        mock_nmp = mocker.patch(
+            "solarwinds_apm.distro.NoOpMeterProvider",
+            return_value="noop"
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.calculate_metrics_enabled",
+            return_value=False,
+        )
+        mock_instrument = mocker.Mock()
+        mock_instrumentor = mocker.Mock()
+        mock_instrumentor.configure_mock(
+            return_value=mocker.Mock(
+                **{
+                    "instrument": mock_instrument
+                }
+            )
+        )
+        mock_load = mocker.Mock()
+        mock_load.configure_mock(return_value=mock_instrumentor)
+        mock_entry_point = mocker.Mock()
+        mock_entry_point.configure_mock(
+            **{
+                "name": "foo-instrumentor",
+                "load": mock_load,
+            }
+        )
+        distro.SolarWindsDistro().load_instrumentor(mock_entry_point, **{"foo": "bar"})
+        # passed custom meter_provider as no-op
+        mock_instrument.assert_called_once_with(
+            foo="bar",
+            meter_provider="noop",
         )
 
     def test_get_enable_commenter_env_map_none(self, mocker):

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -937,7 +937,7 @@ class TestDistro:
         )
 
     def test_load_instrumentor_metrics_disabled(self, mocker):
-        mock_nmp = mocker.patch(
+        mocker.patch(
             "solarwinds_apm.distro.NoOpMeterProvider",
             return_value="noop"
         )

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -122,7 +122,7 @@ class TestDistro:
 
         instance = distro.SolarWindsDistro()
         assert instance._cnf_dict == {"foo": "bar"}
-        assert instance._instrumentor_metrics_enabled is "qux"
+        assert instance._instrumentor_metrics_enabled == "qux"
         mock_get_cnf_dict.assert_called_once()
         mock_calculate_metrics_enabled.assert_called_once_with({"foo": "bar"})
 


### PR DESCRIPTION
Replaces https://github.com/solarwinds/apm-python/pull/508

Breaking changes:

1. APM Python will now always generate and export SWO/vendor OTLP metrics by default (previously an opt-in), like other APM libraries.
2. Behaviour of `SW_APM_EXPORT_METRICS_ENABLED` is changed. It is now a config to opt out of non-SWO metrics, e.g. from Otel Python instrumentors.

I will put in a documentation update PR separately.