### PR TITLE
NH-93748 Add ruff and other tox updates (redo)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.6.9
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: ["--fix", "--show-fixes"]
+      # Run the formatter.
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,8 @@ Automated testing of this repo uses [tox](https://tox.readthedocs.io) and runs i
 
 1. Create and run a Docker build container as described above.
 2. To run all tests for a specific version, provide tox options as a string. For example, to run in Python 3.9: `make tox OPTIONS="-e py39-test"`.
-3. (WARNING: slow!) To run all tests for all supported Python environments, as well as linting and formatting: `make tox`
+3. To run tests specific to Lambda instrumentation in Python 3.13: `make tox OPTIONS="-e py313-lambda"`.
+4. (WARNING: slow!) To run all tests for all supported Python environments, as well as linting and formatting: `make tox`
 
 Other regular `tox` arguments can be included in `OPTIONS`. Some examples:
 
@@ -77,6 +78,8 @@ make tox OPTIONS="-e py312-lint -- --check-only"
 ./run_docker_dev.sh
 make tox OPTIONS="-e py39-lint"
 ```
+
+`ruff` is also available to fix formatting: `make tox OPTIONS="-e ruff"`.
 
 Remotely, CodeQL can be run on GitHub with the [CodeQL Analysis](https://github.com/solarwinds/apm-python/actions/workflows/codeql_analysis.yaml) workflow.
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
   py3{9,10,11,12,13}-test
   py3{9,10,11,12,13}-lambda
   py3{9,10,11,12,13}-lint
+  ruff
 
 [testenv]
 setenv =
@@ -43,3 +44,10 @@ deps =
   psutil
 commands =
   python scripts/lint_and_format.py {posargs}
+
+[testenv:ruff]
+basepython: python3
+deps =
+  pre-commit
+commands =
+  pre-commit run --color=always --all-files {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -20,12 +20,14 @@ commands =
 
 [testenv:py3{9,10,11,12,13}-test]
 changedir = tests
+usedevelop = true
 setenv =
   SW_APM_COLLECTOR = apm.collector.st-ssp.solarwinds.com
   SW_APM_SERVICE_KEY = foo-bar:service-key
 
 [testenv:py3{9,10,11,12,13}-lambda]
 changedir = lambda/tests
+usedevelop = true
 deps =
   {[testenv]deps}
   -r {toxinidir}/lambda/tests/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -11,11 +11,9 @@ setenv =
   OTEL_PYTHON_DISABLED_INSTRUMENTATIONS = urllib3
   SW_APM_DEBUG_LEVEL = 3
 allowlist_externals = echo
+usedevelop = true
 deps =
-  -rdev-requirements.txt
-commands_pre =
-  py3{9,10,11,12,13}: pip install --upgrade pip
-  py3{9,10,11,12,13}: pip install -Ie {toxinidir}
+  -r {toxinidir}/dev-requirements.txt
 commands =
   pytest {posargs}
 
@@ -27,13 +25,9 @@ setenv =
 
 [testenv:py3{9,10,11,12,13}-lambda]
 changedir = lambda/tests
-commands_pre =
-  py3{9,10,11,12,13}-lambda: pip install -r requirements.txt
-
-[testenv:py3{9,10,11,12,13}-lambda-gh]
-changedir = lambda/tests
-commands_pre =
-  py3{9,10,11,12,13}-lambda: pip install -r requirements.txt
+deps =
+  {[testenv]deps}
+  -r {toxinidir}/lambda/tests/requirements.txt
 
 [testenv:py3{9,10,11,12,13}-lint]
 deps =


### PR DESCRIPTION
Summary:

1. Adds `ruff` which is quicker and more comprehensive for code quality management than `pylint` -- we're still keeping the latter for now.
2. Removes a duplicate tox testenv, `py3{9,10,11,12,13}-lambda-gh`, which doesn't seem to be used anywhere.
3. Update other tox testenv to stop installing all deps with every single run. Only does it the first time now.

I've not applied Python code changes recommended by `ruff` here. That will be another PR. Same with adding `ruff` to ci/cd.