### PR TITLE
NH-108028 Support config file collector endpoint resolution

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -124,6 +124,25 @@ class SolarWindsApmConfig:
         return False
 
     @classmethod
+    def calculate_collector(
+        cls,
+        cnf_dict: dict = None,
+    ) -> str:
+        """Special class method to return default/configured collector.
+        Order of precedence: Environment Variable > config file > default.
+        Default is SWO NA-01.
+        Optional cnf_dict is presumably already from a config file, else a call
+        to get_cnf_dict() is made for a fresh read."""
+        collector = cls._CONFIG_COLLECTOR_DEFAULT
+        if cnf_dict is None:
+            cnf_dict = cls.get_cnf_dict()
+        if cnf_dict:
+            cnf_collector = cnf_dict.get("collector")
+            collector = cnf_collector if cnf_collector else collector
+        env_collector = os.environ.get("SW_APM_COLLECTOR")
+        return env_collector if env_collector else collector
+
+    @classmethod
     def calculate_metrics_enabled(
         cls,
         is_legacy: bool = False,

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -59,6 +59,7 @@ class SolarWindsDistro(BaseDistro):
     """OpenTelemetry Distro for SolarWinds reporting environment"""
 
     _cnf_dict = None
+    _collector = None
     _instrumentor_metrics_enabled = None
 
     _DEFAULT_OTLP_EXPORTER = "otlp"
@@ -68,6 +69,7 @@ class SolarWindsDistro(BaseDistro):
         # Maintain singleton pattern and cache SW APM user config
         # for Distro lifecycle at auto-instrumentation
         cls._cnf_dict = SolarWindsApmConfig.get_cnf_dict()
+        cls._collector = SolarWindsApmConfig.calculate_collector(cls._cnf_dict)
         cls._instrumentor_metrics_enabled = (
             SolarWindsApmConfig.calculate_metrics_enabled(cls._cnf_dict)
         )
@@ -121,7 +123,7 @@ class SolarWindsDistro(BaseDistro):
         )
 
         # Default collector OTLP endpoint, which HTTP exporters map to signal-specific routes
-        collector = environ.get("SW_APM_COLLECTOR", None)
+        collector = self._collector
         if collector is not None and collector.startswith("apm.collector"):
             # Collector endpoint is set, try it
             match = re.search(

--- a/tests/unit/test_apm_config/test_apm_config_calculate_collector.py
+++ b/tests/unit/test_apm_config/test_apm_config_calculate_collector.py
@@ -1,0 +1,43 @@
+# © 2025 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+import os
+import pytest
+from solarwinds_apm.apm_config import SolarWindsApmConfig
+
+class TestSolarWindsApmConfigCalculateCollector:
+    @pytest.fixture(autouse=True)
+    def clear_env_vars(self):
+        # Clear environment variables before each test
+        os.environ.clear()
+
+    def test_calculate_collector_default(self, mocker):
+        assert SolarWindsApmConfig.calculate_collector() == "apm.collector.na-01.cloud.solarwinds.com"
+
+    def test_calculate_collector_with_env_var_set(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_COLLECTOR": "foo-collector"})
+        assert SolarWindsApmConfig.calculate_collector() == "foo-collector"
+
+    def test_calculate_collector_with_config_not_provided(self, mocker):
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"collector": "bar-collector"})
+        assert SolarWindsApmConfig.calculate_collector() == "bar-collector"
+
+    def test_calculate_collector_with_config_not_provided_and_env_var(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_COLLECTOR": "foo-collector"})
+        mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"collector": "bar-collector"})
+        assert SolarWindsApmConfig.calculate_collector() == "foo-collector"
+
+    def test_calculate_collector_with_provided_cnf_dict(self, mocker):
+        mock_get_cnf_dict = mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"collector": "bar-collector"})
+        assert SolarWindsApmConfig.calculate_collector(cnf_dict={"collector": "baz-collector"}) == "baz-collector"
+        mock_get_cnf_dict.assert_not_called()
+
+    def test_calculate_collector_with_provided_cnf_dict_while_env(self, mocker):
+        mocker.patch.dict(os.environ, {"SW_APM_COLLECTOR": "foo-collector"})
+        mock_get_cnf_dict = mocker.patch.object(SolarWindsApmConfig, 'get_cnf_dict', return_value={"collector": "bar-collector"})
+        assert SolarWindsApmConfig.calculate_collector(cnf_dict={"collector": "baz-collector"}) == "foo-collector"
+        mock_get_cnf_dict.assert_not_called()
+

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -432,6 +432,52 @@ class TestDistro:
         distro.SolarWindsDistro()._configure()
         assert os.environ[OTEL_EXPORTER_OTLP_ENDPOINT] == "https://otel.collector.na-03.cloud.solarwinds.com:443"
 
+    def test_configure_env_service_key_and_collector_from_file_no_env(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_COLLECTOR": "",
+            },
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.get_cnf_dict",
+            return_value={
+                "collector": "apm.collector.eu-01.st-ssp.solarwinds.com"
+            },
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_EXPORTER_OTLP_ENDPOINT] == "https://otel.collector.eu-01.st-ssp.solarwinds.com:443"
+
+    def test_configure_env_service_key_and_collector_from_env_no_file(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_COLLECTOR": "apm.collector.jp-01.st-ssp.solarwinds.com",
+            },
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.get_cnf_dict",
+            return_value={},
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_EXPORTER_OTLP_ENDPOINT] == "https://otel.collector.jp-01.st-ssp.solarwinds.com:443"
+
+    def test_configure_env_service_key_and_collector_from_env_and_file(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                "SW_APM_COLLECTOR": "apm.collector.jp-01.st-ssp.solarwinds.com",
+            },
+        )
+        mocker.patch(
+            "solarwinds_apm.distro.SolarWindsApmConfig.get_cnf_dict",
+            return_value={
+                "collector": "apm.collector.eu-01.st-ssp.solarwinds.com"
+            },
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_EXPORTER_OTLP_ENDPOINT] == "https://otel.collector.jp-01.st-ssp.solarwinds.com:443"
+
     def test_configure_env_headers(self, mocker):
         mocker.patch.dict(
             os.environ,


### PR DESCRIPTION
Adds new ApmConfig class function to calculate `collector` as `environment Variable > config file > default`. Distro now uses this for `collector` resolution of export endpoint. This is needed because Configurator (and ApmConfig) init happen after Distro lifecycle has ended; Distro and Configurator can't share one ApmConfig due to lifecycles when [sitecustomize](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/748c92592d2f476199667629defce4a3bca9ecc9/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py#L37-L39) is used.