### PR TITLE
NH-105553 Simplify dependabot dep checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,7 @@ updates:
     interval: weekly
 
   groups:
-    otel-instrumentors:
-      patterns:
-        - "opentelemetry-instrumentation-*"
-      update-types:
-        - minor
-        - patch
-
-    otel-utils:
+    otel-dependencies:
       patterns:
         - "opentelemetry-*"
       update-types:
@@ -27,22 +20,7 @@ updates:
     interval: weekly
 
   groups:
-    otel-core:
-      patterns:
-        - "opentelemetry-api"
-        - "opentelemetry-sdk"
-      update-types:
-        - minor
-        - patch
-
-    otel-instrumentors:
-      patterns:
-        - "opentelemetry-instrumentation-*"
-      update-types:
-        - minor
-        - patch
-
-    otel-utils:
+    otel-dependencies:
       patterns:
         - "opentelemetry-*"
       update-types:


### PR DESCRIPTION
Outside the lambda test dir: simplifies dependabot deps checks so that there is one group, `otel-dependencies`, that will result in one PR -- instead of 3 for 3 `otel-*` groups!

Inside lambda test dir: also reduces to one PR, instead of 2