### PR TITLE
NH-104796 Fix init of pure Python Oboe counters

### DIFF
--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 # import enum
 import logging
 
-from opentelemetry.sdk import metrics
+from opentelemetry.metrics import get_meter_provider
 
 # from opentelemetry.context.context import Context as OtelContext
 from opentelemetry.sdk.trace.sampling import (  # Decision,; Sampler,; SamplingResult,
@@ -645,11 +645,11 @@ class ParentBasedSwSampler(ParentBased):
         sampler = None
         if apm_config.is_lambda:
             sampler = JsonSampler(
-                meter_provider=metrics.MeterProvider(), config=configuration
+                meter_provider=get_meter_provider(), config=configuration
             )
         else:
             sampler = HttpSampler(
-                meter_provider=metrics.MeterProvider(),
+                meter_provider=get_meter_provider(),
                 config=configuration,
                 initial=None,
             )


### PR DESCRIPTION
Fixes small bug in the init of pure Python Oboe request counters for sampler-triggered OTLP metrics. Changes to use current global MeterProvider instead of passing a new one, so all metrics export via one reader etc.