### PR TITLE
NH-107706 Python: Pure Python default collector

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -62,6 +62,7 @@ class SolarWindsApmConfig:
     done only once during the initialization and the properties cannot be refreshed.
     """
 
+    _CONFIG_COLLECTOR_DEFAULT = "apm.collector.na-01.cloud.solarwinds.com"
     _CONFIG_FILE_DEFAULT = "./solarwinds-apm-config.json"
     _DELIMITER = "."
     _KEY_MASK = "{}...{}:{}"
@@ -81,7 +82,7 @@ class SolarWindsApmConfig:
             "trigger_trace": OboeTracingMode.get_oboe_trigger_trace_mode(
                 "enabled"
             ),
-            "collector": "",  # the collector address in host:port format.
+            "collector": self._CONFIG_COLLECTOR_DEFAULT,
             "debug_level": apm_logging.ApmLoggingLevel.default_level(),
             "service_key": "",
             "transaction_filters": [],

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -85,6 +85,17 @@ class TestSolarWindsApmConfig:
         if old_expt_metrics:
             os.environ["SW_APM_EXPORT_METRICS_ENABLED"] = old_expt_metrics
 
+    def test__default_collector(self, mocker):
+        test_config = apm_config.SolarWindsApmConfig()
+        assert test_config.get("collector") == apm_config.SolarWindsApmConfig._CONFIG_COLLECTOR_DEFAULT
+
+    def test__init_collector(self, mocker):
+        mocker.patch.dict(os.environ, {
+            "SW_APM_COLLECTOR": "apm.collector.eu-02.cloud.solarwinds.com"
+        })
+        test_config = apm_config.SolarWindsApmConfig()
+        assert test_config.get("collector") == "apm.collector.eu-02.cloud.solarwinds.com"
+
     def _mock_service_key(self, mocker, service_key):
         mocker.patch.dict(os.environ, {
             "SW_APM_SERVICE_KEY": service_key,


### PR DESCRIPTION
- Fixed unset SW_APM_COLLECTOR yield to a `None` value from `apm_config['collector']` issue
- Added unit test case

https://swicloud.atlassian.net/browse/NH-107706