### PR TITLE
NH-107791 Remove grpcio-using dependencies from Lambda

### DIFF
--- a/lambda/requirements-nodeps.txt
+++ b/lambda/requirements-nodeps.txt
@@ -12,7 +12,6 @@ opentelemetry-instrumentation-elasticsearch==0.52b1
 opentelemetry-instrumentation-fastapi==0.52b1
 opentelemetry-instrumentation-falcon==0.52b1
 opentelemetry-instrumentation-flask==0.52b1
-opentelemetry-instrumentation-grpc==0.52b1
 opentelemetry-instrumentation-jinja2==0.52b1
 opentelemetry-instrumentation-logging==0.52b1
 opentelemetry-instrumentation-mysql==0.52b1

--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,5 +1,4 @@
 opentelemetry-exporter-otlp==1.31.1
-opentelemetry-exporter-otlp-proto-grpc==1.31.1
 opentelemetry-exporter-otlp-proto-http==1.31.1
 opentelemetry-instrumentation-aws-lambda==0.52b1
 packaging


### PR DESCRIPTION
Removes two grpcio-using dependencies from Lambda builds that both error with `ImportError: cannot import name ‘cygrpc' from 'grpc._cython' (/opt/python/grpc/_cython/__init__.py)`:

1. `opentelemetry-exporter-otlp-proto-grpc`, because grpc export also not supported by upstream's layer
2. `opentelemetry-instrumentation-grpc`, because its instrumentors fail (stacktrace in CloudWatch, though doesn't stop successful export of other instrumentors' telemetry)