### PR TITLE
NH-114468 Re-enable `max-positional-arguments` for linter as 10

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -75,7 +75,6 @@ disable=missing-docstring,
       too-few-public-methods, # Might be good to re-enable this later.
       too-many-instance-attributes,
       too-many-arguments,
-      too-many-positional-arguments, # TODO remove when drop py38 support
       duplicate-code,
       ungrouped-imports, # Leave this up to isort
       wrong-import-order, # Leave this up to isort
@@ -464,6 +463,10 @@ valid-metaclass-classmethod-first-arg=cls
 
 # Maximum number of arguments for function / method.
 max-args=5
+
+# Maximum number of positional arguments for function / method.
+# Higher due to complexity of APM sampler
+max-positional-arguments=10
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7


### PR DESCRIPTION
Re-enables `max-positional-arguments` for pylint because Python 3.8 support dropped, though we set a higher max 10 (default is 5) to accommodate our complex custom sampler that for the most part requires all args .

Alternatively I could add more lines to the sampler to use `kwargs` with checks instead. Or, I could add several `disabled` comments in the code for pylint which is what upstream typically does. Lmk what you think!