### PR TITLE
NH-119695 Potential fix for code scanning alert no. 451: Wrong name for an argument in a call

### DIFF
--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -180,7 +180,7 @@ def mock_apmconfig_enabled_md_invalid(mocker):
         "solarwinds_apm.configurator.SolarWindsApmConfig",
         get_apmconfig_mocks(
             mocker,
-            md_is_valid=False,
+            export_metrics_enabled=False,
         )
     )
 

--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -174,16 +174,6 @@ def mock_apmconfig_enabled(mocker):
         )
     )
 
-@pytest.fixture(name="mock_apmconfig_enabled_md_invalid")
-def mock_apmconfig_enabled_md_invalid(mocker):
-    return mocker.patch(
-        "solarwinds_apm.configurator.SolarWindsApmConfig",
-        get_apmconfig_mocks(
-            mocker,
-            export_metrics_enabled=False,
-        )
-    )
-
 @pytest.fixture(name="mock_apmconfig_enabled_is_lambda")
 def mock_apmconfig_enabled_is_lambda(mocker):
     return mocker.patch(


### PR DESCRIPTION
Potential fix for [https://github.com/solarwinds/apm-python/security/code-scanning/451](https://github.com/solarwinds/apm-python/security/code-scanning/451)

To fix the problem, we must ensure that only valid keyword arguments are passed when calling `get_apmconfig_mocks`. Since `md_is_valid` is not a parameter of `get_apmconfig_mocks`, we should replace the unsupported `md_is_valid=False` argument with an appropriate supported argument. The function parameters are: `mocker, enabled=True, is_lambda=False, export_metrics_enabled=True`. If the intention was to mock an invalid metric export configuration, then we should pass `export_metrics_enabled=False` instead. Only line 183 (and its surrounding context) within the fixture `mock_apmconfig_enabled_md_invalid` (lines 177-186) needs changing. No new imports or additional definitions are needed, as all required pieces exist.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
