### PR TITLE
Potential fix for code scanning alert no. 446: Unused import

### DIFF
--- a/tests/integration/test_base_sw_headers_attrs.py
+++ b/tests/integration/test_base_sw_headers_attrs.py
@@ -34,7 +34,7 @@ from solarwinds_apm.configurator import SolarWindsConfigurator
 from solarwinds_apm.distro import SolarWindsDistro
 from solarwinds_apm.oboe.json_sampler import JsonSampler
 from solarwinds_apm.propagator import SolarWindsPropagator
-from solarwinds_apm.sampler import ParentBasedSwSampler
+
 
 
 class TestBaseSwHeadersAndAttributes(TestBase):


### PR DESCRIPTION
Potential fix for [https://github.com/solarwinds/apm-python/security/code-scanning/446](https://github.com/solarwinds/apm-python/security/code-scanning/446)

The best way to fix this issue is to remove the unused import statement for `ParentBasedSwSampler`. This will clean up the code and eliminate the unnecessary dependency. The change should be made directly in the file `tests/integration/test_base_sw_headers_attrs.py` by deleting the specific import statement on line 37.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
