### PR TITLE
NH-106956 OTLP exporter compression gzip by default

### DIFF
--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -26,6 +26,7 @@ from opentelemetry.instrumentation.logging.environment_variables import (
 from opentelemetry.instrumentation.version import __version__ as inst_version
 from opentelemetry.metrics import NoOpMeterProvider
 from opentelemetry.sdk.environment_variables import (
+    OTEL_EXPORTER_OTLP_COMPRESSION,
     OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
     OTEL_EXPORTER_OTLP_LOGS_HEADERS,
     OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
@@ -233,6 +234,8 @@ class SolarWindsDistro(BaseDistro):
         # TODO: Support other signal types when available
         # Always opt into new semconv for all instrumentors (if supported)
         environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = self.get_semconv_opt_in()
+
+        environ.setdefault(OTEL_EXPORTER_OTLP_COMPRESSION, "gzip")
 
     def load_instrumentor(self, entry_point: EntryPoint, **kwargs):
         """Takes a collection of instrumentation entry points

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -14,6 +14,7 @@ from opentelemetry.environment_variables import (
     OTEL_TRACES_EXPORTER
 )
 from opentelemetry.sdk.environment_variables import (
+    OTEL_EXPORTER_OTLP_COMPRESSION,
     OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
     OTEL_EXPORTER_OTLP_LOGS_HEADERS,
     OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
@@ -485,6 +486,7 @@ class TestDistro:
         mocker.patch.dict(os.environ, {})
         distro.SolarWindsDistro()._configure()
         assert os.environ[OTEL_PROPAGATORS] == "tracecontext,baggage,solarwinds_propagator"
+        assert os.environ[OTEL_EXPORTER_OTLP_COMPRESSION] == "gzip"
         assert os.environ[OTEL_TRACES_EXPORTER] == "solarwinds_exporter"
         assert os.environ[OTEL_METRICS_EXPORTER] == "otlp_proto_http"
         assert os.environ[OTEL_LOGS_EXPORTER] == "otlp_proto_http"


### PR DESCRIPTION
APM Python sets [OTLP exporter compression](https://github.com/open-telemetry/opentelemetry-python/blob/3644a1e17915aa7e8820dbacc1402338f9bfbb1b/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables/__init__.py#L315-L330) to `"gzip"` by default. User can still configure compression to `"deflate"` if they wish.