### PR TITLE
Potential fix for code scanning alert no. 357: Unused import

### DIFF
--- a/tests/unit/test_oboe/test_sampler.py
+++ b/tests/unit/test_oboe/test_sampler.py
@@ -5,7 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 from __future__ import annotations
 
-import logging
+
 import time
 from typing import Any
 


### PR DESCRIPTION
Potential fix for [https://github.com/solarwinds/apm-python/security/code-scanning/357](https://github.com/solarwinds/apm-python/security/code-scanning/357)

To fix the issue, we will remove the unused `logging` import from line 8. This will eliminate the unnecessary dependency and improve code clarity. No other changes are required since the `logging` module is not used in the provided code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
