### PR TITLE
NH-104999 Remove unused configuration keys

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -714,16 +714,7 @@ class SolarWindsApmConfig:
         )
         key = keys[-1]
         try:
-            if keys == ["ec2_metadata_timeout"]:
-                timeout = int(val)
-                if timeout not in range(0, 3001):
-                    raise ValueError
-                self.__config[key] = timeout
-            elif keys == ["proxy"]:
-                if not isinstance(val, str) or not val.startswith("http://"):
-                    raise ValueError
-                self.__config[key] = val
-            elif keys == ["tracing_mode"]:
+            if keys == ["tracing_mode"]:
                 if not isinstance(val, str):
                     raise ValueError
                 val = val.lower()
@@ -745,15 +736,6 @@ class SolarWindsApmConfig:
                     OboeTracingMode.get_oboe_trigger_trace_mode(val)
                 )
                 self.__config[key] = oboe_trigger_trace
-            elif keys == ["reporter"]:
-                if not isinstance(val, str) or val.lower() not in (
-                    "udp",
-                    "ssl",
-                    "null",
-                    "file",
-                ):
-                    raise ValueError
-                self.__config[key] = val.lower()
             elif keys == ["debug_level"]:
                 val = int(val)
                 if not apm_logging.ApmLoggingLevel.is_valid_level(val):

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -542,8 +542,6 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         #     "token_bucket_capacity": -1,  # always unset
         #     "token_bucket_rate": -1,  # always unset
         #     "file_single": apm_config.get("reporter_file_single"),
-        #     "ec2_metadata_timeout": apm_config.get("ec2_metadata_timeout"),
-        #     "grpc_proxy": apm_config.get("proxy"),
         #     "stdout_clear_nonblocking": 0,
         #     "metric_format": apm_config.metric_format,
         # }

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -686,20 +686,6 @@ class TestSolarWindsApmConfig:
         assert "Ignore invalid configuration key" in caplog.text
 
     # pylint:disable=unused-argument
-    # def test_set_config_value_default_ec2(self, caplog, setup_caplog, mock_env_vars):
-    #     test_config = apm_config.SolarWindsApmConfig()
-    #     test_config._set_config_value("ec2_metadata_timeout", "9999")
-    #     assert test_config.get("ec2_metadata_timeout") == 1000
-    #     assert "Ignore config option" in caplog.text
-
-    # pylint:disable=unused-argument
-    # def test_set_config_value_default_proxy(self, caplog, setup_caplog, mock_env_vars):
-    #     test_config = apm_config.SolarWindsApmConfig()
-    #     test_config._set_config_value("proxy", "not-valid-url")
-    #     assert test_config.get("proxy") == ""
-    #     assert "Ignore config option" in caplog.text
-
-    # pylint:disable=unused-argument
     def test_set_config_value_default_tracing_mode(self, caplog, setup_caplog, mock_env_vars):
         test_config = apm_config.SolarWindsApmConfig()
         test_config._set_config_value("tracing_mode", "not-valid-mode")
@@ -712,13 +698,6 @@ class TestSolarWindsApmConfig:
         test_config._set_config_value("trigger_trace", "not-valid-mode")
         assert test_config.get("trigger_trace") == 1
         assert "Ignore config option" in caplog.text
-
-    # # pylint:disable=unused-argument
-    # def test_set_config_value_default_reporter(self, caplog, setup_caplog, mock_env_vars):
-    #     test_config = apm_config.SolarWindsApmConfig()
-    #     test_config._set_config_value("reporter", "not-valid-mode")
-    #     assert test_config.get("reporter") == ""
-    #     assert "Ignore config option" in caplog.text
 
     # pylint:disable=unused-argument
     def test_set_config_value_default_debug_level(self, caplog, setup_caplog, mock_env_vars):

--- a/tests/unit/test_configurator/test_configurator_init_reporter.py
+++ b/tests/unit/test_configurator/test_configurator_init_reporter.py
@@ -27,7 +27,6 @@ from solarwinds_apm import configurator
 #                 "max_flush_wait_time": "foo",
 #                 "events_flush_interval": "foo",
 #                 "max_request_size_bytes": "foo",
-#                 "reporter": "foo",
 #                 "host": "foo",
 #                 "service_key": "foo",
 #                 "certificates": "foo-certs",
@@ -37,8 +36,6 @@ from solarwinds_apm import configurator
 #                 "token_bucket_capacity": -1,
 #                 "token_bucket_rate": -1,
 #                 "file_single": "foo",
-#                 "ec2_metadata_timeout": "foo",
-#                 "grpc_proxy": "foo",
 #                 "stdout_clear_nonblocking": 0,
 #                 "metric_format": "bar",
 #             }


### PR DESCRIPTION
Removes these user configuration keys as discussed on [other PR comment](https://github.com/solarwinds/apm-python/pull/552#discussion_r2014707559). They are no longer used to init Reporter and aren't needed by HttpSampler/JsonSampler either:

1. `ec2_metadata_timeout`
2. `proxy` (upstream exporters respect `grpc_proxy` and `HTTPS_PROXY`)
3. `reporter`