### PR TITLE
Potential fix for code scanning alert no. 356: Unused import

### DIFF
--- a/tests/unit/test_oboe/test_oboe_sampler.py
+++ b/tests/unit/test_oboe/test_oboe_sampler.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
-import logging
+
 import os
 import time
 from collections.abc import Sequence


### PR DESCRIPTION
Potential fix for [https://github.com/solarwinds/apm-python/security/code-scanning/356](https://github.com/solarwinds/apm-python/security/code-scanning/356)

To fix the issue, the unused `logging` import should be removed from the file. This will eliminate the unnecessary dependency and improve code readability. The change should be made on line 10 of the file `tests/unit/test_oboe/test_oboe_sampler.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
