### PR TITLE
NH-107450 Add units, description to OTel counters for metrics

### DIFF
--- a/solarwinds_apm/oboe/metrics.py
+++ b/solarwinds_apm/oboe/metrics.py
@@ -11,22 +11,34 @@ class Counters:
     def __init__(self, meter_provider: MeterProvider):
         self._meter = meter_provider.get_meter("sw.apm.sampling.metrics")
         self._request_count = self._meter.create_counter(
-            name="trace.service.request_count"
+            name="trace.service.request_count",
+            description="Count of all requests to the service",
+            unit="{request}",
         )
         self._sample_count = self._meter.create_counter(
-            name="trace.service.samplecount"
+            name="trace.service.samplecount",
+            description="Count of sampled requests",
+            unit="{request}",
         )
         self._trace_count = self._meter.create_counter(
-            name="trace.service.tracecount"
+            name="trace.service.tracecount",
+            description="Count of traces generated from requests",
+            unit="{trace}",
         )
         self._through_trace_count = self._meter.create_counter(
-            name="trace.service.through_trace_count"
+            name="trace.service.through_trace_count",
+            description="Count of requests that carried valid upstream sampling decision",
+            unit="{request}",
         )
         self._triggered_trace_count = self._meter.create_counter(
-            name="trace.service.triggered_trace_count"
+            name="trace.service.triggered_trace_count",
+            description="Count of trigger traces",
+            unit="{trace}",
         )
         self._token_bucket_exhaustion_count = self._meter.create_counter(
-            name="trace.service.tokenbucket_exhaustion_count"
+            name="trace.service.tokenbucket_exhaustion_count",
+            description="Count of requests that were not traced",
+            unit="{request}",
         )
 
     @property


### PR DESCRIPTION
Adds units and descriptions to OTel counters for our metrics.

Already being added for the histogram: https://github.com/solarwinds/apm-python/blob/db06001fb4ea3570b0bfc9409d08d431fa3742dc/solarwinds_apm/trace/response_time_processor.py#L49-L53