### PR TITLE
NH-117515 Update workflow

### DIFF
--- a/.github/workflows/build_publish_image_autoinstrumentation.yaml
+++ b/.github/workflows/build_publish_image_autoinstrumentation.yaml
@@ -19,7 +19,7 @@ jobs:
   docker_hub:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Read solarwinds_apm version requirement
         run: echo VERSION=$(head -n 1 image/requirements-nodeps.txt | cut -d '=' -f3) >> $GITHUB_ENV
@@ -100,7 +100,7 @@ jobs:
   ghcr_io:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Read solarwinds_apm version requirement
         run: echo VERSION=$(head -n 1 image/requirements-nodeps.txt | cut -d '=' -f3) >> $GITHUB_ENV

--- a/.github/workflows/build_publish_image_autoinstrumentation_beta.yaml
+++ b/.github/workflows/build_publish_image_autoinstrumentation_beta.yaml
@@ -19,7 +19,7 @@ jobs:
   docker_hub:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Read solarwinds_apm version requirement
         run: echo VERSION=$(head -n 1 image/requirements-nodeps-beta.txt | cut -d '=' -f3) >> $GITHUB_ENV
@@ -100,7 +100,7 @@ jobs:
   ghcr_io:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Read solarwinds_apm version requirement
         run: echo VERSION=$(head -n 1 image/requirements-nodeps-beta.txt | cut -d '=' -f3) >> $GITHUB_ENV

--- a/.github/workflows/build_publish_lambda_layer.yaml
+++ b/.github/workflows/build_publish_lambda_layer.yaml
@@ -26,7 +26,7 @@ jobs:
         python-minor: ["9", "10", "11", "12", "13"]
         apm-env: ["lambda"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
@@ -50,7 +50,7 @@ jobs:
     outputs:
       artifact-name: solarwinds_apm_lambda.zip
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: ./.github/actions/package_lambda_solarwinds_apm
     - uses: actions/upload-artifact@v4
       name: Save assembled layer to build

--- a/.github/workflows/build_publish_pypi_and_draft_release.yaml
+++ b/.github/workflows/build_publish_pypi_and_draft_release.yaml
@@ -25,7 +25,7 @@ jobs:
     name: Check if version valid
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Check version
       run: cd .github/scripts && ./is_publishable.sh ${{ github.event.inputs.version }}
 
@@ -79,7 +79,7 @@ jobs:
         with:
           app_id: ${{ vars.APPLICATION_ID }}
           private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Initialize git
         run: |
           git config user.name "GitHub Actions"

--- a/.github/workflows/build_sdist_and_wheel.yaml
+++ b/.github/workflows/build_sdist_and_wheel.yaml
@@ -25,7 +25,7 @@ jobs:
     outputs:
         artifact-name: scan-wheel-${{ inputs.version }}.zip
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build sdist and wheel
       uses: ./.github/actions/package_solarwinds_apm
     - name: Package sdist and wheels for upload

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/create_release_pr.yaml
+++ b/.github/workflows/create_release_pr.yaml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Initialize git
         run: |
           git config user.name "GitHub Actions"

--- a/.github/workflows/create_testrelease_pr.yaml
+++ b/.github/workflows/create_testrelease_pr.yaml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Initialize git
         run: |
           git config user.name "GitHub Actions"

--- a/.github/workflows/get_apm_python_version.yaml
+++ b/.github/workflows/get_apm_python_version.yaml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       SW_APM_VERSION: ${{ steps.save-apm-python-version.outputs.SW_APM_VERSION }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: grep version from Python src
       id: save-apm-python-version
       run: |

--- a/.github/workflows/run_tox_lint_format.yaml
+++ b/.github/workflows/run_tox_lint_format.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         python-minor: ["9", "10", "11", "12", "13"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Setup Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/run_tox_tests.yaml
+++ b/.github/workflows/run_tox_tests.yaml
@@ -22,7 +22,7 @@ jobs:
         python-minor: ["9", "10", "11", "12", "13"]
         apm-env: ["test"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Setup Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -46,7 +46,6 @@ jobs:
     strategy:
       matrix:
         hostname:
-          - py3.9-alpine3.12
           - py3.9-alpine3.13
           - py3.9-alpine3.16
           - py3.9-alpine3.17
@@ -79,8 +78,6 @@ jobs:
           - x64
           - arm64
         include:
-          - hostname: py3.9-alpine3.12
-            image: python:3.9-alpine3.12
           - hostname: py3.9-alpine3.13
             image: python:3.9-alpine3.13
           - hostname: py3.9-alpine3.16
@@ -139,8 +136,6 @@ jobs:
             image: python:3.13-alpine3.20
         exclude:
           # Note: JavaScript Actions (checkout) in Alpine only supported in x64
-          - hostname: py3.9-alpine3.12
-            arch: arm64
           - hostname: py3.9-alpine3.13
             arch: arm64
           - hostname: py3.9-alpine3.16

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -177,7 +177,7 @@ jobs:
       - if: contains(matrix.image, 'amazonlinux') || contains(matrix.image, 'aws-lambda-python')
         name: Install AmazonLinux deps to use checkout
         run: dnf install -y tar gzip 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup and run install test
         working-directory: ./tests/docker/install
         run: APM_ROOT=$GITHUB_WORKSPACE ./_helper_run_install_tests.sh

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -177,7 +177,12 @@ jobs:
       - if: contains(matrix.image, 'amazonlinux') || contains(matrix.image, 'aws-lambda-python')
         name: Install AmazonLinux deps to use checkout
         run: dnf install -y tar gzip 
-      - uses: actions/checkout@v5
+      # Use checkout@v4 for Alpine versions < 3.17 that don't support Node.js 24
+      - if: contains(matrix.hostname, 'alpine3.13') || contains(matrix.hostname, 'alpine3.14') || contains(matrix.hostname, 'alpine3.15') || contains(matrix.hostname, 'alpine3.16')
+        uses: actions/checkout@v4
+      # Else use latest checkout
+      - if: ${{ !(contains(matrix.hostname, 'alpine3.13') || contains(matrix.hostname, 'alpine3.14') || contains(matrix.hostname, 'alpine3.15') || contains(matrix.hostname, 'alpine3.16')) }}
+        uses: actions/checkout@v5
       - name: Setup and run install test
         working-directory: ./tests/docker/install
         run: APM_ROOT=$GITHUB_WORKSPACE ./_helper_run_install_tests.sh

--- a/.github/workflows/verify_install_macos.yaml
+++ b/.github/workflows/verify_install_macos.yaml
@@ -51,7 +51,7 @@ jobs:
           - "3.12"
           - "3.13"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/verify_install_windows.yaml
+++ b/.github/workflows/verify_install_windows.yaml
@@ -51,7 +51,7 @@ jobs:
           - "3.12"
           - "3.13"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/tests/docker/install/docker-compose.yml
+++ b/tests/docker/install/docker-compose.yml
@@ -60,13 +60,6 @@ services:
     environment:
       << : *envvars-install-test
 
-  py3.9-install-alpine3.12:
-    hostname: "py3.9-alpine3.12"
-    image: "python:3.9-alpine3.12"
-    << : [*command-install-test, *workdir, *volumes-codebase]
-    environment:
-      << : *envvars-install-test
-
   py3.9-install-alpine3.13:
     hostname: "py3.9-alpine3.13"
     image: "python:3.9-alpine3.13"


### PR DESCRIPTION
Updates CI/CD workflows with:

1. Upgrade to latest `checkout@v5` wherever possible
2. Still use `checkout@v4` for those containers/OS that don't use Node 24, which is Alpine < 3.17
3. Remove Alpine 3.12 testing since we [dropped support](https://documentation.solarwinds.com/en/success_center/observability/content/system_requirements/apm_requirements.htm#linux) a while ago.