### PR TITLE
NH-107698 Python: Add back solarwinds_ready integer_response arg as no-op

### DIFF
--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -94,7 +94,9 @@ def set_transaction_name(custom_name: str) -> bool:
     return True
 
 
-def solarwinds_ready(wait_milliseconds: int = 3000) -> bool:
+def solarwinds_ready(
+    wait_milliseconds: int = 3000, integer_response: bool = False
+) -> bool:
     """
     Wait for SolarWinds to be ready to send traces.
 
@@ -103,15 +105,21 @@ def solarwinds_ready(wait_milliseconds: int = 3000) -> bool:
     application while it is starting up.
 
     :param wait_milliseconds:int default 3000, the maximum time to wait in milliseconds
+    :param integer_response:bool default False, we are dropping this support, please see updated docs
 
     :return:
     bool True for ready, False not ready
 
     :Example:
      from solarwinds_apm.api import solarwinds_ready
-     if not solarwinds_ready(wait_milliseconds=10000):
+     if not solarwinds_ready(wait_milliseconds=10000, integer_response=False):
         Logger.info("SolarWinds not ready after 10 seconds, no metrics will be sent")
     """
+    if integer_response:
+        logger.warning(
+            "support of integer_response is dropped, please see updated docs"
+        )
+
     tracer_provider = trace.get_tracer_provider()
     if isinstance(tracer_provider, SolarwindsTracerProvider):
         if isinstance(tracer_provider.sampler, (HttpSampler, JsonSampler)):


### PR DESCRIPTION
Add back integer_response arg for compatibility.
https://swicloud.atlassian.net/browse/NH-107698