### PR TITLE
NH-103814 Don't load LambdaDetector when outside lambda

### DIFF
--- a/solarwinds_apm/apm_constants.py
+++ b/solarwinds_apm/apm_constants.py
@@ -33,7 +33,6 @@ INTL_SWO_DEFAULT_RESOURCE_DETECTORS = [
     "aws_ec2",
     "aws_ecs",
     "aws_eks",
-    "aws_lambda",
     "azure_app_service",
     "azure_functions",
     "azure_vm",


### PR DESCRIPTION
Don't load LambdaDetector when outside lambda, otherwise upstream gives us a warning: `AwsLambdaResourceDetector failed: 'AWS_REGION'`.