### PR TITLE
NH-108983 Add verify_installation_macos CI/CD

### DIFF
--- a/.github/workflows/verify_install_macos.yaml
+++ b/.github/workflows/verify_install_macos.yaml
@@ -1,0 +1,66 @@
+# © 2023-2025 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+name: Verify Installation - MacOS
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    type: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      install-registry:
+        required: true
+        description: 'Registry/Source used for install tests, one of: pypi, testpypi, local (contents of current branch)'
+        type: choice
+        default: 'local'
+        options:
+        - pypi
+        - testpypi
+        - local
+      solarwinds-version:
+        required: false
+        description: 'Optional solarwinds-apm version, e.g. 0.0.3.2'
+
+env:
+  SOLARWINDS_APM_VERSION: ${{ github.event.inputs.solarwinds-version }}
+  SW_APM_COLLECTOR_PROD: ${{ secrets.SW_APM_COLLECTOR_PROD }}
+  SW_APM_COLLECTOR_STAGING: ${{ secrets.SW_APM_COLLECTOR_STAGING }}
+  SW_APM_SERVICE_KEY_PROD: ${{ secrets.SW_APM_SERVICE_KEY_PROD }}
+  SW_APM_SERVICE_KEY_STAGING: ${{ secrets.SW_APM_SERVICE_KEY_STAGING }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  install-tests:
+    runs-on: 'macos-latest'
+    name: install-tests (py${{ matrix.python-version }}-macos, arm64)
+    strategy:
+      matrix:
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup and run install test
+        working-directory: ./tests/docker/install
+        shell: bash
+        env:
+            MODE: ${{ github.event.inputs.install-registry }}
+            PYTHON_VERSION: ${{ matrix.python-version }}
+            APM_ROOT: ${{ github.workspace }}
+        run: |
+          ./_helper_run_install_tests.sh

--- a/tests/docker/install/_helper_check_wheel.sh
+++ b/tests/docker/install/_helper_check_wheel.sh
@@ -38,6 +38,7 @@ fi
 VALID_PLATFORMS=(
     "x86_64"
     "aarch64"
+    "arm64"
 )
 PLATFORM=$(uname -m)
 if [[ ! " ${VALID_PLATFORMS[*]} " =~ ${PLATFORM} ]]

--- a/tests/docker/install/_helper_run_install_tests.sh
+++ b/tests/docker/install/_helper_run_install_tests.sh
@@ -18,12 +18,21 @@
 # stop on error
 set -e
 
-# get Python version from container hostname, e.g. "3.10"
-python_version=$(grep -Eo 'py3.[0-9]+[0-9]*' /etc/hostname | grep -Eo '3.[0-9]+[0-9]*')
-# no-dot Python version, e.g. "310"
-python_version_no_dot=$(echo "$python_version" | sed 's/\.//')
+if [[ "$OSTYPE" == "darwin"* ]];
+then
+    # On macOS, use GitHub Actions environment variable
+    python_version=$PYTHON_VERSION
+    python_version_no_dot=$(echo "$python_version" | sed 's/\.//')
+    pretty_name="macOS $(sw_vers -productVersion)"
+else
+    # get Python version from container hostname, e.g. "3.10"
+    python_version=$(grep -Eo 'py3.[0-9]+[0-9]*' /etc/hostname | grep -Eo '3.[0-9]+[0-9]*')
+    # no-dot Python version, e.g. "310"
+    python_version_no_dot=$(echo "$python_version" | sed 's/\.//')
+    # get pretty name from linux release
+    pretty_name=$(grep PRETTY_NAME /etc/os-release | sed 's/PRETTY_NAME="//' | sed 's/"//')
+fi
 
-pretty_name=$(grep PRETTY_NAME /etc/os-release | sed 's/PRETTY_NAME="//' | sed 's/"//')
 echo "Installing test dependencies for Python $python_version on $pretty_name"
 # setup dependencies quietly
 {

--- a/tests/docker/install/install_tests.sh
+++ b/tests/docker/install/install_tests.sh
@@ -106,7 +106,12 @@ function run_instrumented_server_and_client(){
 
 
 # START TESTING ===========================================
-HOSTNAME=$(cat /etc/hostname)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    HOSTNAME=$(scutil --get LocalHostName)
+else
+    HOSTNAME=$(cat /etc/hostname)
+fi
+
 # Default to docker-compose-set root of local solarwinds_apm package
 if [ -z "$APM_ROOT" ]
 then


### PR DESCRIPTION
Adds `verify_installation_macos` CI/CD to smoke test the installation of APM Python on `macos-latest` for the 5 supported Python versions. This will be run on every PR and push to main with current branch contents, and can be manually triggered to install from local (branch contents), TestPyPI, or PyPI -- like the updates in https://github.com/solarwinds/apm-python/pull/635 and https://github.com/solarwinds/apm-python/pull/636. MacOS is Unix-based so we use the existing Linux test scripts with minor adjustments.

Completed test run: https://github.com/solarwinds/apm-python/actions/runs/15009592518