### PR TITLE
NH-110883 psutil becomes optional dep for APM Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ pip install solarwinds-apm
 opentelemetry-bootstrap --action=install
 ```
 
+To opt into system metrics generation, specify `pip install solarwinds-apm[system-metrics]`.
+
 `solarwinds-apm` already includes OpenTelemetry and therefore doesn't need to be installed separately. Python agent installation should be done _after_ installation of all other service dependencies. This is so `opentelemetry-bootstrap` detects those packages and installs their corresponding instrumentation libraries. For example:
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ dependencies = [
     'opentelemetry-instrumentation-logging == 0.52b1',
     'opentelemetry-sdk-extension-aws == 2.1.0',
     'opentelemetry-resource-detector-azure == 0.1.5',
+]
+
+[project.optional-dependencies]
+system-metrics = [
     'psutil >= 5',
 ]
 

--- a/tests/docker/install/README.md
+++ b/tests/docker/install/README.md
@@ -1,6 +1,6 @@
 # Installation tests
 
-These files provide containers and scripts to test installation of packaged `solarwinds-apm`, from local or from registry. Here is how to set up and run install tests locally:
+These files provide containers and scripts to test installation of packaged `solarwinds-apm` with system-metrics opt-in (`solarwinds-apm[system-metrics]`), from local or from registry. Here is how to set up and run install tests locally:
 
 1. Set test mode to install from one of:
    * `export MODE=local` (default; this will build sdist and wheel in project `dist/`)

--- a/tests/docker/install/_helper_check_sdist.sh
+++ b/tests/docker/install/_helper_check_sdist.sh
@@ -56,7 +56,7 @@ function get_sdist(){
             exit 1
         fi
     else
-        pip_options=(--no-binary solarwinds-apm --dest "$sdist_dir")
+        pip_options=(--no-binary solarwinds-apm[system-metrics] --dest "$sdist_dir")
         if [ "$MODE" == "testpypi" ]
         then
             pip_options+=(--extra-index-url https://test.pypi.org/simple/)
@@ -64,9 +64,9 @@ function get_sdist(){
 
         if [ -z "$SOLARWINDS_APM_VERSION" ]
         then
-            pip_options+=(solarwinds-apm)
+            pip_options+=(solarwinds-apm[system-metrics])
         else
-            pip_options+=(solarwinds-apm=="$SOLARWINDS_APM_VERSION")
+            pip_options+=(solarwinds-apm[system-metrics]=="$SOLARWINDS_APM_VERSION")
         fi
 
         # shellcheck disable=SC2048

--- a/tests/docker/install/_helper_check_wheel.sh
+++ b/tests/docker/install/_helper_check_wheel.sh
@@ -68,7 +68,7 @@ function get_wheel(){
             exit 1
         fi
     else
-        pip_options=(--only-binary solarwinds-apm --dest "$wheel_dir")
+        pip_options=(--only-binary solarwinds-apm[system-metrics] --dest "$wheel_dir")
         if [ "$MODE" == "testpypi" ]
         then
             pip_options+=(--extra-index-url https://test.pypi.org/simple/)
@@ -76,9 +76,9 @@ function get_wheel(){
 
         if [ -z "$SOLARWINDS_APM_VERSION" ]
         then
-            pip_options+=(solarwinds-apm)
+            pip_options+=(solarwinds-apm[system-metrics])
         else
-            pip_options+=(solarwinds-apm=="$SOLARWINDS_APM_VERSION")
+            pip_options+=(solarwinds-apm[system-metrics]=="$SOLARWINDS_APM_VERSION")
         fi
 
         # shellcheck disable=SC2048

--- a/tests/docker/install/windows/_helper_check_sdist.ps1
+++ b/tests/docker/install/windows/_helper_check_sdist.ps1
@@ -48,16 +48,16 @@ function Get-Sdist {
         return $sdist_tar
     }
     else {
-        $pip_options = @("--no-binary", "solarwinds-apm", "--dest", $sdist_dir)
+        $pip_options = @("--no-binary", "solarwinds-apm[system-metrics]", "--dest", $sdist_dir)
         if ($env:MODE -eq "testpypi") {
             $pip_options += "--extra-index-url", "https://test.pypi.org/simple/"
         }
 
         if ($env:SOLARWINDS_APM_VERSION) {
-            $pip_options += "solarwinds-apm==$env:SOLARWINDS_APM_VERSION"
+            $pip_options += "solarwinds-apm[system-metrics]==$env:SOLARWINDS_APM_VERSION"
         }
         else {
-            $pip_options += "solarwinds-apm"
+            $pip_options += "solarwinds-apm[system-metrics]"
         }
 
         pip download $pip_options

--- a/tests/docker/install/windows/_helper_check_wheel.ps1
+++ b/tests/docker/install/windows/_helper_check_wheel.ps1
@@ -58,16 +58,16 @@ function Get-Wheel {
         return $tested_wheel
     }
     else {
-        $pip_options = @("--only-binary", "solarwinds-apm", "--dest", $wheel_dir)
+        $pip_options = @("--only-binary", "solarwinds-apm[system-metrics]", "--dest", $wheel_dir)
         if ($env:MODE -eq "testpypi") {
             $pip_options += "--extra-index-url", "https://test.pypi.org/simple/"
         }
         
         if ($env:SOLARWINDS_APM_VERSION) {
-            $pip_options += "solarwinds-apm==$env:SOLARWINDS_APM_VERSION"
+            $pip_options += "solarwinds-apm[system-metrics]==$env:SOLARWINDS_APM_VERSION"
         }
         else {
-            $pip_options += "solarwinds-apm"
+            $pip_options += "solarwinds-apm[system-metrics]"
         }
 
         pip download $pip_options


### PR DESCRIPTION
`psutil` is now an optional dependency of APM Python. This isn't breaking because the initial addition of `psutil` has not yet been released.

From user point of view, system metrics generation is now an opt-in at time of installation:
* "Regular" install: `pip install solarwinds-apm`
* Opt into metrics generation: `pip install solarwinds-apm[system-metrics]`

I've updated the install tests to always opt in. Successful test runs:
- Linux https://github.com/solarwinds/apm-python/actions/runs/15055786278
- Mac https://github.com/solarwinds/apm-python/actions/runs/15055789490
- Windows https://github.com/solarwinds/apm-python/actions/runs/15055791947

I'm working on a separate PR for documentation update.