### PR TITLE
NH-72398 Nit: Don't need to resolve `http.route` as txn name

### DIFF
--- a/solarwinds_apm/trace/serviceentry_processor.py
+++ b/solarwinds_apm/trace/serviceentry_processor.py
@@ -92,9 +92,7 @@ class ServiceEntrySpanProcessor(SpanProcessor):
                 lambda_function_name[:INTL_SWO_TRANSACTION_ATTR_MAX],
             )
         elif http_route:
-            self.set_default_transaction_name(
-                span, pool, http_route, resolve=True
-            )
+            self.set_default_transaction_name(span, pool, http_route)
         elif url_path:
             self.set_default_transaction_name(
                 span, pool, url_path, resolve=True

--- a/tests/unit/test_processors/test_serviceentry_processor.py
+++ b/tests/unit/test_processors/test_serviceentry_processor.py
@@ -264,7 +264,7 @@ class TestServiceEntrySpanProcessor():
         processor.set_default_transaction_name = mocker.Mock()
         processor.on_start(mock_span, None)
         processor.set_default_transaction_name.assert_called_once_with(
-            mock_span, mock_pool, "http-route", resolve=True
+            mock_span, mock_pool, "http-route"
         )
 
     def test_on_start_url_path(self, mocker):


### PR DESCRIPTION
We don't need to resolve `http.route` when used as default txn name because of how it's [defined in the semconv](https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-route).