### PR TITLE
NH-111009 Remove system-metrics instrumentor pre-installation from k8s

### DIFF
--- a/image/requirements.txt
+++ b/image/requirements.txt
@@ -61,7 +61,6 @@ opentelemetry-instrumentation-requests==0.52b1
 opentelemetry-instrumentation-sqlalchemy==0.52b1
 opentelemetry-instrumentation-sqlite3==0.52b1
 opentelemetry-instrumentation-starlette==0.52b1
-opentelemetry-instrumentation-system-metrics==0.52b1
 opentelemetry-instrumentation-threading==0.52b1
 opentelemetry-instrumentation-tornado==0.52b1
 opentelemetry-instrumentation-tortoiseorm==0.52b1


### PR DESCRIPTION
Remove the system-metrics instrumentor pre-installation from k8s image publishes. This is a precaution against some performance and money penalties.