### PR TITLE
NH-108982 Add create_testrelease action

### DIFF
--- a/.github/scripts/testrelease_pr.sh
+++ b/.github/scripts/testrelease_pr.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# © 2025 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+# input testrelease version number, e.g. 1.1.0.1
+version_number="$1"
+
+branch_name="testrelease/rel-${version_number}"
+
+# Create testrelease branch
+echo "Creating new branch '$branch_name' from 'main'"
+gh api -X POST /repos/solarwinds/apm-python/git/refs \
+    --field ref="refs/heads/$branch_name" \
+    --field sha="$(git rev-parse "origin/main")"
+
+# Get SHA of current version.py at main
+SHA_VERS=$(gh api /repos/solarwinds/apm-python/contents/solarwinds_apm/version.py?ref="main" --jq '.sha')
+
+# Commit version.py with updated agent version
+version_str=$(base64 <<< "__version__ = \"$version_number\"")
+echo "Pushing new version.py to branch '$branch_name'"
+gh api --method PUT /repos/solarwinds/apm-python/contents/solarwinds_apm/version.py \
+    --field message="Update agent test version to $version_number" \
+    --field content="$version_str" \
+    --field encoding="base64" \
+    --field branch="$branch_name" \
+    --field sha="$SHA_VERS"
+
+# Get SHA of current requirements-nodeps-beta.txt at main
+SHA_REQ=$(gh api /repos/solarwinds/apm-python/contents/image/requirements-nodeps-beta.txt?ref="main" --jq '.sha')
+
+# Commit beta image requirements with updated agent version
+requirement_str=$(base64 <<< "solarwinds_apm==$version_number")
+echo "Pushing new image/requirements to branch '$branch_name'"
+gh api --method PUT /repos/solarwinds/apm-python/contents/image/requirements-nodeps-beta.txt \
+    --field message="Update beta image's agent version to $version_number" \
+    --field content="$requirement_str" \
+    --field encoding="base64" \
+    --field branch="$branch_name" \
+    --field sha="$SHA_REQ"
+
+# Open draft Pull Request for version bump
+echo "Creating draft pull request"
+gh pr create --draft --base "main" --head "$branch_name" \
+    --title "solarwinds-apm $version_number" \
+    --body "For testrelease of solarwinds-apm $version_number."

--- a/.github/workflows/create_testrelease_pr.yaml
+++ b/.github/workflows/create_testrelease_pr.yaml
@@ -1,0 +1,35 @@
+# © 2025 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+name: Create Testrelease PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semantic version of testrelease (e.g. 1.0.0.1)'
+        required: true
+
+# Note: We don't maintain nor check for testrelease tags; only for regular releases.
+env:
+  RELEASE_VERSION: ${{ github.event.inputs.version }}
+
+jobs:
+  create_testrelease_pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email noreply@github.com
+      - name: Create testrelease branch draft pull request
+        run: cd .github/scripts && ./testrelease_pr.sh ${{ env.RELEASE_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds new "Create Testrelease PR" github action, which version bumps the APM version + testpypi version used by the beta instrumentation image publish (I forget the latter sometimes).