### PR TITLE
WIP/PoC: ServiceEntrySpanProcessor caches span for set_transaction_name

### DIFF
--- a/solarwinds_apm/apm_entry_span_manager.py
+++ b/solarwinds_apm/apm_entry_span_manager.py
@@ -1,0 +1,25 @@
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class SolarwindsEntrySpanManager:
+    def __init__(self, **kwargs: int) -> None:
+        self.__cache = {}
+
+    def __delitem__(self, key: str) -> None:
+        del self.__cache[key]
+
+    def __getitem__(self, key: str) -> Any:
+        return self.__cache[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.__cache[key] = value
+
+    def __str__(self) -> str:
+        return json.dumps(self.__cache)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.__cache.get(key, default)

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -60,6 +60,7 @@ from solarwinds_apm.apm_constants import (
     INTL_SWO_DEFAULT_TRACES_EXPORTER,
     INTL_SWO_SUPPORT_EMAIL,
 )
+from solarwinds_apm.apm_entry_span_manager import SolarwindsEntrySpanManager
 from solarwinds_apm.apm_fwkv_manager import SolarWindsFrameworkKvManager
 from solarwinds_apm.apm_oboe_codes import OboeReporterCode
 from solarwinds_apm.apm_txname_manager import SolarWindsTxnNameManager
@@ -68,6 +69,7 @@ from solarwinds_apm.response_propagator import (
 )
 from solarwinds_apm.trace import (
     ServiceEntryIdSpanProcessor,
+    SolarWindsEntrySpanProcessor,
     SolarWindsInboundMetricsSpanProcessor,
     SolarWindsOTLPMetricsSpanProcessor,
     TxnNameCalculatorProcessor,
@@ -141,6 +143,12 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         if apm_config.agent_enabled:
             # set MeterProvider first via metrics_exporter config
             self._configure_metrics_exporter(apm_config)
+
+            # Test entry span processor init and register
+            trace.get_tracer_provider().add_span_processor(
+                SolarWindsEntrySpanProcessor(SolarwindsEntrySpanManager())
+            )
+
             # This processor only defines on_start
             self._configure_service_entry_id_span_processor()
 

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -68,7 +68,7 @@ from solarwinds_apm.response_propagator import (
     SolarWindsTraceResponsePropagator,
 )
 from solarwinds_apm.trace import (
-    ServiceEntryIdSpanProcessor,
+    ServiceEntrySpanProcessor,
     SolarWindsEntrySpanProcessor,
     SolarWindsInboundMetricsSpanProcessor,
     SolarWindsOTLPMetricsSpanProcessor,
@@ -150,8 +150,11 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                 SolarWindsEntrySpanProcessor()
             )
 
+            apm_entry_span_manager = SolarwindsEntrySpanManager()
             # This processor only defines on_start
-            self._configure_service_entry_id_span_processor()
+            self._configure_service_entry_id_span_processor(
+                apm_entry_span_manager,
+            )
 
             # The txnname calculator span processor must be registered
             # before the rest of the processors with defined on_end
@@ -249,10 +252,11 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
 
     def _configure_service_entry_id_span_processor(
         self,
+        apm_entry_span_manager: SolarwindsEntrySpanManager,
     ) -> None:
-        """Configure ServiceEntryIdSpanProcessor"""
+        """Configure ServiceEntrySpanProcessor"""
         trace.get_tracer_provider().add_span_processor(
-            ServiceEntryIdSpanProcessor()
+            ServiceEntrySpanProcessor(SolarwindsEntrySpanManager())
         )
 
     def _configure_txnname_calculator_span_processor(

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -144,9 +144,10 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             # set MeterProvider first via metrics_exporter config
             self._configure_metrics_exporter(apm_config)
 
-            # Test entry span processor init and register
+            # Test entry span processor
+            # TODO: remove this
             trace.get_tracer_provider().add_span_processor(
-                SolarWindsEntrySpanProcessor(SolarwindsEntrySpanManager())
+                SolarWindsEntrySpanProcessor()
             )
 
             # This processor only defines on_start

--- a/solarwinds_apm/trace/__init__.py
+++ b/solarwinds_apm/trace/__init__.py
@@ -1,12 +1,12 @@
 from .entry_span_processor import SolarWindsEntrySpanProcessor
 from .inbound_metrics_processor import SolarWindsInboundMetricsSpanProcessor
 from .otlp_metrics_processor import SolarWindsOTLPMetricsSpanProcessor
-from .serviceentry_processor import ServiceEntryIdSpanProcessor
+from .serviceentry_processor import ServiceEntrySpanProcessor
 from .txnname_calculator_processor import TxnNameCalculatorProcessor
 from .txnname_cleanup_processor import TxnNameCleanupProcessor
 
 __all__ = [
-    "ServiceEntryIdSpanProcessor",
+    "ServiceEntrySpanProcessor",
     "SolarWindsEntrySpanProcessor",
     "SolarWindsInboundMetricsSpanProcessor",
     "SolarWindsOTLPMetricsSpanProcessor",

--- a/solarwinds_apm/trace/__init__.py
+++ b/solarwinds_apm/trace/__init__.py
@@ -1,3 +1,4 @@
+from .entry_span_processor import SolarWindsEntrySpanProcessor
 from .inbound_metrics_processor import SolarWindsInboundMetricsSpanProcessor
 from .otlp_metrics_processor import SolarWindsOTLPMetricsSpanProcessor
 from .serviceentry_processor import ServiceEntryIdSpanProcessor
@@ -6,6 +7,7 @@ from .txnname_cleanup_processor import TxnNameCleanupProcessor
 
 __all__ = [
     "ServiceEntryIdSpanProcessor",
+    "SolarWindsEntrySpanProcessor",
     "SolarWindsInboundMetricsSpanProcessor",
     "SolarWindsOTLPMetricsSpanProcessor",
     "TxnNameCalculatorProcessor",

--- a/solarwinds_apm/trace/entry_span_processor.py
+++ b/solarwinds_apm/trace/entry_span_processor.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import SpanProcessor
 
-from solarwinds_apm.apm_entry_span_manager import SolarwindsEntrySpanManager
-
 if TYPE_CHECKING:
 
     from opentelemetry.sdk.trace import ReadableSpan, Span
@@ -14,11 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 class SolarWindsEntrySpanProcessor(SpanProcessor):
-    def __init__(
-        self,
-        apm_entry_span_manager: SolarwindsEntrySpanManager,
-    ) -> None:
-        self.apm_entry_span_manager = apm_entry_span_manager
+    """Test processor repurposed for debugging
+    TODO remove from here, module __init__, and configurator"""
 
     def on_start(
         self,
@@ -34,61 +29,23 @@ class SolarWindsEntrySpanProcessor(SpanProcessor):
         ):
             return
 
-        logger.info("Caching entry span %s", span.context.span_id)
-
-        self.apm_entry_span_manager[span.context.span_id] = span
-
-        try:
-            logger.info("Entry Span at on_start: %s", span)
-            logger.info("with type: %s", type(span))
-            logger.info("with attributes: %s", span.attributes)
-        except Exception as e:
-            logger.error(
-                "%s: %s",
-                type(e).__name__,
-                e,
-            )
+        logger.info("Entry Span at on_start: %s", span)
+        logger.info("with type: %s", type(span))
+        logger.info("with attributes: %s", span.attributes)
 
     def on_end(
         self,
         span: "ReadableSpan",
     ) -> None:
         """Updates cached entry span, if exists"""
-        entry_span = self.apm_entry_span_manager.get(span.context.span_id)
-        if entry_span:
-            logger.info(
-                "Setting span name, attributes for entry span %s",
-                entry_span.context.span_id,
-            )
-            try:
-                # (1)
-                # AttributeError: can't set attribute 'name'/'attributes'
-                # entry_span.name = "MyAwesomeSpanName"
-                # entry_span.attributes = {"bazbaz": "quxqux"}
+        parent_span_context = span.parent
+        if (
+            parent_span_context
+            and parent_span_context.is_valid
+            and not parent_span_context.is_remote
+        ):
+            return
 
-                # (2)
-                # Setting attribute on ended span. (does not work)
-                # (Btw, this was with or without the _attributes part below)
-                entry_span.set_attribute("foofoo", "barbar")
-                entry_span.set_attribute(
-                    "TransactionName", "MyAwesomeTransactionName"
-                )
-
-                # (3)
-                # Full replace works, but does not export
-                new_attributes = {
-                    "bazbaz": "quxqux",
-                    "TransactionName": "MyAwesomestTxnName",
-                }
-                for attr_key, attr_value in entry_span.attributes.items():
-                    new_attributes[attr_key] = attr_value
-                entry_span._attributes = new_attributes
-            except Exception as e:
-                logger.error(
-                    "%s: %s",
-                    type(e).__name__,
-                    e,
-                )
-            logger.info("Entry Span at on_end: %s", entry_span)
-            logger.info("with type: %s", type(entry_span))
-            logger.info("with attributes: %s", entry_span.attributes)
+        logger.info("Entry Span at on_end: %s", span)
+        logger.info("with type: %s", type(span))
+        logger.info("with attributes: %s", span.attributes)

--- a/solarwinds_apm/trace/entry_span_processor.py
+++ b/solarwinds_apm/trace/entry_span_processor.py
@@ -61,16 +61,20 @@ class SolarWindsEntrySpanProcessor(SpanProcessor):
                 entry_span.context.span_id,
             )
             try:
+                # (1)
                 # AttributeError: can't set attribute 'name'/'attributes'
                 # entry_span.name = "MyAwesomeSpanName"
                 # entry_span.attributes = {"bazbaz": "quxqux"}
 
+                # (2)
                 # Setting attribute on ended span. (does not work)
+                # (Btw, this was with or without the _attributes part below)
                 entry_span.set_attribute("foofoo", "barbar")
                 entry_span.set_attribute(
                     "TransactionName", "MyAwesomeTransactionName"
                 )
 
+                # (3)
                 # Full replace works, but does not export
                 new_attributes = {
                     "bazbaz": "quxqux",

--- a/solarwinds_apm/trace/entry_span_processor.py
+++ b/solarwinds_apm/trace/entry_span_processor.py
@@ -61,9 +61,13 @@ class SolarWindsEntrySpanProcessor(SpanProcessor):
                 entry_span.context.span_id,
             )
             try:
-                # AttributeError: Error setting entry span name, attributes: can't set attribute 'name'
+                # AttributeError: can't set attribute 'name'
                 # entry_span.name = "MyAwesomeSpanName"
 
+                # AttributeError: can't set attribute 'attributes'
+                # entry_span.attributes = {"bazbaz": "quxqux"}
+
+                # Setting attribute on ended span.
                 entry_span.set_attribute("foofoo", "barbar")
                 entry_span.set_attribute(
                     "TransactionName", "MyAwesomeTransactionName"

--- a/solarwinds_apm/trace/entry_span_processor.py
+++ b/solarwinds_apm/trace/entry_span_processor.py
@@ -1,0 +1,79 @@
+import logging
+from typing import TYPE_CHECKING
+
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import SpanProcessor
+
+from solarwinds_apm.apm_entry_span_manager import SolarwindsEntrySpanManager
+
+if TYPE_CHECKING:
+
+    from opentelemetry.sdk.trace import ReadableSpan, Span
+
+logger = logging.getLogger(__name__)
+
+
+class SolarWindsEntrySpanProcessor(SpanProcessor):
+    def __init__(
+        self,
+        apm_entry_span_manager: SolarwindsEntrySpanManager,
+    ) -> None:
+        self.apm_entry_span_manager = apm_entry_span_manager
+
+    def on_start(
+        self,
+        span: "Span",
+        parent_context: Context | None = None,
+    ) -> None:
+        """Caches current span, if entry span, in entry span manager"""
+        parent_span_context = span.parent
+        if (
+            parent_span_context
+            and parent_span_context.is_valid
+            and not parent_span_context.is_remote
+        ):
+            return
+
+        logger.info("Caching entry span %s", span.context.span_id)
+
+        self.apm_entry_span_manager[span.context.span_id] = span
+
+        try:
+            logger.info("Entry Span at on_start: %s", span)
+            logger.info("with type: %s", type(span))
+            logger.info("with attributes: %s", span.attributes)
+        except Exception as e:
+            logger.error(
+                "%s: %s",
+                type(e).__name__,
+                e,
+            )
+
+    def on_end(
+        self,
+        span: "ReadableSpan",
+    ) -> None:
+        """Updates cached entry span, if exists"""
+        entry_span = self.apm_entry_span_manager.get(span.context.span_id)
+        if entry_span:
+            logger.info(
+                "Setting span name, attributes for entry span %s",
+                entry_span.context.span_id,
+            )
+            try:
+                # AttributeError: Error setting entry span name, attributes: can't set attribute 'name'
+                # entry_span.name = "MyAwesomeSpanName"
+
+                entry_span.set_attribute("foofoo", "barbar")
+                entry_span.set_attribute(
+                    "TransactionName", "MyAwesomeTransactionName"
+                )
+            except Exception as e:
+                logger.error(
+                    "%s: %s",
+                    type(e).__name__,
+                    e,
+                )
+            logger.info("Entry Span at on_end: %s", entry_span)
+            logger.info("with type: %s", type(entry_span))
+            logger.info("with attributes: %s", entry_span.attributes)

--- a/solarwinds_apm/trace/entry_span_processor.py
+++ b/solarwinds_apm/trace/entry_span_processor.py
@@ -61,17 +61,24 @@ class SolarWindsEntrySpanProcessor(SpanProcessor):
                 entry_span.context.span_id,
             )
             try:
-                # AttributeError: can't set attribute 'name'
+                # AttributeError: can't set attribute 'name'/'attributes'
                 # entry_span.name = "MyAwesomeSpanName"
-
-                # AttributeError: can't set attribute 'attributes'
                 # entry_span.attributes = {"bazbaz": "quxqux"}
 
-                # Setting attribute on ended span.
+                # Setting attribute on ended span. (does not work)
                 entry_span.set_attribute("foofoo", "barbar")
                 entry_span.set_attribute(
                     "TransactionName", "MyAwesomeTransactionName"
                 )
+
+                # Full replace works, but does not export
+                new_attributes = {
+                    "bazbaz": "quxqux",
+                    "TransactionName": "MyAwesomestTxnName",
+                }
+                for attr_key, attr_value in entry_span.attributes.items():
+                    new_attributes[attr_key] = attr_value
+                entry_span._attributes = new_attributes
             except Exception as e:
                 logger.error(
                     "%s: %s",

--- a/tests/unit/test_configurator/test_configurator_span_processors.py
+++ b/tests/unit/test_configurator/test_configurator_span_processors.py
@@ -19,7 +19,7 @@ class TestConfiguratorSpanProcessors:
     ):
         trace_mocks = get_trace_mocks(mocker)
         mocker.patch(
-            "solarwinds_apm.configurator.ServiceEntryIdSpanProcessor"
+            "solarwinds_apm.configurator.ServiceEntrySpanProcessor"
         )
 
         test_configurator = configurator.SolarWindsConfigurator()

--- a/tests/unit/test_processors/test_serviceentryid_processor.py
+++ b/tests/unit/test_processors/test_serviceentryid_processor.py
@@ -4,9 +4,9 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-from solarwinds_apm.trace import ServiceEntryIdSpanProcessor
+from solarwinds_apm.trace import ServiceEntrySpanProcessor
 
-class TestServiceEntryIdSpanProcessor():
+class TestServiceEntrySpanProcessor():
 
     def patch_for_on_start(self, mocker):
         mock_otel_context = mocker.patch(
@@ -57,7 +57,7 @@ class TestServiceEntryIdSpanProcessor():
                 "parent": mock_parent
             }
         )
-        processor = ServiceEntryIdSpanProcessor()
+        processor = ServiceEntrySpanProcessor()
         assert processor.on_start(mock_span, None) is None
         mock_swo_baggage_key.assert_not_called()
         mock_set_baggage.assert_not_called()
@@ -78,7 +78,7 @@ class TestServiceEntryIdSpanProcessor():
                 "parent": mock_parent
             }
         )
-        processor = ServiceEntryIdSpanProcessor()
+        processor = ServiceEntrySpanProcessor()
         assert processor.on_start(mock_span, None) is None
         mock_set_baggage.assert_called_once_with(
             mock_swo_baggage_key,
@@ -101,7 +101,7 @@ class TestServiceEntryIdSpanProcessor():
                 "parent": mock_parent
             }
         )
-        processor = ServiceEntryIdSpanProcessor()
+        processor = ServiceEntrySpanProcessor()
         assert processor.on_start(mock_span, None) is None
         mock_set_baggage.assert_called_once_with(
             mock_swo_baggage_key,
@@ -124,7 +124,7 @@ class TestServiceEntryIdSpanProcessor():
                 "parent": mock_parent
             }
         )
-        processor = ServiceEntryIdSpanProcessor()
+        processor = ServiceEntrySpanProcessor()
         assert processor.on_start(mock_span, None) is None
         mock_set_baggage.assert_called_once_with(
             mock_swo_baggage_key,
@@ -140,7 +140,7 @@ class TestServiceEntryIdSpanProcessor():
                 "parent": None
             }
         )
-        processor = ServiceEntryIdSpanProcessor()
+        processor = ServiceEntrySpanProcessor()
         assert processor.on_start(mock_span, None) is None
         mock_set_baggage.assert_called_once_with(
             mock_swo_baggage_key,


### PR DESCRIPTION
WIP/PoC: `ServiceEntrySpanProcessor` (formerly ServiceEntry**Id**SpanProcessor) caches entry span, assuming only one per trace as before. API `set_transaction_name` uses cached span for direct `set_attribute` call.

There is another new class `SolarWindsEntrySpanProcessor` that's only for debugging at this point.

Tests failing. May need a cache cleanup function.