### PR TITLE
NH-108175 Python: Fix sw.w3c.tracestate attribute

### DIFF
--- a/solarwinds_apm/oboe/oboe_sampler.py
+++ b/solarwinds_apm/oboe/oboe_sampler.py
@@ -196,9 +196,14 @@ class OboeSampler(Sampler, ABC):
         )
 
         # Capture the tracestate from the parent span and store it in the sample state
-        if trace_state is not None:
+        if (
+            parent_span.get_span_context().is_valid
+            and parent_span.get_span_context().trace_state is not None
+        ):
             sample_state.attributes[TRACESTATE_CAPTURE_ATTRIBUTE] = (
-                trace_state.delete(INTL_SWO_X_OPTIONS_RESPONSE_KEY)
+                parent_span.get_span_context()
+                .trace_state.delete(INTL_SWO_X_OPTIONS_RESPONSE_KEY)
+                .to_header()
             )
 
         self.counters.request_count.add(1, {}, parent_context)


### PR DESCRIPTION
sw.w3c.tracestate is not found in the span attributes.
It is because a wrong trace_state was used to check for the inbound trace_state. As a result, the wrong trace state yield a None and skip the attributes setup

Fixed by checking the trace_state from parent_span_context

https://swicloud.atlassian.net/browse/NH-108175