### PR TITLE
NH-108983 Update "Verify Installation" CI/CD for more automation

### DIFF
--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -7,16 +7,22 @@
 name: Verify Installation
 
 on:
+  push:
+    branches:
+      - main
+  pull_request:
+    type: [opened, reopened]
   workflow_dispatch:
     inputs:
       install-registry:
         required: true
-        description: 'Registry used for install tests, one of: pypi, testpypi'
+        description: 'Registry/Source used for install tests, one of: pypi, testpypi, local (contents of current branch)'
         type: choice
-        default: 'pypi'
+        default: 'local'
         options:
         - pypi
         - testpypi
+        - local
       solarwinds-version:
         required: false
         description: 'Optional solarwinds-apm version, e.g. 0.0.3.2'
@@ -160,12 +166,13 @@ jobs:
       image: "${{ matrix.image }}"
       options: --hostname "${{ matrix.hostname }}"
     steps:
-      - if: ${{ matrix.image == 'amazonlinux:2023' }}
-        run: yum install -y tar gzip
+      - if: contains(matrix.image, 'amazonlinux')
+        name: Install AmazonLinux deps to use checkout
+        run: yum install -y tar gzip 
       - uses: actions/checkout@v4
       - name: Setup and run install test
         working-directory: ./tests/docker/install
-        run: ./_helper_run_install_tests.sh
+        run: APM_ROOT=$GITHUB_WORKSPACE ./_helper_run_install_tests.sh
         shell: sh
         env:
           MODE: ${{ github.event.inputs.install-registry }}

--- a/tests/docker/install/README.md
+++ b/tests/docker/install/README.md
@@ -3,7 +3,7 @@
 These files provide containers and scripts to test installation of packaged `solarwinds-apm`, from local or from registry. Here is how to set up and run install tests locally:
 
 1. Set test mode to install from one of:
-   * `export MODE=local` (default; must be built in project `dist/`)
+   * `export MODE=local` (default; this will build sdist and wheel in project `dist/`)
    * `export MODE=testpypi`
    * `export MODE=pypi`
 2. Optionally set the APM library version to install, e.g. `export SOLARWINDS_APM_VERSION=0.6.0`. If not provided, the install tests will use what's set in `version.py` (local) or the latest version (registry).

--- a/tests/docker/install/_helper_run_install_tests.sh
+++ b/tests/docker/install/_helper_run_install_tests.sh
@@ -30,8 +30,8 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
     if grep Alpine /etc/os-release; then
         # test deps
         apk add bash
-        # agent deps - APM dep on psutil, so Alpine need linux-headers
-        apk add python3 curl linux-headers
+        # agent deps - APM deps on psutil, so Alpine needs more deps
+        apk add python3 curl linux-headers gcc musl-dev
 
         pip install --upgrade pip >/dev/null
 

--- a/tests/docker/install/install_tests.sh
+++ b/tests/docker/install/install_tests.sh
@@ -107,8 +107,22 @@ function run_instrumented_server_and_client(){
 
 # START TESTING ===========================================
 HOSTNAME=$(cat /etc/hostname)
-# docker-compose-set root of local solarwinds_apm package
-APM_ROOT='/code/python-solarwinds'
+# Default to docker-compose-set root of local solarwinds_apm package
+if [ -z "$APM_ROOT" ]
+then
+    APM_ROOT="/code/python-solarwinds"
+    echo "Using default APM_ROOT: $APM_ROOT"
+else
+    echo "Using configured APM_ROOT: $APM_ROOT"
+fi
+
+if [[ "$MODE" == "local" ]]
+then
+    echo "Local mode: installing sdist and wheel locally"
+    pip install build
+    python -m build $APM_ROOT --sdist
+    pip -v wheel $APM_ROOT -w $APM_ROOT/dist --no-deps
+fi
 
 # Check sdist
 # shellcheck disable=SC1091


### PR DESCRIPTION
Updates "Verify Installation" CI/CD to be more automated. A `"local"` registry/source is now supported and is the default, which uses contents of the current branch to build sdist and wheel to do the test (not just PyPI/TestPyPI anymore). This allows us to automatically run "Verify Installation" with the other tox tests now on every PR and merge to `main` branch.

This branch was used to successfully run install tests from "local" (branch contents) by manual dispatch: https://github.com/solarwinds/apm-python/actions/runs/14985714435

And they also ran on this PR 😺 