### PR TITLE
NH-108983 Adjust "Verify Installation" test dependencies following Pure Python

### DIFF
--- a/tests/docker/install/_helper_run_install_tests.sh
+++ b/tests/docker/install/_helper_run_install_tests.sh
@@ -30,8 +30,8 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
     if grep Alpine /etc/os-release; then
         # test deps
         apk add bash
-        # agent deps
-        apk add python3-dev g++ make curl
+        # agent deps - APM dep on psutil, so Alpine need linux-headers
+        apk add python3 curl linux-headers
 
         pip install --upgrade pip >/dev/null
 
@@ -42,9 +42,7 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
         sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
         # agent and test deps
         dnf install -y \
-            "python$python_version_no_dot-devel" \
-            gcc \
-            gcc-c++ \
+            "python$python_version_no_dot" \
             unzip \
             findutils
         dnf install -y "python$python_version_no_dot-pip" "python$python_version_no_dot-setuptools"
@@ -62,12 +60,10 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
             apt-get update -y
             TZ=America
             ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+            # distutils needed for pip installation from pypa
             apt-get install -y \
                 "python$python_version" \
                 "python$python_version-distutils" \
-                "python$python_version-dev" \
-                python3-setuptools \
-                build-essential \
                 unzip \
                 wget \
                 curl
@@ -93,11 +89,8 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
         yum update -y
         if grep "Amazon Linux 2023" /etc/os-release; then
             yum install -y \
-                python3-devel \
+                python3 \
                 python3-pip \
-                python3-setuptools \
-                gcc \
-                gcc-c++ \
                 unzip \
                 findutils \
                 tar \


### PR DESCRIPTION
Adjusts "Verify Installation" test dependencies following Pure Python. Generally the deps of each Linux distro can be reduced to "regular" Python and utils to curl/find/grep etc, without needing "dev" Python and g++.

We do add an Alpine dependency, `linux-headers`, needed since adding psutils dep in https://github.com/solarwinds/apm-python/pull/629. This will be needed after next release of APM Python.

Test run using this branch and APM Python 4.0.0: https://github.com/solarwinds/apm-python/actions/runs/14940259260