### PR TITLE
NH-108983 Add verify_installation_windows CI/CD

### DIFF
--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -4,7 +4,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-name: Verify Installation
+name: Verify Installation - Linux
 
 on:
   push:

--- a/.github/workflows/verify_install_windows.yaml
+++ b/.github/workflows/verify_install_windows.yaml
@@ -1,0 +1,66 @@
+# © 2023-2025 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+name: Verify Installation - Windows
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    type: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      install-registry:
+        required: true
+        description: 'Registry/Source used for install tests, one of: pypi, testpypi, local (contents of current branch)'
+        type: choice
+        default: 'local'
+        options:
+        - pypi
+        - testpypi
+        - local
+      solarwinds-version:
+        required: false
+        description: 'Optional solarwinds-apm version, e.g. 0.0.3.2'
+
+env:
+  SOLARWINDS_APM_VERSION: ${{ github.event.inputs.solarwinds-version }}
+  SW_APM_COLLECTOR_PROD: ${{ secrets.SW_APM_COLLECTOR_PROD }}
+  SW_APM_COLLECTOR_STAGING: ${{ secrets.SW_APM_COLLECTOR_STAGING }}
+  SW_APM_SERVICE_KEY_PROD: ${{ secrets.SW_APM_SERVICE_KEY_PROD }}
+  SW_APM_SERVICE_KEY_STAGING: ${{ secrets.SW_APM_SERVICE_KEY_STAGING }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  install-tests:
+    runs-on: 'windows-latest'
+    name: install-tests (py${{ matrix.python-version }}-windows, x64)
+    strategy:
+      matrix:
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup and run install test
+        working-directory: ./tests/docker/install/windows
+        shell: pwsh
+        env:
+            MODE: ${{ github.event.inputs.install-registry }}
+            PYTHON_VERSION: ${{ matrix.python-version }}
+            APM_ROOT: ${{ github.workspace }}
+        run: |
+          .\_helper_run_install_tests.ps1

--- a/tests/docker/install/windows/_helper_check_sdist.ps1
+++ b/tests/docker/install/windows/_helper_check_sdist.ps1
@@ -1,0 +1,86 @@
+# © 2025 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+$ErrorActionPreference = "Stop"
+
+$TEST_MODES = @("local", "testpypi", "pypi")
+
+if (-not $env:MODE) {
+    Write-Host "WARNING: Did not provide MODE for check_sdist test."
+    Write-Host "Defaulting to MODE=local"
+    $env:MODE = "local"
+}
+if ($TEST_MODES -notcontains $env:MODE) {
+    Write-Error "FAILED: Did not provide valid MODE for check_sdist test. Must be one of: testpypi (default), local, pypi."
+    exit 1
+}
+
+if (-not $env:APM_ROOT) {
+    Write-Error "FAILED: Did not provide valid APM_ROOT for check_sdist test."
+    exit 1
+}
+
+function Get-Sdist {
+    $sdist_dir = Join-Path $PWD "tmp\sdist"
+    if (Test-Path $sdist_dir) { Remove-Item -Recurse -Force $sdist_dir }
+
+    if ($env:MODE -eq "local") {
+        # optionally test a previous version on local for debugging
+        if (-not $env:SOLARWINDS_APM_VERSION) {
+            # no SOLARWINDS_APM_VERSION provided, thus test version of current source code
+            $version_file = Join-Path $env:APM_ROOT "solarwinds_apm\version.py"
+            $version_content = Get-Content $version_file
+            if ($version_content -match '__version__ = "(.*)"') {
+                $env:SOLARWINDS_APM_VERSION = $matches[1]
+            }
+            Write-Host "No SOLARWINDS_APM_VERSION provided, thus testing source code version ($env:SOLARWINDS_APM_VERSION)"
+        }
+
+        $sdist_tar = Join-Path $env:APM_ROOT "dist\solarwinds_apm-$env:SOLARWINDS_APM_VERSION.tar.gz"
+        if (-not (Test-Path $sdist_tar)) {
+            Write-Error "FAILED: Did not find sdist for version $env:SOLARWINDS_APM_VERSION. Please run 'python build' before running tests."
+            exit 1
+        }
+
+        return $sdist_tar
+    }
+    else {
+        $pip_options = @("--no-binary", "solarwinds-apm", "--dest", $sdist_dir)
+        if ($env:MODE -eq "testpypi") {
+            $pip_options += "--extra-index-url", "https://test.pypi.org/simple/"
+        }
+
+        if ($env:SOLARWINDS_APM_VERSION) {
+            $pip_options += "solarwinds-apm==$env:SOLARWINDS_APM_VERSION"
+        }
+        else {
+            $pip_options += "solarwinds-apm"
+        }
+
+        pip download $pip_options
+        $sdist_tar = Get-ChildItem -Path $sdist_dir -Filter "solarwinds_apm-*.tar.gz"
+        return $sdist_tar.FullName
+    }
+}
+
+function Check-Sdist {
+    param($sdist_path)
+    
+    if (-not $env:PIP_INSTALL) {
+        Write-Host "PIP_INSTALL not specified."
+        Write-Host "Source distribution verified successfully.`n"
+        exit 0
+    }
+    else {
+        Write-Host "Installing Python agent from source"
+        pip install -I $sdist_path
+    }
+}
+
+# start testing
+Write-Host "#### Verifying Python agent source distribution ####"
+$sdist_path = Get-Sdist
+Check-Sdist $sdist_path

--- a/tests/docker/install/windows/_helper_check_wheel.ps1
+++ b/tests/docker/install/windows/_helper_check_wheel.ps1
@@ -1,0 +1,95 @@
+# © 2025 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+$ErrorActionPreference = "Stop"
+
+$TEST_MODES = @("local", "testpypi", "pypi")
+
+if (-not $env:MODE) {
+    Write-Host "WARNING: Did not provide MODE for check_wheel test."
+    Write-Host "Defaulting to MODE=local"
+    $env:MODE = "local"
+}
+
+if ($TEST_MODES -notcontains $env:MODE) {
+    Write-Error "FAILED: Did not provide valid MODE for check_wheel test. Must be one of: testpypi (default), local, pypi."
+    exit 1
+}
+
+if (-not $env:APM_ROOT) {
+    Write-Error "FAILED: Did not provide valid APM_ROOT for check_wheel test."
+    exit 1
+}
+
+$VALID_PLATFORMS = @("AMD64", "ARM64")
+$PLATFORM = [System.Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE")
+if ($VALID_PLATFORMS -notcontains $PLATFORM) {
+    Write-Error "FAILED: Invalid platform for check_wheel test. Must be run on one of: AMD64, ARM64."
+    exit 1
+}
+
+function Get-Wheel {
+    $wheel_dir = Join-Path $PWD "tmp\wheel"
+    if (Test-Path $wheel_dir) { Remove-Item -Recurse -Force $wheel_dir }
+
+    if ($env:MODE -eq "local") {
+        # optionally test a previous version on local for debugging
+        if (-not $env:SOLARWINDS_APM_VERSION) {
+            # no SOLARWINDS_APM_VERSION provided, thus test version of current source code
+            $version_file = Join-Path $env:APM_ROOT "solarwinds_apm\version.py"
+            $version_content = Get-Content $version_file
+            if ($version_content -match '__version__ = "(.*)"') {
+                $env:SOLARWINDS_APM_VERSION = $matches[1]
+            }
+            Write-Host "No SOLARWINDS_APM_VERSION provided, thus testing source code version"
+        }
+
+        $tested_wheel = Get-ChildItem -Path "$env:APM_ROOT\dist" -Filter "solarwinds_apm-$env:SOLARWINDS_APM_VERSION-py3-none-any.whl"
+        
+        if (-not $tested_wheel) {
+            Write-Host "FAILED: Did not find wheel for version $env:SOLARWINDS_APM_VERSION. Please run 'pip wheel' before running tests."
+            echo "Aborting tests."
+            exit 1
+        }
+
+        return $tested_wheel
+    }
+    else {
+        $pip_options = @("--only-binary", "solarwinds-apm", "--dest", $wheel_dir)
+        if ($env:MODE -eq "testpypi") {
+            $pip_options += "--extra-index-url", "https://test.pypi.org/simple/"
+        }
+        
+        if ($env:SOLARWINDS_APM_VERSION) {
+            $pip_options += "solarwinds-apm==$env:SOLARWINDS_APM_VERSION"
+        }
+        else {
+            $pip_options += "solarwinds-apm"
+        }
+
+        pip download $pip_options
+        $tested_wheel = Get-ChildItem -Path $wheel_dir -Filter "solarwinds_apm-*.whl"
+    }
+    return $tested_wheel.FullName
+}
+
+function Check-Wheel {
+    param($wheel_path)
+    
+    if (-not $env:PIP_INSTALL) {
+        Write-Host "PIP_INSTALL not specified."
+        Write-Host "Python wheel verified successfully.`n"
+        exit 0
+    }
+    else {
+        Write-Host "Installing Python agent from wheel"
+        pip install -I $wheel_path
+    }
+}
+
+Write-Host "#### Verifying Python agent wheel distribution ####"
+$wheel_path = Get-Wheel
+Check-Wheel $wheel_path

--- a/tests/docker/install/windows/_helper_run_install_tests.ps1
+++ b/tests/docker/install/windows/_helper_run_install_tests.ps1
@@ -1,0 +1,21 @@
+# © 2025 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+# Helper script to set up dependencies for the install tests on windows-latest runner, then runs the tests.
+
+# Stop on error
+$ErrorActionPreference = "Stop"
+
+# Python version was installed by calling GH workflow
+Write-Host "Installing test dependencies for Python $env:PYTHON_VERSION on Windows"
+
+# Setup dependencies quietly
+# Install required tools via pip
+python -m pip install --upgrade pip | Out-Null
+
+# Run tests using PowerShell
+$env:PYTHONPATH = $env:APM_ROOT
+& pwsh -NoProfile -NonInteractive -Command ".\install_tests.ps1 2>&1" 

--- a/tests/docker/install/windows/install_tests.ps1
+++ b/tests/docker/install/windows/install_tests.ps1
@@ -1,0 +1,200 @@
+# © 2025 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+# Stop on error
+$ErrorActionPreference = "Stop"
+
+# Test modes
+$TEST_MODES = @("local", "testpypi", "pypi")
+
+if (-not $env:MODE) {
+    Write-Host "WARNING: Did not provide MODE for install test run."
+    Write-Host "Defaulting to MODE=local"
+    $env:MODE = "local"
+}
+if ($TEST_MODES -notcontains $env:MODE) {
+    Write-Error "FAILED: Did not provide valid MODE. Must be one of: testpypi (default), local, pypi."
+    exit 1
+}
+else {
+    Write-Host "Using provided MODE=$($env:MODE)"
+}
+
+Write-Host "Python system information"
+Write-Host "Python version: $(python --version)"
+Write-Host "Pip version: $(pip --version)"
+
+
+function Check-AgentStartup {
+    # verify that installed agent starts up properly
+    Write-Host "---- Verifying proper startup of installed agent ----"
+
+    $env:SW_APM_DEBUG_LEVEL = "6"
+    $env:SW_APM_SERVICE_KEY = "invalid-token-for-testing-1234567890:servicename"
+    $env:SW_APM_COLLECTOR = "apm.collector.na-01.cloud.solarwinds.com"
+  
+    # return value we expect form solarwinds_apm.api.solarwinds_ready().
+    # This should normally be True (ready), because the collector does not send
+    # "invalid api token" response; it sends "ok" with soft disable settings.
+    $expectedAgentReturn = "True"
+
+    $TEST_EXP_LOG_MESSAGES = @(
+        "SolarWinds APM Python $env:SOLARWINDS_APM_VERSION",
+        "retrieving sampling settings from https://apm.collector.na-01.cloud.solarwinds.com/v1/settings/servicename/$env:COMPUTERNAME"
+    )
+
+    # unset stop on error so we can catch debug messages in case of failures
+    $ErrorActionPreference = "Continue"
+
+    $startupLog = Join-Path $PWD "startup.log"
+
+    # Write Python code to temp file to avoid string escape issues and Python SyntaxError
+    $tempScript = Join-Path $PWD "temp_startup_check.py"
+    @"
+from solarwinds_apm.api import solarwinds_ready
+r = solarwinds_ready(wait_milliseconds=10000)
+print(r)
+"@ | Set-Content -Path $tempScript
+    try {
+        $result = & opentelemetry-instrument python $tempScript 2> $startupLog | Select-Object -Last 1
+    }
+    finally {
+        # Clean up temp file
+        Remove-Item -Path $tempScript -ErrorAction SilentlyContinue
+    }
+
+    if ($result -ne $expectedAgentReturn) {
+        Write-Host "FAILED! Expected solarwinds_ready to return $expectedAgentReturn, but got: $result"
+        Write-Host "-- startup.log content --"
+        Get-Content $startupLog
+        exit 1
+    }
+
+    $logsOk = $true
+    $logContent = Get-Content $startupLog -Raw
+    foreach ($expected in $TEST_EXP_LOG_MESSAGES) {
+        if ($logContent -notmatch [regex]::Escape($expected)) {
+            $logsOk = $false
+            break
+        }
+    }
+    if (-not $logsOk) {
+        Write-Host "FAILED! Expected messages were not found in startup.log"
+        Write-Host "-- startup.log content --"
+        Get-Content $startupLog
+        exit 1
+    }
+
+    # Restore stop on error
+    $ErrorActionPreference = "Stop"
+
+    Write-Host "Agent startup verified successfully.`n"
+}
+
+
+function Install-TestAppDependencies {
+    pip install flask requests
+    opentelemetry-bootstrap --action=install
+}
+
+
+function Run-InstrumentedServerAndClient {
+    param(
+        [string]$Port,
+        [string]$ServiceKey,
+        [string]$Collector,
+        [string]$Environment
+    )
+
+    Write-Host "OS: Windows $(Get-CimInstance -ClassName Win32_OperatingSystem | Select-Object -ExpandProperty Caption)"
+    Write-Host "Python version: $(python --version)"
+    Write-Host "Pip version: $(pip --version)"
+    Write-Host "Instrumenting Flask with solarwinds_apm Python from $($env:MODE)."
+
+    # Set environment variables
+    $flaskEnv = @{
+        "FLASK_APP" = (Resolve-Path "..\app.py").Path
+        "FLASK_RUN_HOST" = "0.0.0.0"
+        "FLASK_RUN_PORT" = $Port
+        "OTEL_PYTHON_DISABLED_INSTRUMENTATIONS" = "urllib3"
+        "SW_APM_DEBUG_LEVEL" = "3"
+        "SW_APM_SERVICE_KEY" = $ServiceKey
+        "SW_APM_COLLECTOR" = $Collector
+    }
+
+    Write-Host "Testing trace export from Flask to $Environment..."
+
+    try {
+        # Start Flask server in background with environment variables in job context
+        $serverJob = Start-Job -ScriptBlock {
+            param($env)
+            foreach ($key in $env.Keys) {
+                [Environment]::SetEnvironmentVariable($key, $env[$key])
+            }
+            & opentelemetry-instrument flask run 2>&1 | Tee-Object -FilePath "flask.log"
+        } -ArgumentList $flaskEnv
+
+        # Wait a moment for Flask to start
+        Start-Sleep -Seconds 2
+
+        # Run client with same environment variables
+        foreach ($key in $flaskEnv.Keys) {
+            [Environment]::SetEnvironmentVariable($key, $flaskEnv[$key])
+        }
+        # Except this one to reach local server in serverJob
+        [Environment]::SetEnvironmentVariable("FLASK_RUN_HOST", "127.0.0.1")
+        python ..\client.py
+
+    }
+    finally {
+        if ($serverJob) {
+            Write-Host "Stopping and removing current Flask serverJob - this may take a moment"
+            Stop-Job -Job $serverJob
+            Remove-Job -Job $serverJob -Force
+        }
+    }
+}
+
+# START TESTING ===========================================
+if (-not $env:APM_ROOT) {
+    $env:APM_ROOT = "/code/python-solarwinds"
+    Write-Host "Using default APM_ROOT: $env:APM_ROOT"
+}
+else {
+    Write-Host "Using configured APM_ROOT: $env:APM_ROOT"
+}
+
+if ($env:MODE -eq "local") {
+    Write-Host "Local mode: installing sdist and wheel locally"
+    pip install build
+    python -m build $env:APM_ROOT --sdist
+    pip -v wheel $env:APM_ROOT -w $env:APM_ROOT\dist --no-deps
+}
+
+# Check sdist
+$env:PIP_INSTALL = 1
+. .\_helper_check_sdist.ps1
+Check-AgentStartup
+Write-Host "Source distribution verified successfully.`n"
+
+# Check wheel
+$env:PIP_INSTALL = 1
+. .\_helper_check_wheel.ps1
+Check-AgentStartup
+Write-Host "Wheel distribution verified successfully.`n"
+
+# Check startup and instrumentation
+Install-TestAppDependencies
+Run-InstrumentedServerAndClient `
+    -Port "8001" `
+    -ServiceKey "$env:SW_APM_SERVICE_KEY_STAGING-$env:COMPUTERNAME" `
+    -Collector $env:SW_APM_COLLECTOR_STAGING `
+    -Environment "NH Staging"
+Run-InstrumentedServerAndClient `
+    -Port "8002" `
+    -ServiceKey "$env:SW_APM_SERVICE_KEY_PROD-$env:COMPUTERNAME" `
+    -Collector $env:SW_APM_COLLECTOR_PROD `
+    -Environment "NH Prod"


### PR DESCRIPTION
Adds `verify_installation_windows` CI/CD to smoke test the installation of APM Python on `windows-latest` for the 5 supported Python versions. This will be run on every PR and push to main with current branch contents, and can be manually triggered to install from local (branch contents), TestPyPI, or PyPI -- like the update in https://github.com/solarwinds/apm-python/pull/635. This re-writes the existing `.sh` test scripts as `.ps1` for Windows compatibility.

Completed test runs:
* "local" (with correct job names!): https://github.com/solarwinds/apm-python/actions/runs/15008808953
* "testpypi": https://github.com/solarwinds/apm-python/actions/runs/15008683418/job/42173195998
* "pypi": https://github.com/solarwinds/apm-python/actions/runs/15008722309