### PR TITLE
NH-104807 - Python Reset warning message of http sampler

### DIFF
--- a/solarwinds_apm/oboe/http_sampler.py
+++ b/solarwinds_apm/oboe/http_sampler.py
@@ -95,6 +95,8 @@ class HttpSampler(Sampler):
             parsed = self.update_settings(unparsed)
             if not parsed:
                 self._warn("Retrieved sampling settings are invalid.")
+            else:
+                self._last_warning_message = None
         except requests.RequestException as error:
             message = "Failed to retrieve sampling settings"
             message += f" ({error})"


### PR DESCRIPTION
Reset last warning message if http_sampler recovered itself.

Found this issue during porting code from python to PHP

https://swicloud.atlassian.net/browse/NH-104807
