### PR TITLE
NH-109170 Exponential histogram aggregation by default

### DIFF
--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -30,6 +30,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_COMPRESSION,
     OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_OTLP_HEADERS,
+    OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
     OTEL_EXPORTER_OTLP_PROTOCOL,
 )
 from opentelemetry.sdk.version import __version__ as sdk_version
@@ -120,6 +121,12 @@ class SolarWindsDistro(BaseDistro):
         environ.setdefault(OTEL_LOGS_EXPORTER, self._DEFAULT_OTLP_EXPORTER)
         environ.setdefault(
             OTEL_EXPORTER_OTLP_PROTOCOL, self._DEFAULT_OTLP_PROTOCOL
+        )
+
+        # Default histogram aggregation as exponential
+        environ.setdefault(
+            OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
+            "base2_exponential_bucket_histogram",
         )
 
         # Default collector OTLP endpoint, which HTTP exporters map to signal-specific routes

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -17,6 +17,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_COMPRESSION,
     OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_OTLP_HEADERS,
+    OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
     OTEL_EXPORTER_OTLP_PROTOCOL,
 )
 
@@ -203,6 +204,7 @@ class TestDistro:
         assert os.environ[OTEL_EXPORTER_OTLP_PROTOCOL] == "http/protobuf"
         assert os.environ[OTEL_EXPORTER_OTLP_ENDPOINT] == "https://otel.collector.na-01.cloud.solarwinds.com:443"
         assert os.environ[OTEL_EXPORTER_OTLP_HEADERS] == "authorization=Bearer%20None"
+        assert os.environ[OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION] == "base2_exponential_bucket_histogram"
         assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http"
 
     def test_configure_env_exporter(self, mocker):
@@ -694,6 +696,16 @@ class TestDistro:
         distro.SolarWindsDistro()._configure()
         assert os.environ[OTEL_EXPORTER_OTLP_ENDPOINT] == "http://my-export-endpoint"
         assert os.environ.get(OTEL_EXPORTER_OTLP_HEADERS) is None
+
+    def test_configure_env_metrics_default_histogram_aggregation(self, mocker):
+        mocker.patch.dict(
+            os.environ,
+            {
+                "OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION": "foo",
+            }
+        )
+        distro.SolarWindsDistro()._configure()
+        assert os.environ[OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION] == "foo"
 
     def test_configure_env_propagators(self, mocker):
         mocker.patch.dict(os.environ, {"OTEL_PROPAGATORS": "tracecontext,solarwinds_propagator,foobar"})


### PR DESCRIPTION
APM Python sets `"base2_exponential_bucket_histogram"` histogram aggregation by default. Currently this value is [hard-coded ](https://github.com/open-telemetry/opentelemetry-python/blob/12bcd4508e4aca43667450db090a50b9efab9963/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/metrics_encoder/__init__.py#L146-L148)in the upstream metrics exporter common.