### PR TITLE
NH-107711 NH-107442 Update autoinstrumentation-image builds

### DIFF
--- a/.github/workflows/build_publish_image_autoinstrumentation_beta.yaml
+++ b/.github/workflows/build_publish_image_autoinstrumentation_beta.yaml
@@ -8,9 +8,6 @@ name: "Publish Beta APM Python Auto-Instrumentation"
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - update-image-builds
 
 permissions:
   packages: write

--- a/.github/workflows/build_publish_image_autoinstrumentation_beta.yaml
+++ b/.github/workflows/build_publish_image_autoinstrumentation_beta.yaml
@@ -1,0 +1,129 @@
+# © 2025 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+name: "Publish Beta APM Python Auto-Instrumentation"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  packages: write
+  contents: write
+  id-token: write
+  security-events: write
+
+jobs:
+  docker_hub:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read solarwinds_apm version requirement
+        run: echo VERSION=$(head -n 1 image/requirements-nodeps-beta.txt | cut -d '=' -f3) >> $GITHUB_ENV
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into Docker.io (build)
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKER_SOLARWINDS_ORG_LOGIN }}
+          password: ${{ secrets.ENOPS5919_APM_DOCKER_HUB_CI_OAT }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ github.repository_owner }}/autoinstrumentation-python
+          tags: |
+            type=raw,value=${{ env.VERSION }}-beta
+          labels: |
+            maintainer=swo-librarians
+            org.opencontainers.image.title=apm-python
+            org.opencontainers.image.description=Solarwinds OTEL distro Python agent
+            org.opencontainers.image.vendor=SolarWinds Worldwide, LLC
+
+      - name: Login to GitHub Package Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push - amd64, arm64
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: image
+          file: image/Dockerfile-beta
+          platforms: linux/amd64,linux/arm64
+          build-args: version=${{ env.VERSION }}-beta
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build locally for scan - amd64
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          context: image
+          platforms: linux/amd64
+          build-args: version=${{ env.VERSION }}-beta
+          tags: ${{ steps.meta.outputs.tags }}-scan
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Log into Docker.io (scan)
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.ENOPS5919_DOCKER_SCOUT_CI_USER }}
+          password: ${{ secrets.ENOPS5919_DOCKER_SCOUT_CI_PAT }}
+
+      - name: Analyze for critical and high CVEs - tagged image
+        id: docker-scout-image-cves
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: ${{ steps.meta.outputs.tags[0] }}
+          platform: "linux/amd64"
+          sarif-file: sarif.output.json
+
+      - name: Upload SARIF result
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: sarif.output.json
+
+  ghcr_io:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read solarwinds_apm version requirement
+        run: echo VERSION=$(head -n 1 image/requirements-nodeps-beta.txt | cut -d '=' -f3) >> $GITHUB_ENV
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Package Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: image
+          file: image/Dockerfile-beta
+          platforms: linux/amd64,linux/arm64
+          build-args: version=${{ env.VERSION }}-beta
+          tags: ghcr.io/${{ github.repository_owner }}/autoinstrumentation-python:${{ env.VERSION }}-beta

--- a/.github/workflows/build_publish_image_autoinstrumentation_beta.yaml
+++ b/.github/workflows/build_publish_image_autoinstrumentation_beta.yaml
@@ -8,6 +8,9 @@ name: "Publish Beta APM Python Auto-Instrumentation"
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - update-image-builds
 
 permissions:
   packages: write

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -9,35 +9,8 @@
 # - Grant the necessary access to `/autoinstrumentation{,-musl}` directory. `chmod -R go+r /autoinstrumentation`
 # - For auto-instrumentation by container injection, the Linux command cp is
 #   used and must be availabe in the image.
-#
-# We install `nodeps` to cover all Python versions for Debian and Alpine
-# for extension installations
-
-FROM python:3.8 AS build-38
-WORKDIR /operator-build
-ADD requirements-nodeps.txt .
-RUN mkdir workspace
-RUN pip install --no-deps --target workspace -r requirements-nodeps.txt
 
 FROM python:3.9 AS build-39
-WORKDIR /operator-build
-ADD requirements-nodeps.txt .
-RUN mkdir workspace
-RUN pip install --no-deps --target workspace -r requirements-nodeps.txt
-
-FROM python:3.10 AS build-310
-WORKDIR /operator-build
-ADD requirements-nodeps.txt .
-RUN mkdir workspace
-RUN pip install --no-deps --target workspace -r requirements-nodeps.txt
-
-FROM python:3.11 AS build-311
-WORKDIR /operator-build
-ADD requirements-nodeps.txt .
-RUN mkdir workspace
-RUN pip install --no-deps --target workspace -r requirements-nodeps.txt
-
-FROM python:3.12 AS build-312
 WORKDIR /operator-build
 ADD requirements-nodeps.txt .
 ADD requirements.txt .
@@ -45,36 +18,7 @@ RUN mkdir workspace
 RUN pip install --no-deps --target workspace -r requirements-nodeps.txt
 RUN pip install --target workspace -r requirements.txt
 
-
-FROM python:3.8-alpine AS build-musl-38
-WORKDIR /operator-build
-ADD requirements-nodeps.txt .
-RUN apk add g++ gcc python3-dev musl-dev linux-headers
-RUN mkdir workspace
-RUN pip install --no-deps --target workspace -r requirements-nodeps.txt
-
 FROM python:3.9-alpine AS build-musl-39
-WORKDIR /operator-build
-ADD requirements-nodeps.txt .
-RUN apk add g++ gcc python3-dev musl-dev linux-headers
-RUN mkdir workspace
-RUN pip install --no-deps --target workspace -r requirements-nodeps.txt
-
-FROM python:3.10-alpine AS build-musl-310
-WORKDIR /operator-build
-ADD requirements-nodeps.txt .
-RUN apk add g++ gcc python3-dev musl-dev linux-headers
-RUN mkdir workspace
-RUN pip install --no-deps --target workspace -r requirements-nodeps.txt
-
-FROM python:3.11-alpine AS build-musl-311
-WORKDIR /operator-build
-ADD requirements-nodeps.txt .
-RUN apk add g++ gcc python3-dev musl-dev linux-headers
-RUN mkdir workspace
-RUN pip install --no-deps --target workspace -r requirements-nodeps.txt
-
-FROM python:3.12-alpine AS build-musl-312
 WORKDIR /operator-build
 ADD requirements-nodeps.txt .
 ADD requirements.txt .
@@ -85,17 +29,8 @@ RUN pip install --target workspace -r requirements.txt
 
 FROM busybox
 
-COPY --from=build-38 /operator-build/workspace /autoinstrumentation
 COPY --from=build-39 /operator-build/workspace /autoinstrumentation
-COPY --from=build-310 /operator-build/workspace /autoinstrumentation
-COPY --from=build-311 /operator-build/workspace /autoinstrumentation
-COPY --from=build-312 /operator-build/workspace /autoinstrumentation
-
-COPY --from=build-musl-38 /operator-build/workspace /autoinstrumentation-musl
 COPY --from=build-musl-39 /operator-build/workspace /autoinstrumentation-musl
-COPY --from=build-musl-310 /operator-build/workspace /autoinstrumentation-musl
-COPY --from=build-musl-311 /operator-build/workspace /autoinstrumentation-musl
-COPY --from=build-musl-312 /operator-build/workspace /autoinstrumentation-musl
 
 RUN chmod -R go+r /autoinstrumentation
 RUN chmod -R go+r /autoinstrumentation-musl

--- a/image/Dockerfile-beta
+++ b/image/Dockerfile-beta
@@ -1,0 +1,36 @@
+# To build one auto-instrumentation image for Python, please:
+# - Ensure the packages are installed in the `/autoinstrumentation,{-musl}` directory. This is required as when instrumenting the pod,
+#   one init container will be created to copy all the content in `/autoinstrumentation{,-musl}` directory to your app's container. Then
+#   update the `PYTHONPATH` environment variable accordingly. To achieve this, you can mimic the one in `autoinstrumentation/python/Dockerfile`
+#   by using multi-stage builds. In the first stage, install all the required packages in one custom directory with `pip install --target`.
+#   Then in the second stage, copy the directory to `/autoinstrumentation{,-musl}`.
+# - Ensure you have `opentelemetry-distro` and `opentelemetry-instrumentation` or your customized alternatives installed.
+#   Those two packages are essential to Python auto-instrumentation.
+# - Grant the necessary access to `/autoinstrumentation{,-musl}` directory. `chmod -R go+r /autoinstrumentation`
+# - For auto-instrumentation by container injection, the Linux command cp is
+#   used and must be availabe in the image.
+
+FROM python:3.12 AS build-312
+WORKDIR /operator-build
+ADD requirements-nodeps.txt .
+ADD requirements.txt .
+RUN mkdir workspace
+RUN pip install --no-deps --target workspace -r requirements-nodeps-beta.txt --extra-index-url https://test.pypi.org/simple/
+RUN pip install --target workspace -r requirements.txt
+
+FROM python:3.12-alpine AS build-musl-312
+WORKDIR /operator-build
+ADD requirements-nodeps.txt .
+ADD requirements.txt .
+RUN apk add g++ gcc python3-dev musl-dev linux-headers
+RUN mkdir workspace
+RUN pip install --no-deps --target workspace -r requirements-nodeps-beta.txt --extra-index-url https://test.pypi.org/simple/
+RUN pip install --target workspace -r requirements.txt
+
+FROM busybox
+
+COPY --from=build-312 /operator-build/workspace /autoinstrumentation
+COPY --from=build-musl-312 /operator-build/workspace /autoinstrumentation-musl
+
+RUN chmod -R go+r /autoinstrumentation
+RUN chmod -R go+r /autoinstrumentation-musl

--- a/image/Dockerfile-beta
+++ b/image/Dockerfile-beta
@@ -10,7 +10,7 @@
 # - For auto-instrumentation by container injection, the Linux command cp is
 #   used and must be availabe in the image.
 
-FROM python:3.12 AS build-312
+FROM python:3.9 AS build-39
 WORKDIR /operator-build
 ADD requirements-nodeps-beta.txt .
 ADD requirements.txt .
@@ -18,7 +18,7 @@ RUN mkdir workspace
 RUN pip install --no-deps --target workspace --extra-index-url https://test.pypi.org/simple/ -r requirements-nodeps-beta.txt
 RUN pip install --target workspace -r requirements.txt
 
-FROM python:3.12-alpine AS build-musl-312
+FROM python:3.9-alpine AS build-musl-39
 WORKDIR /operator-build
 ADD requirements-nodeps-beta.txt .
 ADD requirements.txt .
@@ -29,8 +29,8 @@ RUN pip install --target workspace -r requirements.txt
 
 FROM busybox
 
-COPY --from=build-312 /operator-build/workspace /autoinstrumentation
-COPY --from=build-musl-312 /operator-build/workspace /autoinstrumentation-musl
+COPY --from=build-39 /operator-build/workspace /autoinstrumentation
+COPY --from=build-musl-39 /operator-build/workspace /autoinstrumentation-musl
 
 RUN chmod -R go+r /autoinstrumentation
 RUN chmod -R go+r /autoinstrumentation-musl

--- a/image/Dockerfile-beta
+++ b/image/Dockerfile-beta
@@ -15,7 +15,7 @@ WORKDIR /operator-build
 ADD requirements-nodeps.txt .
 ADD requirements.txt .
 RUN mkdir workspace
-RUN pip install --no-deps --target workspace -r requirements-nodeps-beta.txt --extra-index-url https://test.pypi.org/simple/
+RUN pip install --no-deps --target workspace --extra-index-url https://test.pypi.org/simple/ -r requirements-nodeps-beta.txt
 RUN pip install --target workspace -r requirements.txt
 
 FROM python:3.12-alpine AS build-musl-312
@@ -24,7 +24,7 @@ ADD requirements-nodeps.txt .
 ADD requirements.txt .
 RUN apk add g++ gcc python3-dev musl-dev linux-headers
 RUN mkdir workspace
-RUN pip install --no-deps --target workspace -r requirements-nodeps-beta.txt --extra-index-url https://test.pypi.org/simple/
+RUN pip install --no-deps --target workspace --extra-index-url https://test.pypi.org/simple/ -r requirements-nodeps-beta.txt
 RUN pip install --target workspace -r requirements.txt
 
 FROM busybox

--- a/image/Dockerfile-beta
+++ b/image/Dockerfile-beta
@@ -12,7 +12,7 @@
 
 FROM python:3.12 AS build-312
 WORKDIR /operator-build
-ADD requirements-nodeps.txt .
+ADD requirements-nodeps-beta.txt .
 ADD requirements.txt .
 RUN mkdir workspace
 RUN pip install --no-deps --target workspace --extra-index-url https://test.pypi.org/simple/ -r requirements-nodeps-beta.txt
@@ -20,7 +20,7 @@ RUN pip install --target workspace -r requirements.txt
 
 FROM python:3.12-alpine AS build-musl-312
 WORKDIR /operator-build
-ADD requirements-nodeps.txt .
+ADD requirements-nodeps-beta.txt .
 ADD requirements.txt .
 RUN apk add g++ gcc python3-dev musl-dev linux-headers
 RUN mkdir workspace

--- a/image/requirements-nodeps-beta.txt
+++ b/image/requirements-nodeps-beta.txt
@@ -1,0 +1,1 @@
+solarwinds_apm==4.0.0.5

--- a/image/requirements-nodeps-beta.txt
+++ b/image/requirements-nodeps-beta.txt
@@ -1,1 +1,1 @@
-solarwinds_apm==4.0.0.5
+solarwinds_apm==4.0.0.8


### PR DESCRIPTION
(1)
For NH-107711: changes autoinstrumentation image publish to only pre-install with Python 3.9. This will support Python 3.8-3.12 because no need to pre-install and copy multiple `.so` for now-removed dependencies.

(2)
For NH-107442: adds a second workflow, “Publish Beta APM Python Auto-Instrumentation“. Example run: https://github.com/solarwinds/apm-python/actions/runs/14524617943. Using [testrelease 4.0.0.5](https://test.pypi.org/project/solarwinds-apm/4.0.0.5/), this workflow was used to publish image with tag 4.0.0.5-beta (NOT latest) on [Docker Hub](https://hub.docker.com/r/solarwinds/autoinstrumentation-python/tags) and [ghcr.io](https://github.com/solarwinds/apm-python/pkgs/container/autoinstrumentation-python). See ticket comment for more testing. A little duplicative right now but can revisit later.