### PR TITLE
NH-107164 Drop support of SW_APM_EXPORT_LOGS_ENABLED

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -680,6 +680,7 @@ class SolarWindsApmConfig:
                 self.__config[key] = val
             elif keys == ["transaction_name"]:
                 self.__config[key] = val
+            # TODO NH-101930 remove export_logs_enabled
             elif keys in [["export_logs_enabled"], ["export_metrics_enabled"]]:
                 val = self.convert_to_bool(val)
                 if val not in (True, False):

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -198,21 +198,21 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             resource=apm_resource,
         )
 
-        # Only emit log event telemetry (auto-instrument logs) if feature enabled,
-        # with settings precedence: OTEL_* > SW_APM_EXPORT_LOGS_ENABLED.
-        # TODO NH-107164 drop support of SW config, and super() will only check OTEL config
-        setup_logging_handler = False
-        # We don't set a default, so this could be None
-        otel_log_enabled = SolarWindsApmConfig.convert_to_bool(
-            os.environ.get(_OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED)
+        # Only emit log event telemetry (auto-instrument logs) if feature enabled.
+        # Distro does not set a default, so this could be None
+        setup_logging_handler = SolarWindsApmConfig.convert_to_bool(
+            os.environ.get(
+                _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED, False
+            )
         )
-        # SW config is False by default
+        # TODO NH-101930 remove this check
         sw_log_enabled = self.apm_config.get("export_logs_enabled")
-        if otel_log_enabled is not None:
-            if otel_log_enabled is True:
-                setup_logging_handler = True
-        elif sw_log_enabled:
-            setup_logging_handler = True
+        if sw_log_enabled:
+            logger.warning(
+                "Support for SW_APM_EXPORT_LOG_ENABLED / exportLogsEnabled "
+                "has been dropped. Please update use "
+                "OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED instead."
+            )
 
         _init_logging(log_exporters, apm_resource, setup_logging_handler)
 

--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -139,6 +139,7 @@ def get_apmconfig_mocks(
     def get_side_effect(param):
         if param == "export_metrics_enabled":
             return export_metrics_enabled
+        # TODO NH-101930 remove export_logs_enabled
         elif param == "export_logs_enabled":
             return export_logs_enabled
         elif param == "service_key":

--- a/tests/unit/test_configurator/test_configurator_configure_otel.py
+++ b/tests/unit/test_configurator/test_configurator_configure_otel.py
@@ -176,7 +176,7 @@ class TestConfiguratorConfigureOtelComponents:
             mock_config_propagator,
             mock_config_response_propagator,
             "true",
-            True,
+            True,  # True because OTEL log instrumentation set to true
             True,
         )
 
@@ -201,7 +201,7 @@ class TestConfiguratorConfigureOtelComponents:
             mock_config_propagator,
             mock_config_response_propagator,
             "",
-            False,
+            None,  # none because OTEL log instrumentation not set
         )
 
     def test_configure_otel_components_logs_enabled_otel_none_sw_true(self,
@@ -225,7 +225,7 @@ class TestConfiguratorConfigureOtelComponents:
             mock_config_propagator,
             mock_config_response_propagator,
             "",
-            True,  # true because SW next in precedence
+            None,  # none because OTEL log instrumentation not set
         )
 
     def test_configure_otel_components_logs_enabled_otel_false_sw_default(self,
@@ -249,6 +249,7 @@ class TestConfiguratorConfigureOtelComponents:
             mock_config_propagator,
             mock_config_response_propagator,
             "false",
+            False,  # False because OTEL log instrumentation False
             False,
         )
 
@@ -298,7 +299,7 @@ class TestConfiguratorConfigureOtelComponents:
             mock_config_propagator,
             mock_config_response_propagator,
             "not-a-bool-string",
-            False,
+            None,  # None because OTEL log instrumentation not valid bool
         )
 
     def test_configure_otel_components_agent_enabled(
@@ -317,6 +318,11 @@ class TestConfiguratorConfigureOtelComponents:
         mocker.patch(
             "solarwinds_apm.configurator.SolarWindsApmConfig",
             return_value=mock_apmconfig_enabled,
+        )
+        # Mock return of _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
+        mocker.patch(
+            "solarwinds_apm.configurator.SolarWindsApmConfig.convert_to_bool",
+            return_value=False,
         )
         mock_apm_sampler = mocker.Mock()
         mocker.patch(


### PR DESCRIPTION
Drops support of `SW_APM_EXPORT_LOGS_ENABLED` because it's a convenience for `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` which is already supported. This is a small breaking change for the next release; documentation changes in ticket.

Logs a special warning for the next release. In the future, it will be removed and the regular warning of "ignoring unsupported config" will be shown instead.