### PR TITLE
Potential fix for code scanning alert no. 354: Unused import

### DIFF
--- a/tests/unit/test_oboe/test_http_sampler.py
+++ b/tests/unit/test_oboe/test_http_sampler.py
@@ -3,7 +3,6 @@
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-import logging
 import os
 import socket
 from unittest.mock import patch, MagicMock


### PR DESCRIPTION
Potential fix for [https://github.com/solarwinds/apm-python/security/code-scanning/354](https://github.com/solarwinds/apm-python/security/code-scanning/354)

To fix the issue, we will remove the unused `logging` import from line 6. This will clean up the code and eliminate the unnecessary dependency. No other changes are required since the `logging` module is not used in the provided code snippet.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
