### PR TITLE
NH-104999 Remove unused `oboe_api` from configurator, sampler init

### DIFF
--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -95,7 +95,6 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         """Configure SolarWinds APM and OTel components"""
         apm_fwkv_manager = SolarWindsFrameworkKvManager()
         apm_config = SolarWindsApmConfig()
-        # oboe_api = apm_config.oboe_api
 
         # Reporter may be no-op e.g. disabled, lambda
         # reporter = self._initialize_solarwinds_reporter(apm_config)
@@ -103,9 +102,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             apm_fwkv_manager,
             apm_config,
             None,
-            None,
             # reporter,
-            # oboe_api,
         )
 
         # if apm_config.is_lambda:
@@ -127,13 +124,11 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         apm_fwkv_manager: SolarWindsFrameworkKvManager,
         apm_config: SolarWindsApmConfig,
         reporter: Any = None,
-        oboe_api: Any = None,
     ) -> None:
         """Configure OTel sampler, exporter, propagator, response propagator"""
         self._configure_sampler(
             apm_config,
             reporter,
-            oboe_api,
         )
         if apm_config.agent_enabled:
             # set MeterProvider first via metrics_exporter config
@@ -165,7 +160,6 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         self,
         apm_config: SolarWindsApmConfig,
         reporter,
-        oboe_api,
     ) -> None:
         """Always configure SolarWinds OTel sampler, or none if disabled"""
         if not apm_config.agent_enabled:
@@ -180,7 +174,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                         name=self._DEFAULT_SW_TRACES_SAMPLER,
                     )
                 )
-            ).load()(apm_config, reporter, oboe_api)
+            ).load()(apm_config, reporter)
         except Exception as ex:
             logger.exception("A exception was raised: %s", ex)
             logger.exception(

--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -634,7 +634,6 @@ class ParentBasedSwSampler(ParentBased):
         self,
         apm_config: "SolarWindsApmConfig",
         reporter,
-        oboe_api,
     ):
         """
         Uses HttpSampler/JsonSampler if no parent span.

--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -438,10 +438,6 @@ def mock_fwkv_manager_init(mocker):
         "solarwinds_apm.configurator.SolarWindsFrameworkKvManager"
     )
 
-@pytest.fixture(name="mock_oboe_api_obj")
-def mock_oboe_api_obj(mocker):
-    return mocker.Mock()
-
 
 # ==================================================================
 # Configurator APM Python other mocks

--- a/tests/unit/test_configurator/test_configurator_configure_otel.py
+++ b/tests/unit/test_configurator/test_configurator_configure_otel.py
@@ -50,7 +50,6 @@ class TestConfiguratorConfigureOtelComponents:
         mock_fwkv_manager,
         mock_extension,
         mock_apmconfig_disabled,
-        mock_oboe_api_obj,
 
         mock_config_serviceentryid_processor,
         mock_config_inbound_processor,
@@ -66,7 +65,6 @@ class TestConfiguratorConfigureOtelComponents:
             mock_fwkv_manager,
             mock_apmconfig_disabled,
             mock_extension.Reporter,
-            mock_oboe_api_obj,
         )
 
         mock_config_serviceentryid_processor.assert_not_called()

--- a/tests/unit/test_configurator/test_configurator_sampler.py
+++ b/tests/unit/test_configurator/test_configurator_sampler.py
@@ -19,7 +19,6 @@ class TestConfiguratorSampler:
         self,
         mocker,
         mock_apmconfig_disabled,
-        mock_oboe_api_obj,
         mock_tracerprovider,
     ):
         # Mock Otel
@@ -30,7 +29,6 @@ class TestConfiguratorSampler:
         test_configurator._configure_sampler(
             mock_apmconfig_disabled,
             mocker.Mock(),
-            mock_oboe_api_obj,
         )
 
         # sets tracer_provider with noop
@@ -45,7 +43,6 @@ class TestConfiguratorSampler:
         self,
         mocker,
         mock_apmconfig_enabled,
-        mock_oboe_api_obj,
         mock_tracerprovider,
     ):
         # Mock entry points
@@ -66,7 +63,6 @@ class TestConfiguratorSampler:
             test_configurator._configure_sampler(
                 mock_apmconfig_enabled,
                 mocker.Mock(),
-                mock_oboe_api_obj,
             )
 
         # no tracer_provider is set
@@ -79,7 +75,6 @@ class TestConfiguratorSampler:
         self,
         mocker,
         mock_apmconfig_enabled,
-        mock_oboe_api_obj,
         mock_tracerprovider,
     ):
         # Mock entry points
@@ -111,7 +106,6 @@ class TestConfiguratorSampler:
         test_configurator._configure_sampler(
             mock_apmconfig_enabled,
             mocker.Mock(),
-            mock_oboe_api_obj,
         )
 
         # tracer_provider set with new resource using configured service_name
@@ -137,7 +131,6 @@ class TestConfiguratorSampler:
         self,
         mocker,
         mock_apmconfig_enabled,
-        mock_oboe_api_obj,
         mock_tracerprovider,
     ):
         # Save any SAMPLER env var for later
@@ -186,7 +179,6 @@ class TestConfiguratorSampler:
         test_configurator._configure_sampler(
             mock_apmconfig_enabled,
             mocker.Mock(),
-            mock_oboe_api_obj,
         )
 
         # sampler loaded was solarwinds_sampler, not configured foo_sampler


### PR DESCRIPTION
A bit of cleanup along the way. Removes unused `oboe_api` from configurator, sampler init. Pure Python sampler in any mode does not need it.