### PR TITLE
NH-106957 All meters under APM Python use Delta as preferred default

### DIFF
--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -41,7 +41,15 @@ from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.environment_variables import (
     _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
 )
-from opentelemetry.sdk.metrics import Histogram, MeterProvider
+from opentelemetry.sdk.metrics import (
+    Counter,
+    Histogram,
+    MeterProvider,
+    ObservableCounter,
+    ObservableGauge,
+    ObservableUpDownCounter,
+    UpDownCounter,
+)
 from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,
     PeriodicExportingMetricReader,
@@ -428,8 +436,15 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             return
         environ_exporter_names = environ_exporter.split(",")
 
-        # Report all histograms with delta aggregation, including response_time
-        temporality_delta = {Histogram: AggregationTemporality.DELTA}
+        # Report all meters with delta aggregation as preferred temporality
+        temporality_delta = {
+            Counter: AggregationTemporality.DELTA,
+            UpDownCounter: AggregationTemporality.DELTA,
+            Histogram: AggregationTemporality.DELTA,
+            ObservableCounter: AggregationTemporality.DELTA,
+            ObservableUpDownCounter: AggregationTemporality.DELTA,
+            ObservableGauge: AggregationTemporality.DELTA,
+        }
         metric_readers = []
         for exporter_name in environ_exporter_names:
             exporter = None

--- a/tests/unit/test_configurator/test_configurator_metrics_exporter.py
+++ b/tests/unit/test_configurator/test_configurator_metrics_exporter.py
@@ -132,8 +132,23 @@ class TestConfiguratorMetricsExporter:
         # Mock Otel
         get_resource_mocks(mocker)
         trace_mocks = get_trace_mocks(mocker)
+        mock_counter = mocker.patch(
+            "solarwinds_apm.configurator.Counter"
+        )
+        mock_updowncounter = mocker.patch(
+            "solarwinds_apm.configurator.UpDownCounter"
+        )
         mock_histogram = mocker.patch(
             "solarwinds_apm.configurator.Histogram"
+        )
+        mock_observablecounter = mocker.patch(
+            "solarwinds_apm.configurator.ObservableCounter"
+        )
+        mock_observableupdowncounter = mocker.patch(
+            "solarwinds_apm.configurator.ObservableUpDownCounter"
+        )
+        mock_observablegauge = mocker.patch(
+            "solarwinds_apm.configurator.ObservableGauge"
         )
         mock_agg_temp = mocker.patch(
             "solarwinds_apm.configurator.AggregationTemporality"
@@ -151,7 +166,12 @@ class TestConfiguratorMetricsExporter:
                 mocker.call(),
                 mocker.call()(
                     preferred_temporality={
-                        mock_histogram: "foo-delta"
+                        mock_counter: "foo-delta",
+                        mock_updowncounter: "foo-delta",
+                        mock_histogram: "foo-delta",
+                        mock_observablecounter: "foo-delta",
+                        mock_observableupdowncounter: "foo-delta",
+                        mock_observablegauge: "foo-delta",
                     }
                 )
             ]
@@ -213,8 +233,23 @@ class TestConfiguratorMetricsExporter:
         # Mock Otel
         get_resource_mocks(mocker)
         trace_mocks = get_trace_mocks(mocker)
+        mock_counter = mocker.patch(
+            "solarwinds_apm.configurator.Counter"
+        )
+        mock_updowncounter = mocker.patch(
+            "solarwinds_apm.configurator.UpDownCounter"
+        )
         mock_histogram = mocker.patch(
             "solarwinds_apm.configurator.Histogram"
+        )
+        mock_observablecounter = mocker.patch(
+            "solarwinds_apm.configurator.ObservableCounter"
+        )
+        mock_observableupdowncounter = mocker.patch(
+            "solarwinds_apm.configurator.ObservableUpDownCounter"
+        )
+        mock_observablegauge = mocker.patch(
+            "solarwinds_apm.configurator.ObservableGauge"
         )
         mock_agg_temp = mocker.patch(
             "solarwinds_apm.configurator.AggregationTemporality"
@@ -232,7 +267,12 @@ class TestConfiguratorMetricsExporter:
                 mocker.call(),
                 mocker.call()(
                     preferred_temporality={
-                        mock_histogram: "foo-delta"
+                        mock_counter: "foo-delta",
+                        mock_updowncounter: "foo-delta",
+                        mock_histogram: "foo-delta",
+                        mock_observablecounter: "foo-delta",
+                        mock_observableupdowncounter: "foo-delta",
+                        mock_observablegauge: "foo-delta",
                     }
                 )
             ]
@@ -395,8 +435,23 @@ class TestConfiguratorMetricsExporter:
         # Mock Otel
         get_resource_mocks(mocker)
         trace_mocks = get_trace_mocks(mocker)
+        mock_counter = mocker.patch(
+            "solarwinds_apm.configurator.Counter"
+        )
+        mock_updowncounter = mocker.patch(
+            "solarwinds_apm.configurator.UpDownCounter"
+        )
         mock_histogram = mocker.patch(
             "solarwinds_apm.configurator.Histogram"
+        )
+        mock_observablecounter = mocker.patch(
+            "solarwinds_apm.configurator.ObservableCounter"
+        )
+        mock_observableupdowncounter = mocker.patch(
+            "solarwinds_apm.configurator.ObservableUpDownCounter"
+        )
+        mock_observablegauge = mocker.patch(
+            "solarwinds_apm.configurator.ObservableGauge"
         )
         mock_agg_temp = mocker.patch(
             "solarwinds_apm.configurator.AggregationTemporality"
@@ -427,7 +482,12 @@ class TestConfiguratorMetricsExporter:
                 mocker.call(),
                 mocker.call()(
                     preferred_temporality={
-                        mock_histogram: "foo-delta"
+                        mock_counter: "foo-delta",
+                        mock_updowncounter: "foo-delta",
+                        mock_histogram: "foo-delta",
+                        mock_observablecounter: "foo-delta",
+                        mock_observableupdowncounter: "foo-delta",
+                        mock_observablegauge: "foo-delta",
                     }
                 )
             ]
@@ -513,8 +573,23 @@ class TestConfiguratorMetricsExporter:
         # Mock Otel
         get_resource_mocks(mocker)
         trace_mocks = get_trace_mocks(mocker)
+        mock_counter = mocker.patch(
+            "solarwinds_apm.configurator.Counter"
+        )
+        mock_updowncounter = mocker.patch(
+            "solarwinds_apm.configurator.UpDownCounter"
+        )
         mock_histogram = mocker.patch(
             "solarwinds_apm.configurator.Histogram"
+        )
+        mock_observablecounter = mocker.patch(
+            "solarwinds_apm.configurator.ObservableCounter"
+        )
+        mock_observableupdowncounter = mocker.patch(
+            "solarwinds_apm.configurator.ObservableUpDownCounter"
+        )
+        mock_observablegauge = mocker.patch(
+            "solarwinds_apm.configurator.ObservableGauge"
         )
         mock_agg_temp = mocker.patch(
             "solarwinds_apm.configurator.AggregationTemporality"
@@ -545,7 +620,12 @@ class TestConfiguratorMetricsExporter:
                 mocker.call(),
                 mocker.call()(
                     preferred_temporality={
-                        mock_histogram: "foo-delta"
+                        mock_counter: "foo-delta",
+                        mock_updowncounter: "foo-delta",
+                        mock_histogram: "foo-delta",
+                        mock_observablecounter: "foo-delta",
+                        mock_observableupdowncounter: "foo-delta",
+                        mock_observablegauge: "foo-delta",
                     }
                 )
             ]


### PR DESCRIPTION
All meters initialized under APM Python will use Delta as preferred default for aggregation temporality, not just histograms.