### PR TITLE
NH-112434 SDK set_transaction_name uses to upstream labeler

### DIFF
--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -7,10 +7,12 @@
 import logging
 
 from opentelemetry import context, trace
+from opentelemetry.instrumentation._labeler import get_labeler
 from opentelemetry.trace import NoOpTracerProvider, get_tracer_provider
 
 from solarwinds_apm.apm_constants import (
     INTL_SWO_OTEL_CONTEXT_ENTRY_SPAN,
+    INTL_SWO_TRANSACTION_ATTR_KEY,
     INTL_SWO_TRANSACTION_NAME_ATTR,
 )
 from solarwinds_apm.oboe import get_transaction_name_pool
@@ -93,6 +95,11 @@ def set_transaction_name(custom_name: str) -> bool:
     current_trace_entry_span.set_attribute(
         INTL_SWO_TRANSACTION_NAME_ATTR, registered_name
     )
+
+    # Also sets transaction name in Labeler used by some upstream instrumentors
+    labeler = get_labeler()
+    labeler.add(INTL_SWO_TRANSACTION_ATTR_KEY, registered_name)
+
     return True
 
 


### PR DESCRIPTION
Updates SDK `set_transaction_name` to add transaction name to upstream Labeler.