### PR TITLE
NH-104796 Rename as ResponseTimeProcessor

### DIFF
--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -69,9 +69,9 @@ from solarwinds_apm.response_propagator import (
     SolarWindsTraceResponsePropagator,
 )
 from solarwinds_apm.trace import (
+    ResponseTimeProcessor,
     ServiceEntrySpanProcessor,
     SolarWindsInboundMetricsSpanProcessor,
-    SolarWindsOTLPMetricsSpanProcessor,
 )
 from solarwinds_apm.tracer_provider import SolarwindsTracerProvider
 from solarwinds_apm.version import __version__
@@ -147,7 +147,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             self._configure_inbound_metrics_span_processor(
                 apm_config,
             )
-            self._configure_otlp_metrics_span_processors(
+            self._configure_response_time_processor(
                 apm_config,
             )
 
@@ -244,12 +244,12 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             )
         )
 
-    def _configure_otlp_metrics_span_processors(
+    def _configure_response_time_processor(
         self,
         apm_config: SolarWindsApmConfig,
     ) -> None:
-        """Configure SolarWindsOTLPMetricsSpanProcessor (including OTLP meters)
-        if metrics exporters are configured and set up i.e. by _configure_metrics_exporter
+        """Configure ResponseTimeProcessor if metrics exporters are configured and set up
+        i.e. by _configure_metrics_exporter
         """
         # SolarWindsDistro._configure does setdefault before this is called
         environ_exporter = os.environ.get(
@@ -262,7 +262,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             return
 
         trace.get_tracer_provider().add_span_processor(
-            SolarWindsOTLPMetricsSpanProcessor(
+            ResponseTimeProcessor(
                 apm_config,
             )
         )

--- a/solarwinds_apm/trace/__init__.py
+++ b/solarwinds_apm/trace/__init__.py
@@ -1,9 +1,9 @@
 from .inbound_metrics_processor import SolarWindsInboundMetricsSpanProcessor
-from .otlp_metrics_processor import SolarWindsOTLPMetricsSpanProcessor
+from .response_time_processor import ResponseTimeProcessor
 from .serviceentry_processor import ServiceEntrySpanProcessor
 
 __all__ = [
     "ServiceEntrySpanProcessor",
     "SolarWindsInboundMetricsSpanProcessor",
-    "SolarWindsOTLPMetricsSpanProcessor",
+    "ResponseTimeProcessor",
 ]

--- a/solarwinds_apm/trace/response_time_processor.py
+++ b/solarwinds_apm/trace/response_time_processor.py
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class SolarWindsOTLPMetricsSpanProcessor(_SwBaseMetricsProcessor):
-    """SolarWinds span processor for OTLP metrics recording."""
+class ResponseTimeProcessor(_SwBaseMetricsProcessor):
+    """SolarWinds span processor for recording response_time metrics."""
 
     def __init__(
         self,

--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -365,10 +365,10 @@ def mock_config_inbound_processor(mocker):
         "solarwinds_apm.configurator.SolarWindsConfigurator._configure_inbound_metrics_span_processor"
     )
 
-@pytest.fixture(name="mock_config_otlp_processors")
-def mock_config_otlp_processors(mocker):
+@pytest.fixture(name="mock_response_time_processor")
+def mock_response_time_processor(mocker):
     return mocker.patch(
-        "solarwinds_apm.configurator.SolarWindsConfigurator._configure_otlp_metrics_span_processors"
+        "solarwinds_apm.configurator.SolarWindsConfigurator._configure_response_time_processor"
     )
 
 @pytest.fixture(name="mock_config_traces_exp")

--- a/tests/unit/test_configurator/test_configurator_configure_otel.py
+++ b/tests/unit/test_configurator/test_configurator_configure_otel.py
@@ -15,7 +15,7 @@ class TestConfiguratorConfigureOtelComponents:
 
         mock_config_serviceentryid_processor,
         mock_config_inbound_processor,
-        mock_config_otlp_processors,
+        mock_response_time_processor,
         mock_config_traces_exp,
         mock_config_metrics_exp,
         mock_config_logs_exp,
@@ -32,7 +32,7 @@ class TestConfiguratorConfigureOtelComponents:
         # mock_config_inbound_processor.assert_called_once_with(
         #     mock_apmconfig_enabled,
         # )
-        # mock_config_otlp_processors.assert_called_once_with(
+        # mock_response_time_processor.assert_called_once_with(
         #     mock_apmconfig_enabled,
         # )
         # mock_config_traces_exp.assert_called_once_with(
@@ -54,7 +54,7 @@ class TestConfiguratorConfigureOtelComponents:
 
         mock_config_serviceentryid_processor,
         mock_config_inbound_processor,
-        mock_config_otlp_processors,
+        mock_response_time_processor,
         mock_config_traces_exp,
         mock_config_metrics_exp,
         mock_config_logs_exp,
@@ -71,7 +71,7 @@ class TestConfiguratorConfigureOtelComponents:
 
         mock_config_serviceentryid_processor.assert_not_called()
         mock_config_inbound_processor.assert_not_called()
-        mock_config_otlp_processors.assert_not_called()
+        mock_response_time_processor.assert_not_called()
         mock_config_traces_exp.assert_not_called()
         mock_config_metrics_exp.assert_not_called()
         mock_config_logs_exp.assert_not_called()

--- a/tests/unit/test_configurator/test_configurator_span_processors.py
+++ b/tests/unit/test_configurator/test_configurator_span_processors.py
@@ -116,7 +116,7 @@ class TestConfiguratorSpanProcessors:
         if old_exporter:
             os.environ["OTEL_TRACES_EXPORTER"] = old_exporter
 
-    def test_configure_otlp_metrics_span_processors_exporters_not_set(
+    def test_configure_response_time_processor_exporters_not_set(
         self,
         mocker,
         mock_apmconfig_enabled,
@@ -132,12 +132,12 @@ class TestConfiguratorSpanProcessors:
         trace_mocks = get_trace_mocks(mocker)
         mock_processor_instance = mocker.Mock()
         mock_otlp_processor = mocker.patch(
-            "solarwinds_apm.configurator.SolarWindsOTLPMetricsSpanProcessor",
+            "solarwinds_apm.configurator.ResponseTimeProcessor",
             return_value=mock_processor_instance,
         )
 
         test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_otlp_metrics_span_processors(
+        test_configurator._configure_response_time_processor(
             mock_apmconfig_enabled,
         )
         trace_mocks.get_tracer_provider.assert_not_called()
@@ -148,7 +148,7 @@ class TestConfiguratorSpanProcessors:
         if old_exporter:
             os.environ["OTEL_METRICS_EXPORTER"] = old_exporter
 
-    def test_configure_otlp_metrics_span_processors_exporters_set(
+    def test_configure_response_time_processor_exporters_set(
         self,
         mocker,
         mock_apmconfig_enabled,
@@ -164,12 +164,12 @@ class TestConfiguratorSpanProcessors:
         trace_mocks = get_trace_mocks(mocker)
         mock_processor_instance = mocker.Mock()
         mock_otlp_processor = mocker.patch(
-            "solarwinds_apm.configurator.SolarWindsOTLPMetricsSpanProcessor",
+            "solarwinds_apm.configurator.ResponseTimeProcessor",
             return_value=mock_processor_instance,
         )
 
         test_configurator = configurator.SolarWindsConfigurator()
-        test_configurator._configure_otlp_metrics_span_processors(
+        test_configurator._configure_response_time_processor(
             mock_apmconfig_enabled,
         )
         trace_mocks.get_tracer_provider.assert_has_calls(

--- a/tests/unit/test_processors/test_otlp_metrics_processor.py
+++ b/tests/unit/test_processors/test_otlp_metrics_processor.py
@@ -4,9 +4,9 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-from solarwinds_apm.trace import SolarWindsOTLPMetricsSpanProcessor
+from solarwinds_apm.trace import ResponseTimeProcessor
 
-class TestSolarWindsOTLPMetricsSpanProcessor:
+class TestResponseTimeProcessor:
 
     def get_mock_apm_config(
         self,
@@ -36,7 +36,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             "foo-env-txn-name",
             "foo-lambda-name",
         )
-        processor = SolarWindsOTLPMetricsSpanProcessor(
+        processor = ResponseTimeProcessor(
             mock_apm_config,
         )
         assert processor.service_name == "foo-service"
@@ -48,7 +48,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             mocker,
             "foo-env-trans-name",
         )
-        assert "foo-env-trans-name" == SolarWindsOTLPMetricsSpanProcessor(
+        assert "foo-env-trans-name" == ResponseTimeProcessor(
             mock_apm_config,
         ).calculate_otlp_transaction_name("foo-span")
 
@@ -57,7 +57,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             mocker,
             "foo-txn-ffoooofofooooooofooofooooofofofofoooooofoooooooooffoffooooooffffofooooofffooooooofoooooffoofofoooooofffofooofoffoooofooofoooooooooooooofooffoooofofooofoooofoofooffooooofoofooooofoooooffoofffoffoooooofoooofoooffooffooofofooooooffffooofoooooofoooooofooofoooofoo",
         )
-        assert "foo-txn-ffoooofofooooooofooofooooofofofofoooooofoooooooooffoffooooooffffofooooofffooooooofoooooffoofofoooooofffofooofoffoooofooofoooooooooooooofooffoooofofooofoooofoofooffooooofoofooooofoooooffoofffoffoooooofoooofoooffooffooofofooooooffffooofoooooofoooooo" == SolarWindsOTLPMetricsSpanProcessor(
+        assert "foo-txn-ffoooofofooooooofooofooooofofofofoooooofoooooooooffoffooooooffffofooooofffooooooofoooooffoofofoooooofffofooofoffoooofooofoooooooooooooofooffoooofofooofoooofoofooffooooofoofooooofoooooffoofffoffoooooofoooofoooffooffooofofooooooffffooofoooooofoooooo" == ResponseTimeProcessor(
             mock_apm_config,
         ).calculate_otlp_transaction_name("foo-span")
 
@@ -67,7 +67,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             outer_txn_retval=None,
             lambda_function_name="foo-lambda-ffoooofofooooooofooofooooofofofofoooooofoooooooooffoffooooooffffofooooofffooooooofoooooffoofofoooooofffofooofoffoooofooofoooooooooooooofooffoooofofooofoooofoofooffooooofoofooooofoooooffoofffoffoooooofoooofoooffooffooofofooooooffffooofoooooofoooooofooofoooofoo",
         )
-        assert "foo-lambda-ffoooofofooooooofooofooooofofofofoooooofoooooooooffoffooooooffffofooooofffooooooofoooooffoofofoooooofffofooofoffoooofooofoooooooooooooofooffoooofofooofoooofoofooffooooofoofooooofoooooffoofffoffoooooofoooofoooffooffooofofooooooffffooofoooooofooo" == SolarWindsOTLPMetricsSpanProcessor(
+        assert "foo-lambda-ffoooofofooooooofooofooooofofofofoooooofoooooooooffoffooooooffffofooooofffooooooofoooooffoofofoooooofffofooofoffoooofooofoooooooooooooofooffoooofofooofoooofoofooffooooofoofooooofoooooffoofffoffoooooofoooofoooffooffooofofooooooffffooofoooooofooo" == ResponseTimeProcessor(
             mock_apm_config,
         ).calculate_otlp_transaction_name("foo-span")
 
@@ -77,7 +77,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             outer_txn_retval=None,
             lambda_function_name="foo-lambda-name",
         )
-        assert "foo-lambda-name" == SolarWindsOTLPMetricsSpanProcessor(
+        assert "foo-lambda-name" == ResponseTimeProcessor(
             mock_apm_config,
         ).calculate_otlp_transaction_name("foo-span")
 
@@ -87,7 +87,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             outer_txn_retval=None,
             lambda_function_name=None,
         )
-        assert "foo-span" == SolarWindsOTLPMetricsSpanProcessor(
+        assert "foo-span" == ResponseTimeProcessor(
             mock_apm_config,
         ).calculate_otlp_transaction_name("foo-span")
 
@@ -97,7 +97,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             outer_txn_retval=None,
             lambda_function_name=None,
         )
-        assert "foo-span-ffoooofofooooooofooofooooofofofofoooooofoooooooooffoffooooooffffofooooofffooooooofoooooffoofofoooooofffofooofoffoooofooofoooooooooooooofooffoooofofooofoooofoofooffooooofoofooooofoooooffoofffoffoooooofoooofoooffooffooofofooooooffffooofoooooofooooo" == SolarWindsOTLPMetricsSpanProcessor(
+        assert "foo-span-ffoooofofooooooofooofooooofofofofoooooofoooooooooffoffooooooffffofooooofffooooooofoooooffoofofoooooofffofooofoffoooofooofoooooooooooooofooffoooofofooofoooofoofooffooooofoofooooofoooooffoofffoffoooooofoooofoooffooffooofofooooooffffooofoooooofooooo" == ResponseTimeProcessor(
             mock_apm_config,
         ).calculate_otlp_transaction_name("foo-span-ffoooofofooooooofooofooooofofofofoooooofoooooooooffoffooooooffffofooooofffooooooofoooooffoofofoooooofffofooofoffoooofooofoooooooooooooofooffoooofofooofoooofoofooffooooofoofooooofoooooffoofffoffoooooofoooofoooffooffooofofooooooffffooofoooooofoooooofooofoooofoo")
 
@@ -107,7 +107,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             outer_txn_retval=None,
             lambda_function_name=None,
         )
-        assert "unknown" == SolarWindsOTLPMetricsSpanProcessor(
+        assert "unknown" == ResponseTimeProcessor(
             mock_apm_config,
         ).calculate_otlp_transaction_name("")
 
@@ -120,12 +120,12 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
         missing_http_attrs=False,
     ):
         mocker.patch(
-            "solarwinds_apm.trace.SolarWindsOTLPMetricsSpanProcessor.calculate_otlp_transaction_name",
+            "solarwinds_apm.trace.ResponseTimeProcessor.calculate_otlp_transaction_name",
             return_value="foo",
         )
 
         mock_has_error = mocker.patch(
-            "solarwinds_apm.trace.SolarWindsOTLPMetricsSpanProcessor.has_error"
+            "solarwinds_apm.trace.ResponseTimeProcessor.has_error"
         )
         if has_error:
             mock_has_error.configure_mock(return_value=True)
@@ -133,7 +133,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             mock_has_error.configure_mock(return_value=False)
 
         mock_is_span_http = mocker.patch(
-            "solarwinds_apm.trace.SolarWindsOTLPMetricsSpanProcessor.is_span_http"
+            "solarwinds_apm.trace.ResponseTimeProcessor.is_span_http"
         )
         if is_span_http:
             mock_is_span_http.configure_mock(return_value=True)
@@ -141,12 +141,12 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             mock_is_span_http.configure_mock(return_value=False)
 
         mock_calculate_span_time = mocker.patch(
-            "solarwinds_apm.trace.SolarWindsOTLPMetricsSpanProcessor.calculate_span_time"
+            "solarwinds_apm.trace.ResponseTimeProcessor.calculate_span_time"
         )
         mock_calculate_span_time.configure_mock(return_value=123)
 
         mock_get_http_status_code = mocker.patch(
-            "solarwinds_apm.trace.SolarWindsOTLPMetricsSpanProcessor.get_http_status_code"
+            "solarwinds_apm.trace.ResponseTimeProcessor.get_http_status_code"
         )
         if missing_http_attrs:
             mock_get_http_status_code.configure_mock(return_value=0)
@@ -185,7 +185,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             )
 
         mock_get_meter = mocker.patch(
-            "solarwinds_apm.trace.otlp_metrics_processor.get_meter"
+            "solarwinds_apm.trace.response_time_processor.get_meter"
         )
         mock_meter = mocker.Mock()
         mock_get_meter.return_value = mock_meter
@@ -220,7 +220,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             }
         )
 
-        processor = SolarWindsOTLPMetricsSpanProcessor(
+        processor = ResponseTimeProcessor(
             mock_apm_config,
         )
         processor.on_end(mock_span)
@@ -251,7 +251,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             }
         )
 
-        processor = SolarWindsOTLPMetricsSpanProcessor(
+        processor = ResponseTimeProcessor(
             mock_apm_config,
         )
         processor.on_end(mock_span)
@@ -295,7 +295,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             }
         )
 
-        processor = SolarWindsOTLPMetricsSpanProcessor(
+        processor = ResponseTimeProcessor(
             mock_apm_config,
         )
         processor.on_end(mock_span)
@@ -339,7 +339,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             }
         )
 
-        processor = SolarWindsOTLPMetricsSpanProcessor(
+        processor = ResponseTimeProcessor(
             mock_apm_config,
         )
         processor.on_end(mock_span)
@@ -376,7 +376,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
             }
         )
 
-        processor = SolarWindsOTLPMetricsSpanProcessor(
+        processor = ResponseTimeProcessor(
             mock_apm_config,
         )
         processor.on_end(mock_span)
@@ -404,7 +404,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 mocker,
                 get_retval=None,
             )
-        processor = SolarWindsOTLPMetricsSpanProcessor(
+        processor = ResponseTimeProcessor(
             mock_apm_config,
         )
         processor.on_end(mock_basic_span)
@@ -418,7 +418,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 get_retval="some-str",
             )
 
-        processor = SolarWindsOTLPMetricsSpanProcessor(
+        processor = ResponseTimeProcessor(
             mock_apm_config,
         )
         processor.on_end(mock_basic_span)
@@ -433,7 +433,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 is_span_http=True,
             )
         
-        processor = SolarWindsOTLPMetricsSpanProcessor(
+        processor = ResponseTimeProcessor(
             mock_apm_config,
         )
         processor.on_end(mock_basic_span)
@@ -463,7 +463,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 is_span_http=True,
             )
         
-        processor = SolarWindsOTLPMetricsSpanProcessor(
+        processor = ResponseTimeProcessor(
             mock_apm_config,
         )
         processor.on_end(mock_basic_span)
@@ -494,7 +494,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 missing_http_attrs=True,
             )
 
-        processor = SolarWindsOTLPMetricsSpanProcessor(
+        processor = ResponseTimeProcessor(
             mock_apm_config,
         )
         processor.on_end(mock_basic_span)
@@ -522,7 +522,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 is_span_http=False,
             )
         
-        processor = SolarWindsOTLPMetricsSpanProcessor(
+        processor = ResponseTimeProcessor(
             mock_apm_config,
         )
         processor.on_end(mock_basic_span)
@@ -550,7 +550,7 @@ class TestSolarWindsOTLPMetricsSpanProcessor:
                 is_span_http=False,
             )
         
-        processor = SolarWindsOTLPMetricsSpanProcessor(
+        processor = ResponseTimeProcessor(
             mock_apm_config,
         )
         processor.on_end(mock_basic_span)


### PR DESCRIPTION
Renames APM Python `SolarWindsOTLPMetricsSpanProcessor` to simpler `ResponseTimeProcessor`. It's not so all-encompassing now that we've created the Pure Python sampler, and it's only responsible for recording `response_time` metrics.