### PR TITLE
NH-115253 Add more Python 3.13 testing, update Lambda tags

### DIFF
--- a/.github/workflows/build_publish_lambda_layer.yaml
+++ b/.github/workflows/build_publish_lambda_layer.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-minor: ["9", "10", "11", "12"]
+        python-minor: ["9", "10", "11", "12", "13"]
         apm-env: ["lambda"]
     steps:
     - uses: actions/checkout@v4
@@ -80,6 +80,6 @@ jobs:
     with:
       artifact-name: solarwinds_apm_lambda.zip
       component-version: ${{ needs.get_apm_python_version.outputs.sw-apm-version }}
-      runtimes: "python3.9 python3.10 python3.11 python3.12"
+      runtimes: "python3.9 python3.10 python3.11 python3.12 python3.13"
       publish-dest: ${{ inputs.publish-dest }}
     secrets: inherit

--- a/.github/workflows/run_tox_lint_format.yaml
+++ b/.github/workflows/run_tox_lint_format.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-minor: ["9", "10", "11", "12"]
+        python-minor: ["9", "10", "11", "12", "13"]
     steps:
     - uses: actions/checkout@v4
     - name: Setup Python

--- a/.github/workflows/run_tox_tests.yaml
+++ b/.github/workflows/run_tox_tests.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-minor: ["9", "10", "11", "12"]
+        python-minor: ["9", "10", "11", "12", "13"]
         apm-env: ["test"]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -174,7 +174,7 @@ jobs:
       image: "${{ matrix.image }}"
       options: --hostname "${{ matrix.hostname }}"
     steps:
-      - if: contains(matrix.image, 'amazonlinux')
+      - if: contains(matrix.image, 'amazonlinux') || contains(matrix.image, 'aws-lambda-python')
         name: Install AmazonLinux deps to use checkout
         run: dnf install -y tar gzip 
       - uses: actions/checkout@v4

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -128,7 +128,7 @@ jobs:
           - hostname: py3.13-amazon2023-arm64
             image: amazon/aws-lambda-python:3.13-arm64
           - hostname: py3.13-amazon2023-x86-64
-            image: amazon/aws-lambda-python:3.13-x86-64
+            image: amazon/aws-lambda-python:3.13-x86_64
           - hostname: py3.13-debian11
             image: python:3.13-bullseye
           - hostname: py3.13-debian12

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -69,6 +69,12 @@ jobs:
           - py3.12-alpine3.20
           - py3.12-debian11
           - py3.12-debian12
+          - py3.13-amazon2023-arm64
+          - py3.13-amazon2023-x86-64
+          - py3.13-debian11
+          - py3.13-debian12
+          - py3.13-alpine3.19
+          - py3.13-alpine3.20
         arch:
           - x64
           - arm64
@@ -119,8 +125,20 @@ jobs:
             image: python:3.12-bullseye
           - hostname: py3.12-debian12
             image: python:3.12-bookworm
-        # Note: JavaScript Actions (checkout) in Alpine only supported in x64
-        exclude:         
+          - hostname: py3.13-amazon2023-arm64
+            image: amazon/aws-lambda-python:3.13-arm64
+          - hostname: py3.13-amazon2023-x86-64
+            image: amazon/aws-lambda-python:3.13-x86-64
+          - hostname: py3.13-debian11
+            image: python:3.13-bullseye
+          - hostname: py3.13-debian12
+            image: python:3.13-bookworm
+          - hostname: py3.13-alpine3.19
+            image: python:3.13-alpine3.19
+          - hostname: py3.13-alpine3.20
+            image: python:3.13-alpine3.20
+        exclude:
+          # Note: JavaScript Actions (checkout) in Alpine only supported in x64
           - hostname: py3.9-alpine3.12
             arch: arm64
           - hostname: py3.9-alpine3.13
@@ -143,13 +161,22 @@ jobs:
             arch: arm64
           - hostname: py3.12-alpine3.20
             arch: arm64
+          - hostname: py3.13-alpine3.19
+            arch: arm64
+          - hostname: py3.13-alpine3.20
+            arch: arm64
+          # Mutual excludes for arch-specific Amazon hosts
+          - hostname: py3.13-amazon2023-arm64
+            arch: x64
+          - hostname: py3.13-amazon2023-x86-64
+            arch: arm64
     container:
       image: "${{ matrix.image }}"
       options: --hostname "${{ matrix.hostname }}"
     steps:
       - if: contains(matrix.image, 'amazonlinux')
         name: Install AmazonLinux deps to use checkout
-        run: yum install -y tar gzip 
+        run: dnf install -y tar gzip 
       - uses: actions/checkout@v4
       - name: Setup and run install test
         working-directory: ./tests/docker/install

--- a/.github/workflows/verify_install_macos.yaml
+++ b/.github/workflows/verify_install_macos.yaml
@@ -49,6 +49,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/verify_install_windows.yaml
+++ b/.github/workflows/verify_install_windows.yaml
@@ -49,6 +49,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,6 @@ keywords = [
   "observability",
 ]
 classifiers = [
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "Typing :: Typed",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",

--- a/tests/docker/install/README.md
+++ b/tests/docker/install/README.md
@@ -10,11 +10,10 @@ These files provide containers and scripts to test installation of packaged `sol
 3. Set these additional environment variables, required to create and export test traces:
    * `SW_APM_COLLECTOR_PROD`
    * `SW_APM_COLLECTOR_STAGING`
-   * `SW_APM_COLLECTOR_AO`
    * `SW_APM_SERVICE_KEY_PROD`
    * `SW_APM_SERVICE_KEY_STAGING`
-   * `SW_APM_SERVICE_KEY_AO`
 4. Run one of the containers interactively, with service name specified in `docker-compose.yml`:
-   * For Debian/CentOS/Amazon/Fedora: `docker-compose run --rm <service_name> /bin/bash`
+   * For Debian / CentOS / Amazon (py3.9) /Fedora: `docker-compose run --rm <service_name> /bin/bash`
+   * For Amazon (py3.13): `docker-compose run --rm --entrypoint="" py3.13-install-amazon2023 /bin/sh`
    * For Alpine: `docker-compose run --rm <service_name> /bin/sh`
 5. `./_helper_run_install_tests.sh`

--- a/tests/docker/install/README.md
+++ b/tests/docker/install/README.md
@@ -14,6 +14,6 @@ These files provide containers and scripts to test installation of packaged `sol
    * `SW_APM_SERVICE_KEY_STAGING`
 4. Run one of the containers interactively, with service name specified in `docker-compose.yml`:
    * For Debian / CentOS / Amazon (py3.9) /Fedora: `docker-compose run --rm <service_name> /bin/bash`
-   * For Amazon (py3.13): `docker-compose run --rm --entrypoint="" py3.13-install-amazon2023 /bin/sh`
+   * For Amazon (py3.13): `docker-compose run --rm --entrypoint="" py3.13-install-amazon2023-<arch> /bin/sh`
    * For Alpine: `docker-compose run --rm <service_name> /bin/sh`
 5. `./_helper_run_install_tests.sh`

--- a/tests/docker/install/_helper_run_install_tests.sh
+++ b/tests/docker/install/_helper_run_install_tests.sh
@@ -91,17 +91,27 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
         fi
 
     elif grep "Amazon Linux" /etc/os-release; then
-        yum update -y
         if grep "Amazon Linux 2023" /etc/os-release; then
-            yum install -y \
+            dnf update -y
+            dnf install -y \
                 python3 \
                 python3-pip \
                 unzip \
                 findutils \
                 tar \
-                gzip
-            update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-            # cannot symlink/update-alternatives nor upgrade pip
+                gzip \
+                bash \
+                chkconfig
+
+            if command -v update-alternatives >/dev/null 2>&1; then
+                update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+            else
+                # For AWS Lambda images or other minimal images, use symlinks
+                command -v python ||
+                    ln -s /usr/bin/python3 /usr/local/bin/python
+                command -v pip ||
+                    ln -s /usr/bin/pip3 /usr/local/bin/pip
+            fi
         else
             echo "ERROR: Testing on Amazon <2023 not supported."
             exit 1

--- a/tests/docker/install/docker-compose.yml
+++ b/tests/docker/install/docker-compose.yml
@@ -211,3 +211,43 @@ services:
     << : [*command-install-test, *workdir, *volumes-codebase]
     environment:
       << : *envvars-install-test
+
+
+  #--------------------------------------------------------------------
+  # Python 3.13
+  #--------------------------------------------------------------------
+
+  py3.13-install-amazon2023:
+    hostname: "py3.13-amazon2023"
+    image: "amazon/aws-lambda-python:3.13-arm64"
+    << : [*command-install-test, *workdir, *volumes-codebase]
+    environment:
+      << : *envvars-install-test
+
+  py3.13-install-debian11:
+    hostname: "py3.13-debian11"
+    image: "python:3.13-bullseye"
+    << : [*command-install-test, *workdir, *volumes-codebase]
+    environment:
+      << : *envvars-install-test
+
+  py3.13-install-debian12:
+    hostname: "py3.13-debian12"
+    image: "python:3.13-bookworm"
+    << : [*command-install-test, *workdir, *volumes-codebase]
+    environment:
+      << : *envvars-install-test
+
+  py3.13-install-alpine3.19:
+    hostname: "py3.13-alpine3.19"
+    image: "python:3.13-alpine3.19"
+    << : [*command-install-test, *workdir, *volumes-codebase]
+    environment:
+      << : *envvars-install-test
+
+  py3.13-install-alpine3.20:
+    hostname: "py3.13-alpine3.20"
+    image: "python:3.13-alpine3.20"
+    << : [*command-install-test, *workdir, *volumes-codebase]
+    environment:
+      << : *envvars-install-test

--- a/tests/docker/install/docker-compose.yml
+++ b/tests/docker/install/docker-compose.yml
@@ -217,9 +217,16 @@ services:
   # Python 3.13
   #--------------------------------------------------------------------
 
-  py3.13-install-amazon2023:
-    hostname: "py3.13-amazon2023"
+  py3.13-install-amazon2023-arm64:
+    hostname: "py3.13-amazon2023-arm64"
     image: "amazon/aws-lambda-python:3.13-arm64"
+    << : [*command-install-test, *workdir, *volumes-codebase]
+    environment:
+      << : *envvars-install-test
+
+  py3.13-install-amazon2023-x86-64:
+    hostname: "py3.13-amazon2023-x86-64"
+    image: "amazon/aws-lambda-python:3.13-x86-64"
     << : [*command-install-test, *workdir, *volumes-codebase]
     environment:
       << : *envvars-install-test

--- a/tests/docker/install/docker-compose.yml
+++ b/tests/docker/install/docker-compose.yml
@@ -226,7 +226,7 @@ services:
 
   py3.13-install-amazon2023-x86-64:
     hostname: "py3.13-amazon2023-x86-64"
-    image: "amazon/aws-lambda-python:3.13-x86-64"
+    image: "amazon/aws-lambda-python:3.13-x86_64"
     << : [*command-install-test, *workdir, *volumes-codebase]
     environment:
       << : *envvars-install-test

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 skipsdist = True
 skip_missing_interpreters = True
 envlist =
-  py3{9,10,11,12}-test
-  py3{9,10,11,12}-lambda
-  py3{9,10,11,12}-lint
+  py3{9,10,11,12,13}-test
+  py3{9,10,11,12,13}-lambda
+  py3{9,10,11,12,13}-lint
 
 [testenv]
 setenv =
@@ -14,28 +14,28 @@ allowlist_externals = echo
 deps =
   -rdev-requirements.txt
 commands_pre =
-  py3{9,10,11,12}: pip install --upgrade pip
-  py3{9,10,11,12}: pip install -Ie {toxinidir}
+  py3{9,10,11,12,13}: pip install --upgrade pip
+  py3{9,10,11,12,13}: pip install -Ie {toxinidir}
 commands =
   pytest {posargs}
 
-[testenv:py3{9,10,11,12}-test]
+[testenv:py3{9,10,11,12,13}-test]
 changedir = tests
 setenv =
   SW_APM_COLLECTOR = apm.collector.st-ssp.solarwinds.com
   SW_APM_SERVICE_KEY = foo-bar:service-key
 
-[testenv:py3{9,10,11,12}-lambda]
+[testenv:py3{9,10,11,12,13}-lambda]
 changedir = lambda/tests
 commands_pre =
-  py3{9,10,11,12}-lambda: pip install -r requirements.txt
+  py3{9,10,11,12,13}-lambda: pip install -r requirements.txt
 
-[testenv:py3{9,10,11,12}-lambda-gh]
+[testenv:py3{9,10,11,12,13}-lambda-gh]
 changedir = lambda/tests
 commands_pre =
-  py3{9,10,11,12}-lambda: pip install -r requirements.txt
+  py3{9,10,11,12,13}-lambda: pip install -r requirements.txt
 
-[testenv:py3{9,10,11,12}-lint]
+[testenv:py3{9,10,11,12,13}-lint]
 deps =
   opentelemetry-api
   opentelemetry-sdk


### PR DESCRIPTION
Updates APM Python unit tests and installation/smoke tests to include Python 3.13 -- required some helper shell script changes. All pass on this PR's ci/cd.

Removes explicit Python version `Classifiers` from pyproject.toml to match upstream. We still have [requires-python](https://github.com/solarwinds/apm-python/pull/667/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L41) defined. Updates the tags for Lambda layer build too.