### PR TITLE
Potential fix for code scanning alert no. 450: Unused import

### DIFF
--- a/scripts/lint_and_format.py
+++ b/scripts/lint_and_format.py
@@ -7,7 +7,6 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 import argparse
-import os
 import subprocess
 import sys
 


### PR DESCRIPTION
Potential fix for [https://github.com/solarwinds/apm-python/security/code-scanning/450](https://github.com/solarwinds/apm-python/security/code-scanning/450)

To fix the problem, simply remove the unused import statement `import os` from line 10 of `scripts/lint_and_format.py`. This change should be made only to the import statement itself, leaving all other code unchanged. No additional methods, imports, or definitions are required, as the rest of the code does not depend on the `os` module.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
