### PR TITLE
NH-110883 Remove psutil dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,14 @@ SolarWinds APM captures OpenTelemetry distributed traces and metrics from your a
 
 To install `solarwinds-apm` and all relevant Opentelemetry Python instrumentation libraries:
 ```
-pip install solarwinds-apm
+pip install solarwinds-apm "psutil>=5.0"
 opentelemetry-bootstrap --action=install
 ```
-
-To opt into system metrics generation, specify `pip install solarwinds-apm[system-metrics]`.
-
 `solarwinds-apm` already includes OpenTelemetry and therefore doesn't need to be installed separately. Python agent installation should be done _after_ installation of all other service dependencies. This is so `opentelemetry-bootstrap` detects those packages and installs their corresponding instrumentation libraries. For example:
 
 ```
 pip install -r requirements.txt           # installs all other dependencies
-pip install solarwinds-apm
+pip install solarwinds-apm "psutil>=5.0"
 opentelemetry-bootstrap --action=install
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,11 +50,6 @@ dependencies = [
     'opentelemetry-resource-detector-azure == 0.1.5',
 ]
 
-[project.optional-dependencies]
-system-metrics = [
-    'psutil >= 5',
-]
-
 [project.urls]
 Homepage = "https://www.solarwinds.com/solarwinds-observability/use-cases/python-performance-monitoring"
 Download = "https://pypi.org/project/solarwinds-apm/"

--- a/tests/docker/install/README.md
+++ b/tests/docker/install/README.md
@@ -1,6 +1,6 @@
 # Installation tests
 
-These files provide containers and scripts to test installation of packaged `solarwinds-apm` with system-metrics opt-in (`solarwinds-apm[system-metrics]`), from local or from registry. Here is how to set up and run install tests locally:
+These files provide containers and scripts to test installation of packaged `solarwinds-apm` with system-metrics opt-in (`psutil`), from local or from registry. Here is how to set up and run install tests locally:
 
 1. Set test mode to install from one of:
    * `export MODE=local` (default; this will build sdist and wheel in project `dist/`)

--- a/tests/docker/install/_helper_check_sdist.sh
+++ b/tests/docker/install/_helper_check_sdist.sh
@@ -56,7 +56,7 @@ function get_sdist(){
             exit 1
         fi
     else
-        pip_options=(--no-binary solarwinds-apm[system-metrics] --dest "$sdist_dir")
+        pip_options=(--no-binary solarwinds-apm --dest "$sdist_dir")
         if [ "$MODE" == "testpypi" ]
         then
             pip_options+=(--extra-index-url https://test.pypi.org/simple/)
@@ -64,9 +64,9 @@ function get_sdist(){
 
         if [ -z "$SOLARWINDS_APM_VERSION" ]
         then
-            pip_options+=(solarwinds-apm[system-metrics])
+            pip_options+=(solarwinds-apm)
         else
-            pip_options+=(solarwinds-apm[system-metrics]=="$SOLARWINDS_APM_VERSION")
+            pip_options+=(solarwinds-apm=="$SOLARWINDS_APM_VERSION")
         fi
 
         # shellcheck disable=SC2048

--- a/tests/docker/install/_helper_check_wheel.sh
+++ b/tests/docker/install/_helper_check_wheel.sh
@@ -68,7 +68,7 @@ function get_wheel(){
             exit 1
         fi
     else
-        pip_options=(--only-binary solarwinds-apm[system-metrics] --dest "$wheel_dir")
+        pip_options=(--only-binary solarwinds-apm --dest "$wheel_dir")
         if [ "$MODE" == "testpypi" ]
         then
             pip_options+=(--extra-index-url https://test.pypi.org/simple/)
@@ -76,9 +76,9 @@ function get_wheel(){
 
         if [ -z "$SOLARWINDS_APM_VERSION" ]
         then
-            pip_options+=(solarwinds-apm[system-metrics])
+            pip_options+=(solarwinds-apm)
         else
-            pip_options+=(solarwinds-apm[system-metrics]=="$SOLARWINDS_APM_VERSION")
+            pip_options+=(solarwinds-apm=="$SOLARWINDS_APM_VERSION")
         fi
 
         # shellcheck disable=SC2048

--- a/tests/docker/install/_helper_run_install_tests.sh
+++ b/tests/docker/install/_helper_run_install_tests.sh
@@ -39,7 +39,7 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
     if grep Alpine /etc/os-release; then
         # test deps
         apk add bash
-        # agent deps - APM deps on psutil, so Alpine needs more deps
+        # agent deps - we install psutil for this test, so Alpine needs more deps
         apk add python3 curl linux-headers gcc musl-dev
 
         pip install --upgrade pip >/dev/null

--- a/tests/docker/install/install_tests.sh
+++ b/tests/docker/install/install_tests.sh
@@ -82,7 +82,7 @@ function check_agent_startup(){
 }
 
 function install_test_app_dependencies(){
-    pip install flask requests
+    pip install flask requests psutil
     opentelemetry-bootstrap --action=install
 }
 

--- a/tests/docker/install/windows/_helper_check_sdist.ps1
+++ b/tests/docker/install/windows/_helper_check_sdist.ps1
@@ -48,16 +48,16 @@ function Get-Sdist {
         return $sdist_tar
     }
     else {
-        $pip_options = @("--no-binary", "solarwinds-apm[system-metrics]", "--dest", $sdist_dir)
+        $pip_options = @("--no-binary", "solarwinds-apm", "--dest", $sdist_dir)
         if ($env:MODE -eq "testpypi") {
             $pip_options += "--extra-index-url", "https://test.pypi.org/simple/"
         }
 
         if ($env:SOLARWINDS_APM_VERSION) {
-            $pip_options += "solarwinds-apm[system-metrics]==$env:SOLARWINDS_APM_VERSION"
+            $pip_options += "solarwinds-apm==$env:SOLARWINDS_APM_VERSION"
         }
         else {
-            $pip_options += "solarwinds-apm[system-metrics]"
+            $pip_options += "solarwinds-apm"
         }
 
         pip download $pip_options

--- a/tests/docker/install/windows/_helper_check_wheel.ps1
+++ b/tests/docker/install/windows/_helper_check_wheel.ps1
@@ -58,16 +58,16 @@ function Get-Wheel {
         return $tested_wheel
     }
     else {
-        $pip_options = @("--only-binary", "solarwinds-apm[system-metrics]", "--dest", $wheel_dir)
+        $pip_options = @("--only-binary", "solarwinds-apm", "--dest", $wheel_dir)
         if ($env:MODE -eq "testpypi") {
             $pip_options += "--extra-index-url", "https://test.pypi.org/simple/"
         }
         
         if ($env:SOLARWINDS_APM_VERSION) {
-            $pip_options += "solarwinds-apm[system-metrics]==$env:SOLARWINDS_APM_VERSION"
+            $pip_options += "solarwinds-apm==$env:SOLARWINDS_APM_VERSION"
         }
         else {
-            $pip_options += "solarwinds-apm[system-metrics]"
+            $pip_options += "solarwinds-apm"
         }
 
         pip download $pip_options

--- a/tests/docker/install/windows/install_tests.ps1
+++ b/tests/docker/install/windows/install_tests.ps1
@@ -96,7 +96,7 @@ print(r)
 
 
 function Install-TestAppDependencies {
-    pip install flask requests
+    pip install flask requests psutil
     opentelemetry-bootstrap --action=install
 }
 


### PR DESCRIPTION
Remove `psutil` dependency -- not breaking because APM Python has not been released with the psutil dep.

Instead, we instruct users to install psutil separately to opt into system metrics export.